### PR TITLE
Replace guard allowlist with protocol-aware firewall engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] - 2026-03-26
+
+### Added
+
+- **Firewall mode redesign:** Guard mode has been redesigned as a granular firewall system. The new `M()` pattern object enables matching against protocol-specific fields (host, path, method, command, service, etc.) using glob patterns, CIDR notation, regex, or callable predicates. Example: `@pytest.mark.allow(M(protocol="http", host="*.example.com"))`.
+- **`restrict()` context manager:** Sets a ceiling on allowed calls that inner blocks cannot widen. Useful for enforcing that a code path only makes specific types of calls: `with bigfoot.restrict(M(protocol="http", host="api.stripe.com")): ...`.
+- **`FirewallRequest` protocol-typed dataclasses:** Each protocol (HTTP, Redis, subprocess, boto3, etc.) defines a typed dataclass carrying the request details for firewall matching. Plugin authors construct these objects to provide precise matching fields.
+- **TOML firewall configuration:** New `[tool.bigfoot.firewall]` section replaces the deprecated `guard_allow` key. Supports structured per-protocol rules (`[tool.bigfoot.firewall.allow.http]` with `hosts`, `paths`, `methods` arrays), deny rules, and per-file overrides.
+- **Three-level configuration:** Firewall rules combine from TOML (project-wide), marks (per-test), and context managers (scoped blocks), with `restrict()` enforcing ceilings.
+
+### Changed
+
+- **`guard_allow` deprecated:** The `guard_allow` key in `[tool.bigfoot]` is still accepted but deprecated in favor of `[tool.bigfoot.firewall.allow]` structured config.
+- **Guard mode docs rewritten** as the Firewall Mode guide, covering `M()` patterns, TOML config, `restrict()`, `FirewallRequest`, and per-protocol examples.
+- **README** updated to describe firewall mode with `M()` patterns and `restrict()`.
+
 ## [0.18.0] - 2026-03-25
 
 ### Added
@@ -336,6 +352,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-OS CI matrix (Ubuntu, macOS, Windows) across Python 3.11, 3.12, and 3.13
 - OIDC trusted publishing to PyPI on `v*` tags
 
+[0.19.0]: https://github.com/axiomantic/bigfoot/releases/tag/v0.19.0
+[0.18.0]: https://github.com/axiomantic/bigfoot/releases/tag/v0.18.0
+[0.17.0]: https://github.com/axiomantic/bigfoot/releases/tag/v0.17.0
 [0.16.0]: https://github.com/axiomantic/bigfoot/releases/tag/v0.16.0
 [0.15.0]: https://github.com/axiomantic/bigfoot/releases/tag/v0.15.0
 [0.14.0]: https://github.com/axiomantic/bigfoot/releases/tag/v0.14.0

--- a/README.md
+++ b/README.md
@@ -5,15 +5,66 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-**Full-certainty test mocking for Python.**
+<!-- CHANGED: New opening description repositioned as unittest.mock replacement -->
 
-bigfoot intercepts every external call your code makes and forces your tests to account for all of them. It ships with plugins for HTTP, subprocess, database, socket, Redis, SMTP, WebSocket, logging, and more. It enforces three guarantees that most mocking libraries leave silent:
+**bigfoot replaces `unittest.mock` with full-certainty test mocking for Python.**
+
+Drop-in mocking that catches the bugs `unittest.mock` silently ignores. bigfoot intercepts every external call your code makes and forces your tests to account for all of them. It ships with plugins for HTTP, subprocess, database, socket, Redis, SMTP, WebSocket, logging, and more. It enforces three guarantees that `unittest.mock` and most mocking libraries leave silent:
+
+<!-- END CHANGED -->
 
 1. **Every call must be pre-authorized.** Code makes a call with no registered mock? `UnmockedInteractionError`, immediately.
 2. **Every recorded interaction must be explicitly asserted.** Forget to assert an interaction? `UnassertedInteractionsError` at teardown.
 3. **Every registered mock must actually be triggered.** Register a mock that never fires? `UnusedMocksError` at teardown.
 
-**Guard mode** (enabled by default) goes further: bigfoot installs interceptors at test session startup, catching any real I/O call that happens outside a sandbox. In the default `"warn"` level, accidental calls emit a `GuardedCallWarning` and proceed normally, so existing test suites keep working while you see exactly which calls are unguarded. Set `guard = "error"` in `[tool.bigfoot]` for strict enforcement that raises `GuardedCallError` on every unguarded call. Use `bigfoot.allow("dns", "socket")` or `@pytest.mark.allow(...)` to selectively permit real calls. Use `bigfoot.deny(...)` or `@pytest.mark.deny(...)` to narrow the allowlist and re-guard specific plugins in nested contexts.
+<!-- NEW SECTION: Why Not unittest.mock? -->
+
+## Why Not unittest.mock?
+
+`unittest.mock` is designed for flexibility. bigfoot is designed for correctness. Here is what `unittest.mock` silently allows that bigfoot catches:
+
+| Scenario | unittest.mock | bigfoot |
+|----------|---------------|---------|
+| Mocked function is never called | Test passes silently | `UnusedMocksError` at teardown |
+| Mocked function called with wrong args | `assert_called_with` only if you remember to add it | Recorded and required to be asserted with exact args |
+| Real HTTP/DB/Redis call leaks through | Nothing happens (call goes to production) | `UnmockedInteractionError` immediately |
+| You forget to assert a call happened | Test passes silently | `UnassertedInteractionsError` at teardown |
+| Mock returns wrong type, caller doesn't notice | `MagicMock` auto-generates attributes forever | Not applicable; you declare explicit return values |
+| Production code adds a new external call | Existing tests still pass, new call is untested | `UnmockedInteractionError` forces you to handle it |
+
+**The core problem:** `unittest.mock` makes it your responsibility to remember what to assert. bigfoot makes it impossible to forget.
+
+```python
+# unittest.mock -- this test passes, but proves nothing
+from unittest.mock import patch
+
+@patch("myapp.payments.httpx.post")
+def test_payment(mock_post):
+    mock_post.return_value.json.return_value = {"id": "ch_123"}
+    create_charge(5000)
+    # Forgot assert_called_with? Test passes.
+    # Called with wrong amount? Test passes.
+    # Added a second HTTP call? Test passes.
+
+# bigfoot -- every interaction is accounted for
+def test_payment():
+    bigfoot.http.mock_response("POST", "https://api.stripe.com/v1/charges",
+                               json={"id": "ch_123"}, status=200)
+
+    with bigfoot:
+        result = create_charge(5000)
+
+    # MUST assert this or test fails at teardown
+    bigfoot.http.assert_request(
+        "POST", "https://api.stripe.com/v1/charges",
+        headers=IsInstance(dict), body='{"amount": 5000}',
+    )
+    assert result["id"] == "ch_123"
+```
+
+<!-- END NEW SECTION -->
+
+**Firewall mode** (enabled by default) goes further: bigfoot installs interceptors at test session startup, catching any real I/O call that happens outside a sandbox. In the default `"warn"` level, accidental calls emit a `GuardedCallWarning` and proceed normally, so existing test suites keep working while you see exactly which calls are unguarded. Set `guard = "error"` in `[tool.bigfoot]` for strict enforcement that raises `GuardedCallError` on every unguarded call. Use `bigfoot.allow("dns", "socket")` or `@pytest.mark.allow(...)` to selectively permit real calls. Use `M()` pattern objects for granular matching (e.g., `M(protocol="http", host="*.example.com")`). Use `bigfoot.restrict(...)` to set a ceiling that inner blocks cannot widen. Configure project-wide rules in `[tool.bigfoot.firewall]` TOML sections.
 
 A plugin system makes it straightforward to intercept any service and enforce all three guarantees.
 
@@ -74,6 +125,120 @@ Every field is shown. Every value is real. Copy, paste, done.
 5. **`verify_all()`** runs automatically at test teardown via the pytest plugin
 
 No fixture injection required. Install bigfoot, `import bigfoot`, and go.
+
+<!-- NEW SECTION: Coming from unittest.mock -->
+
+## Coming from unittest.mock
+
+### Concepts mapping
+
+| unittest.mock | bigfoot equivalent | Notes |
+|---------------|-------------------|-------|
+| `@patch("module.Class")` | `bigfoot.mock("module:Class")` | Colon-separated import path |
+| `@patch.object(obj, "attr")` | `bigfoot.mock.object(obj, "attr")` | Same idea, stricter enforcement |
+| `MagicMock()` | Plugin-specific mocks | `mock_response`, `mock_run`, `mock_command`, etc. |
+| `mock.return_value = X` | `.returns(X)` | Explicit, typed return values |
+| `mock.side_effect = Exception` | `mock_error(..., raises=Exception)` | Explicit error mocking |
+| `mock.assert_called_with(...)` | `plugin.assert_request(...)` / `spy.assert_call(...)` | Required, not optional |
+| `mock.assert_not_called()` | Not needed | If it was not registered, it cannot be called |
+| `call_args_list` | Interaction log | Automatic, exhaustive, shown on failure |
+
+### Migration by example
+
+**Patching an HTTP call**
+
+```python
+# BEFORE: unittest.mock
+from unittest.mock import patch, MagicMock
+
+@patch("myapp.client.requests.get")
+def test_fetch_user(mock_get):
+    mock_get.return_value = MagicMock(
+        status_code=200,
+        json=MagicMock(return_value={"name": "Alice"}),
+    )
+    user = fetch_user(42)
+    mock_get.assert_called_once_with("https://api.example.com/users/42")
+    assert user["name"] == "Alice"
+
+# AFTER: bigfoot
+from dirty_equals import IsInstance
+
+def test_fetch_user():
+    bigfoot.http.mock_response(
+        "GET", "https://api.example.com/users/42",
+        json={"name": "Alice"}, status=200,
+    )
+    with bigfoot:
+        user = fetch_user(42)
+
+    bigfoot.http.assert_request(
+        "GET", "https://api.example.com/users/42",
+        headers=IsInstance(dict), body=None,
+    )
+    assert user["name"] == "Alice"
+```
+
+**Patching a subprocess call**
+
+```python
+# BEFORE: unittest.mock
+from unittest.mock import patch
+
+@patch("myapp.deploy.subprocess.run")
+def test_deploy(mock_run):
+    mock_run.return_value.returncode = 0
+    mock_run.return_value.stdout = "deployed"
+    result = deploy("prod")
+    mock_run.assert_called_once()
+
+# AFTER: bigfoot
+def test_deploy():
+    bigfoot.subprocess_mock.mock_run(
+        ["kubectl", "apply", "-f", "prod.yaml"],
+        returncode=0, stdout="deployed",
+    )
+    with bigfoot:
+        result = deploy("prod")
+
+    bigfoot.subprocess_mock.assert_run(
+        ["kubectl", "apply", "-f", "prod.yaml"],
+        returncode=0, stdout="deployed",
+    )
+```
+
+**Patching an arbitrary object**
+
+```python
+# BEFORE: unittest.mock
+from unittest.mock import patch
+
+@patch("myapp.services.cache")
+def test_cached_lookup(mock_cache):
+    mock_cache.get.return_value = "cached_value"
+    result = lookup("key")
+    mock_cache.get.assert_called_once_with("key")
+
+# AFTER: bigfoot
+def test_cached_lookup():
+    cache_mock = bigfoot.mock("myapp.services:cache")
+    cache_mock.get.returns("cached_value")
+
+    with bigfoot:
+        result = lookup("key")
+
+    cache_mock.get.assert_call(args=("key",), kwargs={}, returned="cached_value")
+```
+
+### Incremental adoption
+
+You do not have to migrate your entire test suite at once. bigfoot and `unittest.mock` can coexist in the same project:
+
+1. **Start with guard mode.** Install bigfoot and run your suite. Guard mode (default `"warn"`) will show you every real I/O call across all tests without breaking anything.
+2. **Migrate test by test.** Pick tests that touch HTTP, subprocess, or database calls first -- these benefit most from bigfoot's strict enforcement.
+3. **Escalate to strict guard mode.** Once coverage is high, set `guard = "error"` in `pyproject.toml` to catch any remaining leaks.
+
+<!-- END NEW SECTION -->
 
 ## Plugins
 

--- a/docs/guides/guard-mode.md
+++ b/docs/guides/guard-mode.md
@@ -200,16 +200,15 @@ regions = ["us-east-1"]
 hosts = ["*.production.internal"]
 ```
 
-### Per-file overrides
+### Per-file allow rules
 
-Override firewall rules for specific test files:
+Override firewall rules for specific test files using the flat `per-file-allow` map.
+Keys are glob patterns matched against test file paths; values are lists of allow rules:
 
 ```toml
-[tool.bigfoot.firewall.overrides."tests/integration/test_api.py"]
-allow.http.hosts = ["*"]
-
-[tool.bigfoot.firewall.overrides."tests/unit/"]
-deny.http.hosts = ["*"]
+[tool.bigfoot.firewall.per-file-allow]
+"tests/integration/test_api.py" = ["http:*"]
+"tests/api/*" = ["http:*", "dns:*"]
 ```
 
 ### Legacy `guard_allow` migration

--- a/docs/guides/guard-mode.md
+++ b/docs/guides/guard-mode.md
@@ -161,7 +161,7 @@ Multiple `M()` objects in a single `allow()` or `deny()` create a union (any mat
 ```python
 @pytest.mark.allow(
     M(protocol="http", host="*.example.com"),
-    M(protocol="http", host="*.internal.co"),
+    M(protocol="http", host="*.internal.com"),
 )
 def test_multi_host():
     ...
@@ -177,27 +177,23 @@ The `[tool.bigfoot.firewall]` section in `pyproject.toml` replaces the old `guar
 [tool.bigfoot]
 guard = "error"
 
-[tool.bigfoot.firewall.allow.http]
-hosts = ["*.example.com", "api.stripe.com"]
-methods = ["GET", "POST"]
-
-[tool.bigfoot.firewall.allow.redis]
-hosts = ["localhost"]
-commands = ["GET", "SET", "DEL"]
-
-[tool.bigfoot.firewall.allow.subprocess]
-commands = ["/usr/bin/git", "/usr/local/bin/helm"]
-
-[tool.bigfoot.firewall.allow.boto3]
-services = ["s3", "sqs"]
-regions = ["us-east-1"]
+[tool.bigfoot.firewall]
+allow = [
+    "http://*.example.com",
+    "http://api.stripe.com",
+    "redis://localhost",
+    "subprocess:/usr/bin/git",
+    "subprocess:/usr/local/bin/helm",
+    "boto3:s3",
+    "boto3:sqs",
+]
 ```
 
 ### Denying in TOML
 
 ```toml
-[tool.bigfoot.firewall.deny.http]
-hosts = ["*.production.internal"]
+[tool.bigfoot.firewall]
+deny = ["http://*.production.internal"]
 ```
 
 ### Per-file allow rules
@@ -213,17 +209,16 @@ Keys are glob patterns matched against test file paths; values are lists of allo
 
 ### Legacy `guard_allow` migration
 
-The old `guard_allow` config is still supported but deprecated:
+The old `guard_allow` config key has been removed. If you see a `BigfootConfigError` about `guard_allow`, migrate as follows:
 
 ```toml
-# OLD (deprecated):
+# OLD (removed):
 [tool.bigfoot]
 guard_allow = ["socket", "database"]
 
-# NEW (recommended):
-[tool.bigfoot.firewall.allow]
-socket = {}
-database = {}
+# NEW:
+[tool.bigfoot.firewall]
+allow = ["socket:*", "database:*"]
 ```
 
 ## Three-level configuration

--- a/docs/guides/guard-mode.md
+++ b/docs/guides/guard-mode.md
@@ -1,8 +1,10 @@
-# Guard Mode
+# Firewall Mode
 
-## What is guard mode?
+## What is firewall mode?
 
-Guard mode prevents accidental real I/O during tests. bigfoot installs interceptors at **session startup** and keeps them active for the entire test run. Every I/O call is routed through bigfoot, and any call that is not covered by a sandbox or an explicit allowlist is either warned about or blocked, depending on the guard level.
+Firewall mode prevents accidental real I/O during tests. bigfoot installs interceptors at **session startup** and keeps them active for the entire test run. Every I/O call is routed through bigfoot, and any call that is not covered by a sandbox or an explicit firewall rule is either warned about or blocked, depending on the firewall level.
+
+In earlier versions of bigfoot, this was called "guard mode" with coarse plugin-level `allow("http")` / `deny("redis")` rules. The firewall redesign introduces **granular pattern matching** via `M()` objects, **TOML-based configuration**, **ceiling restrictions** via `restrict()`, and **protocol-typed request objects** (`FirewallRequest`).
 
 ## I just saw a warning. What do I do?
 
@@ -23,23 +25,76 @@ def test_something():
     ...
 ```
 
-**Option 2: Allow the plugin for a specific block:**
+**Option 2: Allow with a granular pattern:**
+
+```python
+from bigfoot import M
+
+@pytest.mark.allow(M(protocol="http", host="*.example.com"))
+def test_something():
+    ...
+```
+
+**Option 3: Allow in a scoped block:**
 
 ```python
 with bigfoot.allow("http"):
     ...
 ```
 
-**Option 3: Mock the call with a sandbox:**
+**Option 4: Mock the call with a sandbox:**
 
 ```python
 with bigfoot:
     ...
 ```
 
-## Guard Levels
+## Quick start
 
-Configure the guard level in `pyproject.toml` under `[tool.bigfoot]`:
+### String-based rules (simplest)
+
+The simplest way to use the firewall is with string-based plugin names, which works the same as the old guard mode:
+
+```python
+import bigfoot
+
+# Mark: allow for entire test
+@pytest.mark.allow("http")
+def test_needs_http():
+    ...
+
+# Context manager: allow for a block
+def test_scoped():
+    with bigfoot.allow("dns", "socket"):
+        ...
+```
+
+### Pattern-based rules with M()
+
+For granular control, use `M()` pattern objects:
+
+```python
+from bigfoot import M
+
+# Allow HTTP only to specific hosts
+@pytest.mark.allow(M(protocol="http", host="*.example.com"))
+def test_api_calls():
+    ...
+
+# Allow HTTP GET only
+@pytest.mark.allow(M(protocol="http", method="GET"))
+def test_readonly():
+    ...
+
+# Allow Redis only for specific commands
+@pytest.mark.allow(M(protocol="redis", command="GET"))
+def test_cache_reads():
+    ...
+```
+
+## Firewall levels
+
+Configure the firewall level in `pyproject.toml` under `[tool.bigfoot]`:
 
 | Level | Config | Behavior |
 |-------|--------|----------|
@@ -56,37 +111,154 @@ guard = "error"  # strict enforcement
 
 **Note:** `guard = true` is rejected with a clear error message. Use `"warn"`, `"error"`, or `false` instead.
 
-## How it works
+## Pattern matching with M()
 
-bigfoot's pytest plugin installs two layers of guard infrastructure:
+The `M()` object lets you define granular firewall rules that match against `FirewallRequest` fields. Each protocol defines its own set of matchable fields.
 
-1. **Session-scoped patches** (`_bigfoot_guard_patches`): At the start of the test session, bigfoot activates every guard-eligible plugin. The interceptors remain installed for the entire session.
+### Matching syntax
 
-2. **Per-test guard activation** (`pytest_runtest_call` hook): During each test function's body, bigfoot sets the guard ContextVars. When an interceptor fires and there is no active sandbox, it checks guard state and either warns, blocks, or passes through.
-
-### Decision tree
-
-When an interceptor fires, `get_verifier_or_raise()` follows this precedence:
-
-1. **Sandbox active**: Return the verifier. The call is mocked and recorded as usual.
-2. **Guard active, plugin in allowlist**: Raise `GuardPassThrough` internally. The interceptor catches this and delegates to the original function. The call is invisible to bigfoot.
-3. **Guard active, plugin not in allowlist, warn mode**: Emit `GuardedCallWarning`, then raise `GuardPassThrough`. The real call proceeds.
-4. **Guard active, plugin not in allowlist, error mode**: Raise `GuardedCallError`. The test fails immediately.
-5. **Guard patches installed but guard not active** (fixture setup/teardown): Raise `GuardPassThrough`. Calls pass through to originals.
-6. **No sandbox, no guard**: Raise `SandboxNotActiveError` (existing behavior for non-guard-eligible plugins).
-
-In short: **sandbox > allow/deny > guard level**.
-
-## Allowing Plugins
-
-### pytest marker (whole test)
-
-For tests that need real calls throughout the entire test body:
+`M()` accepts keyword arguments. Each key corresponds to a field on the protocol's `FirewallRequest` dataclass:
 
 ```python
+from bigfoot import M
+
+# Exact match
+M(protocol="http", method="GET")
+
+# Glob patterns (for strings)
+M(protocol="http", host="*.example.com")
+M(protocol="subprocess", command="/usr/bin/*")
+
+# CIDR notation (for hosts/IPs)
+M(protocol="http", host="10.0.0.0/8")
+
+# Regex (prefix with ~)
+M(protocol="http", path="~^/api/v[0-9]+/users")
+
+# Callable (arbitrary predicate)
+M(protocol="http", host=lambda h: h.endswith(".internal"))
+```
+
+### Supported fields by protocol
+
+| Protocol | Fields |
+|----------|--------|
+| `http` | `host`, `path`, `method`, `port` |
+| `redis` | `host`, `port`, `command`, `db` |
+| `subprocess` | `command`, `args` |
+| `boto3` | `service`, `operation`, `region` |
+| `database` | `host`, `port`, `database`, `driver` |
+| `socket` | `host`, `port`, `family` |
+| `dns` | `name`, `rdtype` |
+| `smtp` | `host`, `port` |
+| `grpc` | `host`, `port`, `service`, `method` |
+| `ssh` | `host`, `port`, `username` |
+
+### Combining patterns
+
+Multiple `M()` objects in a single `allow()` or `deny()` create a union (any match allows/denies):
+
+```python
+@pytest.mark.allow(
+    M(protocol="http", host="*.example.com"),
+    M(protocol="http", host="*.internal.co"),
+)
+def test_multi_host():
+    ...
+```
+
+## TOML configuration
+
+### Basic TOML firewall config
+
+The `[tool.bigfoot.firewall]` section in `pyproject.toml` replaces the old `guard_allow` key. It provides structured, per-protocol rules:
+
+```toml
+[tool.bigfoot]
+guard = "error"
+
+[tool.bigfoot.firewall.allow.http]
+hosts = ["*.example.com", "api.stripe.com"]
+methods = ["GET", "POST"]
+
+[tool.bigfoot.firewall.allow.redis]
+hosts = ["localhost"]
+commands = ["GET", "SET", "DEL"]
+
+[tool.bigfoot.firewall.allow.subprocess]
+commands = ["/usr/bin/git", "/usr/local/bin/helm"]
+
+[tool.bigfoot.firewall.allow.boto3]
+services = ["s3", "sqs"]
+regions = ["us-east-1"]
+```
+
+### Denying in TOML
+
+```toml
+[tool.bigfoot.firewall.deny.http]
+hosts = ["*.production.internal"]
+```
+
+### Per-file overrides
+
+Override firewall rules for specific test files:
+
+```toml
+[tool.bigfoot.firewall.overrides."tests/integration/test_api.py"]
+allow.http.hosts = ["*"]
+
+[tool.bigfoot.firewall.overrides."tests/unit/"]
+deny.http.hosts = ["*"]
+```
+
+### Legacy `guard_allow` migration
+
+The old `guard_allow` config is still supported but deprecated:
+
+```toml
+# OLD (deprecated):
+[tool.bigfoot]
+guard_allow = ["socket", "database"]
+
+# NEW (recommended):
+[tool.bigfoot.firewall.allow]
+socket = {}
+database = {}
+```
+
+## Three-level configuration
+
+Firewall rules combine from three sources, with later sources able to narrow but not widen earlier ones:
+
+1. **TOML** (`pyproject.toml`): Project-wide defaults. Applied to every test.
+2. **Marks** (`@pytest.mark.allow`, `@pytest.mark.deny`): Per-test overrides. Can widen or narrow the TOML rules.
+3. **Context managers** (`bigfoot.allow()`, `bigfoot.deny()`, `bigfoot.restrict()`): Scoped blocks within a test. `restrict()` enforces a ceiling that inner blocks cannot widen.
+
+### Precedence
+
+The general rule is: **sandbox > allow/deny > firewall level**.
+
+Within the allow/deny layer:
+- Marks merge with TOML rules (union for allow, union for deny)
+- Context managers stack: `allow()` widens, `deny()` narrows, `restrict()` sets a ceiling
+- `deny()` always wins over `allow()` when both match the same request
+
+## Marks
+
+### @pytest.mark.allow
+
+Allow real calls for the entire test:
+
+```python
+# String form (allow entire plugin)
 @pytest.mark.allow("dns", "socket")
 def test_needs_network():
-    # DNS and socket calls pass through for the entire test
+    ...
+
+# Pattern form (granular)
+@pytest.mark.allow(M(protocol="http", host="*.example.com"))
+def test_api():
     ...
 ```
 
@@ -99,9 +271,23 @@ def test_also_needs_network():
     ...
 ```
 
-### Context manager (scoped block)
+### @pytest.mark.deny
 
-For allowing real calls in a specific block:
+Narrow the allowlist for the entire test:
+
+```python
+@pytest.mark.allow("dns", "socket", "http")
+@pytest.mark.deny("http")
+def test_network_but_not_http():
+    # DNS and socket pass through, but http is guarded
+    ...
+```
+
+## Context managers
+
+### allow()
+
+Widen the allowlist for a scoped block:
 
 ```python
 import bigfoot
@@ -110,7 +296,6 @@ def test_boto3_integration():
     bigfoot.boto3_mock.mock_api_call("s3", "PutObject", returns={})
 
     with bigfoot.allow("dns", "socket"):
-        # DNS resolution and raw socket calls pass through
         with bigfoot:
             upload_file("my-bucket", "key", b"data")
 
@@ -129,63 +314,9 @@ with bigfoot.allow("dns"):
     # back to dns only
 ```
 
-### Fixture-based (setup-time)
+### deny()
 
-Fixtures can set up allowlists during test setup:
-
-```python
-@pytest.fixture
-def allow_dns():
-    with bigfoot.allow("dns"):
-        yield
-```
-
-### Combining markers and fixtures
-
-Marker allowlists and fixture allowlists are **merged** (unioned). A test with `@pytest.mark.allow("socket")` that uses a fixture which calls `bigfoot.allow("dns")` will have both `"dns"` and `"socket"` in its allowlist.
-
-`@pytest.mark.deny` narrows the merged allowlist:
-
-```python
-@pytest.mark.allow("dns", "socket")
-@pytest.mark.deny("dns")
-def test_socket_only():
-    # socket is allowed, dns is blocked
-    ...
-```
-
-### Valid names
-
-`allow()` accepts any plugin registry name (e.g., `"http"`, `"redis"`, `"boto3"`) or guard-eligible source-ID prefix (e.g., `"db"`, `"asyncio"`). Passing an unknown name raises `BigfootConfigError` immediately.
-
-## Denying Plugins
-
-### pytest marker
-
-The `deny` mark removes plugins from the allowlist for the entire test:
-
-```python
-@pytest.mark.allow("dns", "socket", "http")
-@pytest.mark.deny("http")
-def test_network_but_not_http():
-    # DNS and socket pass through, but http is guarded
-    ...
-```
-
-Multiple deny marks combine via union:
-
-```python
-@pytest.mark.allow("dns", "socket", "http")
-@pytest.mark.deny("http")
-@pytest.mark.deny("socket")
-def test_dns_only():
-    # Only DNS passes through
-    ...
-```
-
-### Context manager
-
-`deny()` narrows the current allowlist by removing specific plugins:
+Narrow the current allowlist:
 
 ```python
 with bigfoot.allow("dns", "socket", "http"):
@@ -196,21 +327,226 @@ with bigfoot.allow("dns", "socket", "http"):
     # http is allowed again here
 ```
 
-Like `allow()`, `deny()` blocks nest and restore the previous allowlist on exit:
+Like `allow()`, `deny()` blocks nest and restore the previous state on exit.
+
+### restrict()
+
+Set a **ceiling** that inner blocks cannot widen. This is the key new context manager in the firewall redesign:
 
 ```python
-with bigfoot.allow("dns", "socket"):
-    with bigfoot.deny("socket"):
-        # only dns allowed
-        with bigfoot.deny("dns"):
-            # nothing allowed -- full guard mode
-        # dns allowed again
-    # dns and socket allowed again
+with bigfoot.restrict("http"):
+    # Only http is allowed in this block, nothing else
+    with bigfoot.allow("dns"):
+        # dns is NOT allowed here -- restrict() prevents widening
+        # only http is still allowed
+    ...
 ```
 
-Denying a plugin that is not currently allowed is a no-op (no error).
+`restrict()` is useful for enforcing that a code path only makes specific types of calls:
 
-## Filtering Warnings
+```python
+from bigfoot import M
+
+def test_payment_isolation():
+    with bigfoot.restrict(M(protocol="http", host="api.stripe.com")):
+        # Only Stripe HTTP calls are allowed
+        # Any other HTTP call, or any non-HTTP call, is blocked
+        process_payment(amount=5000)
+```
+
+### Fixture-based
+
+Fixtures can set up firewall rules during test setup:
+
+```python
+@pytest.fixture
+def allow_dns():
+    with bigfoot.allow("dns"):
+        yield
+```
+
+## FirewallRequest protocol
+
+Each protocol defines a `FirewallRequest` dataclass that carries the details of an intercepted call. Plugins construct these objects and pass them to the firewall for matching:
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class HttpFirewallRequest:
+    protocol: str = "http"
+    method: str = ""
+    host: str = ""
+    port: int = 0
+    path: str = ""
+
+@dataclass(frozen=True)
+class RedisFirewallRequest:
+    protocol: str = "redis"
+    host: str = ""
+    port: int = 6379
+    command: str = ""
+    db: int = 0
+
+@dataclass(frozen=True)
+class SubprocessFirewallRequest:
+    protocol: str = "subprocess"
+    command: str = ""
+    args: tuple = ()
+```
+
+Plugin authors constructing `FirewallRequest` objects should populate all available fields so that user-defined `M()` patterns can match precisely.
+
+## How it works
+
+bigfoot's pytest plugin installs two layers of firewall infrastructure:
+
+1. **Session-scoped patches** (`_bigfoot_guard_patches`): At the start of the test session, bigfoot activates every guard-eligible plugin. The interceptors remain installed for the entire session.
+
+2. **Per-test firewall activation** (`pytest_runtest_call` hook): During each test function's body, bigfoot sets the firewall ContextVars. When an interceptor fires and there is no active sandbox, it checks firewall state and either warns, blocks, or passes through.
+
+### Decision tree
+
+When an interceptor fires, `get_verifier_or_raise()` follows this precedence:
+
+1. **Sandbox active**: Return the verifier. The call is mocked and recorded as usual.
+2. **Firewall active, request matches allow rule**: Raise `GuardPassThrough` internally. The interceptor catches this and delegates to the original function. The call is invisible to bigfoot.
+3. **Firewall active, request matches deny rule** (or no allow rule matches): Check firewall level.
+4. **Warn mode**: Emit `GuardedCallWarning`, then raise `GuardPassThrough`. The real call proceeds.
+5. **Error mode**: Raise `GuardedCallError`. The test fails immediately.
+6. **Firewall patches installed but firewall not active** (fixture setup/teardown): Raise `GuardPassThrough`. Calls pass through to originals.
+7. **No sandbox, no firewall**: Raise `SandboxNotActiveError` (existing behavior for non-guard-eligible plugins).
+
+In short: **sandbox > allow/deny/restrict > firewall level**.
+
+## Examples for common protocols
+
+### HTTP
+
+```python
+from bigfoot import M
+
+# Allow all HTTP to a specific host
+@pytest.mark.allow(M(protocol="http", host="api.example.com"))
+def test_api_integration():
+    ...
+
+# Allow only GET requests
+@pytest.mark.allow(M(protocol="http", method="GET", host="*.example.com"))
+def test_readonly_api():
+    ...
+```
+
+### Redis
+
+```python
+from bigfoot import M
+
+# Allow read-only Redis commands
+@pytest.mark.allow(M(protocol="redis", command="GET"))
+def test_cache_read():
+    ...
+
+# Allow Redis to a specific host
+@pytest.mark.allow(M(protocol="redis", host="localhost", port=6379))
+def test_local_redis():
+    ...
+```
+
+### Subprocess
+
+```python
+from bigfoot import M
+
+# Allow specific binaries
+@pytest.mark.allow(M(protocol="subprocess", command="/usr/bin/git"))
+def test_git_operations():
+    ...
+
+# Allow a directory of binaries
+@pytest.mark.allow(M(protocol="subprocess", command="/usr/local/bin/*"))
+def test_local_tools():
+    ...
+```
+
+### boto3
+
+```python
+from bigfoot import M
+
+# Allow S3 operations only
+@pytest.mark.allow(M(protocol="boto3", service="s3"))
+def test_s3_upload():
+    ...
+
+# Allow S3 and SQS in a specific region
+@pytest.mark.allow(
+    M(protocol="boto3", service="s3", region="us-east-1"),
+    M(protocol="boto3", service="sqs", region="us-east-1"),
+)
+def test_aws_pipeline():
+    ...
+```
+
+### Mixed: boto3 with DNS and socket
+
+boto3 makes DNS lookups and raw socket connections internally. A test that mocks the boto3 API call but runs outside a sandbox needs to allow the underlying network access:
+
+```python
+import pytest
+import bigfoot
+from bigfoot import M
+
+@pytest.mark.allow("dns", "socket")
+def test_s3_upload():
+    bigfoot.boto3_mock.mock_api_call("s3", "PutObject", returns={})
+
+    with bigfoot:
+        upload_to_s3("my-bucket", "my-key", b"hello")
+
+    bigfoot.boto3_mock.assert_api_call(
+        service="s3", operation="PutObject",
+        params={"Bucket": "my-bucket", "Key": "my-key", "Body": b"hello"},
+    )
+```
+
+## Error messages
+
+When firewall mode is set to `"error"` and blocks a call, `GuardedCallError` provides resolution options:
+
+```
+GuardedCallError: 'http:request' blocked by bigfoot firewall.
+
+  Request details:
+    protocol=http, method=POST, host=api.stripe.com, path=/v1/charges
+
+  Fix: allow this call to pass through:
+
+    # Allow the entire plugin:
+    @pytest.mark.allow("http")
+    def test_something():
+        ...
+
+    # Allow with a pattern:
+    @pytest.mark.allow(M(protocol="http", host="api.stripe.com"))
+    def test_something():
+        ...
+
+    # Or use a context manager (scoped to a block):
+    with bigfoot.allow("http"):
+        ...
+
+    # Or mock the call with a sandbox:
+    with bigfoot:
+        ...
+
+  Valid plugin names for allow():
+    async_subprocess, async_websocket, ...
+
+  Docs: https://bigfoot.readthedocs.io/guides/guard-mode/
+```
+
+## Filtering warnings
 
 In warn mode, you can filter `GuardedCallWarning` using Python's standard `warnings` module:
 
@@ -234,49 +570,13 @@ filterwarnings = [
 ]
 ```
 
-## Configuration
-
-Guard mode is **enabled by default** in warn mode. Configuration lives in `pyproject.toml` under `[tool.bigfoot]`:
-
-```toml
-# Default: warn mode (emit warnings, calls proceed)
-[tool.bigfoot]
-# guard key can be omitted entirely
-
-# Strict enforcement: block unguarded calls
-[tool.bigfoot]
-guard = "error"
-
-# Disable guard mode entirely
-[tool.bigfoot]
-guard = false
-```
-
-When guard mode is disabled (`guard = false`), bigfoot does not install session-scoped patches and does not activate guard during tests. Plugins only intercept calls inside explicit sandboxes, which is the pre-guard-mode behavior.
-
-## Default Allowlist
-
-Set a project-wide default allowlist in `pyproject.toml`:
-
-```toml
-[tool.bigfoot]
-guard = "error"
-guard_allow = ["socket", "database"]
-```
-
-Every test runs as if marked with `@pytest.mark.allow("socket", "database")`. Individual tests can still use `@pytest.mark.deny(...)` to narrow the default.
-
-This is useful for projects where most tests make real I/O (e.g., web frameworks with TestClient) and you want guard mode to catch only specific categories of unguarded calls.
-
-Invalid names in `guard_allow` raise `BigfootConfigError` at test collection time, just like invalid names in `@pytest.mark.allow`.
-
 ## Supported plugins
 
-Guard mode applies to plugins that perform external I/O. The `supports_guard` class variable controls eligibility.
+Firewall mode applies to plugins that perform external I/O. The `supports_guard` class variable controls eligibility.
 
-### Guard-eligible plugins (21)
+### Firewall-eligible plugins (21)
 
-These plugins have `supports_guard = True` (the default) and are activated by guard mode:
+These plugins have `supports_guard = True` (the default) and are activated by firewall mode:
 
 | Plugin | Intercepts |
 |--------|------------|
@@ -302,7 +602,7 @@ These plugins have `supports_guard = True` (the default) and are activated by gu
 | SyncWebSocketPlugin | `websocket-client` |
 | McpPlugin | `mcp` |
 
-### Non-guard plugins (7)
+### Non-firewall plugins (7)
 
 These plugins set `supports_guard = False` because they do not perform external I/O:
 
@@ -316,64 +616,12 @@ These plugins set `supports_guard = False` because they do not perform external 
 | FileIoPlugin | Opt-in (`default_enabled=False`), local filesystem |
 | NativePlugin | Opt-in (`default_enabled=False`), ctypes/cffi |
 
-## Error messages
-
-When guard mode is set to `"error"` and blocks a call, `GuardedCallError` provides three resolution options:
-
-```
-GuardedCallError: 'http:request' blocked by bigfoot guard mode.
-
-  Fix: allow this plugin to make real calls:
-
-    @pytest.mark.allow("http")
-    def test_something():
-        ...
-
-  Or use a context manager (scoped to a block):
-
-    with bigfoot.allow("http"):
-        ...
-
-  Or mock the call with a sandbox:
-
-    with bigfoot:
-        ...
-
-  Valid plugin names for allow():
-    async_subprocess, async_websocket, ...
-
-  Docs: https://bigfoot.readthedocs.io/guides/guard-mode/
-```
-
-## Example: boto3 with DNS and socket
-
-boto3 makes DNS lookups and raw socket connections internally. A test that mocks the boto3 API call but runs outside a sandbox needs to allow the underlying network access:
-
-```python
-import pytest
-import bigfoot
-
-@pytest.mark.allow("dns", "socket")
-def test_s3_upload():
-    bigfoot.boto3_mock.mock_api_call("s3", "PutObject", returns={})
-
-    with bigfoot:
-        upload_to_s3("my-bucket", "my-key", b"hello")
-
-    bigfoot.boto3_mock.assert_api_call(
-        service="s3", operation="PutObject",
-        params={"Bucket": "my-bucket", "Key": "my-key", "Body": b"hello"},
-    )
-```
-
-Without the `@pytest.mark.allow("dns", "socket")` mark, any DNS or socket calls that happen during test setup (before `with bigfoot:`) would trigger warnings (or errors in strict mode).
-
 ## Interaction with sandbox mode
 
-Guard mode and sandbox mode are complementary:
+Firewall mode and sandbox mode are complementary:
 
-- **Inside a sandbox** (`with bigfoot:`): All calls are intercepted, mocked, and recorded. Guard mode is irrelevant because the sandbox verifier handles everything.
-- **Outside a sandbox, guard active**: Calls to guard-eligible plugins are warned about or blocked, unless in an `allow()` block or marked with `@pytest.mark.allow`. The `deny()` context manager and `@pytest.mark.deny` can narrow the allowlist to re-guard specific plugins.
-- **Outside a sandbox, guard inactive** (fixture setup/teardown): Interceptors are installed but pass through to originals. This prevents guard from interfering with test infrastructure.
+- **Inside a sandbox** (`with bigfoot:`): All calls are intercepted, mocked, and recorded. Firewall mode is irrelevant because the sandbox verifier handles everything.
+- **Outside a sandbox, firewall active**: Calls to firewall-eligible plugins are checked against the allow/deny rules and `M()` patterns. Calls that do not match an allow rule are warned about or blocked. The `restrict()` context manager can set a ceiling that inner blocks cannot widen.
+- **Outside a sandbox, firewall inactive** (fixture setup/teardown): Interceptors are installed but pass through to originals. This prevents the firewall from interfering with test infrastructure.
 
-Guard mode does not change how sandboxes work. It only adds protection for the code that runs outside sandboxes during a test.
+Firewall mode does not change how sandboxes work. It only adds protection for the code that runs outside sandboxes during a test.

--- a/docs/guides/threading.md
+++ b/docs/guides/threading.md
@@ -32,7 +32,7 @@ bigfoot defines nine `ContextVar` instances. All of them are captured by `copy_c
 | `_current_test_verifier` | `_context` | Points module-level API functions to the per-test verifier |
 | `_any_order_depth` | `_context` | Tracks nesting depth of `in_any_order()` blocks |
 | `_guard_active` | `_context` | Whether guard mode is active for the current test |
-| `_guard_allowlist` | `_context` | Set of plugin names allowed to pass through |
+| `_guard_allowlist` | `_context` | Firewall rules (allow/deny/restrict) for the current scope |
 | `_guard_level` | `_context` | Guard level: `"warn"` or `"error"` |
 | `_guard_patches_installed` | `_context` | Whether session-scoped guard patches are installed |
 | `_recording_in_progress` | `_recording` | Auto-assert guard (prevents `mark_asserted` during `record`) |
@@ -78,7 +78,7 @@ The `dev-ft` extra excludes `psycopg2-binary`, which does not ship prebuilt whee
 
 ## Interaction with guard mode
 
-Guard state (`_guard_active`, `_guard_allowlist`, `_guard_level`, `_guard_patches_installed`) propagates to child threads through the same mechanism. This means:
+Firewall state (`_guard_active`, `_guard_allowlist`, `_guard_level`, `_guard_patches_installed`) propagates to child threads through the same mechanism. This means:
 
 - If a test is running with guard mode active, calls in child threads are guarded.
 - If a test uses `@pytest.mark.allow("http")` or `bigfoot.allow("http")`, the allowlist propagates to child threads.

--- a/docs/guides/writing-plugins.md
+++ b/docs/guides/writing-plugins.md
@@ -529,13 +529,13 @@ Key implementation rules:
 
 ---
 
-## Guard mode support
+## Firewall mode support
 
-Plugins declare whether they participate in guard mode via the `supports_guard` class variable.
+Plugins declare whether they participate in firewall mode (formerly guard mode) via the `supports_guard` class variable.
 
 ### Default: `supports_guard = True`
 
-The default value in `BasePlugin` is `True`. This means bigfoot will activate the plugin at session startup during guard mode, and any intercepted call outside a sandbox will be blocked (or passed through if allowed). This is correct for any plugin that intercepts external I/O (HTTP, database, socket, etc.).
+The default value in `BasePlugin` is `True`. This means bigfoot will activate the plugin at session startup during firewall mode, and any intercepted call outside a sandbox will be checked against the firewall rules (allow/deny/restrict with `M()` patterns). This is correct for any plugin that intercepts external I/O (HTTP, database, socket, etc.).
 
 ### Setting `supports_guard = False`
 
@@ -549,9 +549,26 @@ class MyComputePlugin(BasePlugin):
     # ...
 ```
 
+### Constructing FirewallRequest objects
+
+When a firewall-eligible plugin intercepts a call outside a sandbox, it should construct a protocol-specific `FirewallRequest` dataclass and pass it to the firewall for matching against `M()` patterns. Each protocol defines its own request type with fields relevant to that protocol:
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class MyProtocolFirewallRequest:
+    protocol: str = "myprotocol"
+    host: str = ""
+    port: int = 0
+    operation: str = ""
+```
+
+Populate all available fields so that user-defined `M()` patterns can match precisely. The firewall checks these fields against the rules defined in TOML config, `@pytest.mark.allow`/`deny`, and `allow()`/`deny()`/`restrict()` context managers.
+
 ### Handling `GuardPassThrough` in interceptors
 
-When guard mode is active and a call is allowed (via `allow()` or `@pytest.mark.allow`), `get_verifier_or_raise()` raises `GuardPassThrough` instead of returning a verifier. The allowlist can also be narrowed with `deny()` or `@pytest.mark.deny`, which re-guards specific plugins. Guard-eligible interceptors must catch `GuardPassThrough` and delegate to the original function:
+When firewall mode is active and a call is allowed (via `allow()`, `@pytest.mark.allow`, or an `M()` pattern match), `get_verifier_or_raise()` raises `GuardPassThrough` instead of returning a verifier. The allowlist can also be narrowed with `deny()`, `@pytest.mark.deny`, or `restrict()`. Firewall-eligible interceptors must catch `GuardPassThrough` and delegate to the original function:
 
 ```python
 from bigfoot import get_verifier_or_raise, GuardPassThrough
@@ -568,7 +585,7 @@ def _my_interceptor(original_self, *args, **kwargs):
 
 `GuardPassThrough` inherits from `BaseException` (not `Exception`) so that generic `except Exception` clauses in user code do not accidentally swallow it. Only interceptors should catch it.
 
-If your plugin has `supports_guard = False`, you do not need `GuardPassThrough` handling because guard mode will never activate your plugin's interceptors.
+If your plugin has `supports_guard = False`, you do not need `GuardPassThrough` handling because firewall mode will never activate your plugin's interceptors.
 
 ---
 

--- a/examples/boto3_service/test_app.py
+++ b/examples/boto3_service/test_app.py
@@ -8,8 +8,6 @@ import bigfoot
 
 from .app import upload_and_notify
 
-pytestmark = pytest.mark.allow("dns", "socket")
-
 
 @pytest.fixture(autouse=True)
 def _silence_botocore():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,9 @@ module = [
 ]
 ignore_missing_imports = true
 
+[tool.bigfoot.firewall]
+allow = ["dns:*", "socket:*"]
+
 [tool.ruff]
 target-version = "py310"
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bigfoot"
-version = "0.18.1"
+version = "0.19.0"
 description = "Full-certainty test mocking: every call recorded and verified"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/bigfoot/__init__.py
+++ b/src/bigfoot/__init__.py
@@ -59,9 +59,9 @@ from bigfoot._errors import (
     UnusedMocksError,
     VerificationError,
 )
-from bigfoot._guard import allow, deny
+from bigfoot._guard import allow, deny, restrict
 from bigfoot._mock_plugin import MockPlugin
-from bigfoot._registry import GUARD_ELIGIBLE_PREFIXES, PluginEntry
+from bigfoot._registry import is_guard_eligible, PluginEntry
 from bigfoot._timeline import Interaction, Timeline
 from bigfoot._verifier import InAnyOrderContext, SandboxContext, StrictVerifier
 
@@ -238,7 +238,7 @@ __all__ = [
     "Timeline",
     "GuardPassThrough",
     "get_verifier_or_raise",
-    "GUARD_ELIGIBLE_PREFIXES",
+    "is_guard_eligible",
     "PluginEntry",
     # Classes
     "StrictVerifier",
@@ -267,6 +267,7 @@ __all__ = [
     # Guard mode
     "allow",
     "deny",
+    "restrict",
     "GuardedCallError",
     "GuardedCallWarning",
     # Errors

--- a/src/bigfoot/__init__.py
+++ b/src/bigfoot/__init__.py
@@ -64,7 +64,7 @@ from bigfoot._firewall_request import FirewallRequest
 from bigfoot._guard import allow, deny, restrict
 from bigfoot._match import M
 from bigfoot._mock_plugin import MockPlugin
-from bigfoot._registry import is_guard_eligible, PluginEntry
+from bigfoot._registry import PluginEntry, is_guard_eligible
 from bigfoot._timeline import Interaction, Timeline
 from bigfoot._verifier import InAnyOrderContext, SandboxContext, StrictVerifier
 

--- a/src/bigfoot/__init__.py
+++ b/src/bigfoot/__init__.py
@@ -59,7 +59,10 @@ from bigfoot._errors import (
     UnusedMocksError,
     VerificationError,
 )
+from bigfoot._firewall import Disposition
+from bigfoot._firewall_request import FirewallRequest
 from bigfoot._guard import allow, deny, restrict
+from bigfoot._match import M
 from bigfoot._mock_plugin import MockPlugin
 from bigfoot._registry import is_guard_eligible, PluginEntry
 from bigfoot._timeline import Interaction, Timeline
@@ -268,6 +271,9 @@ __all__ = [
     "allow",
     "deny",
     "restrict",
+    "M",
+    "Disposition",
+    "FirewallRequest",
     "GuardedCallError",
     "GuardedCallWarning",
     # Errors

--- a/src/bigfoot/__init__.pyi
+++ b/src/bigfoot/__init__.pyi
@@ -37,7 +37,7 @@ from bigfoot._guard import allow as allow
 from bigfoot._guard import deny as deny
 from bigfoot._mock_plugin import ImportSiteMock, ObjectMock
 from bigfoot._mock_plugin import MockPlugin as MockPlugin
-from bigfoot._registry import GUARD_ELIGIBLE_PREFIXES as GUARD_ELIGIBLE_PREFIXES
+from bigfoot._registry import is_guard_eligible as is_guard_eligible
 from bigfoot._registry import PluginEntry as PluginEntry
 from bigfoot._timeline import Interaction as Interaction
 from bigfoot._timeline import Timeline as Timeline

--- a/src/bigfoot/__init__.pyi
+++ b/src/bigfoot/__init__.pyi
@@ -37,8 +37,8 @@ from bigfoot._guard import allow as allow
 from bigfoot._guard import deny as deny
 from bigfoot._mock_plugin import ImportSiteMock, ObjectMock
 from bigfoot._mock_plugin import MockPlugin as MockPlugin
-from bigfoot._registry import is_guard_eligible as is_guard_eligible
 from bigfoot._registry import PluginEntry as PluginEntry
+from bigfoot._registry import is_guard_eligible as is_guard_eligible
 from bigfoot._timeline import Interaction as Interaction
 from bigfoot._timeline import Timeline as Timeline
 from bigfoot._verifier import InAnyOrderContext as InAnyOrderContext

--- a/src/bigfoot/_base_plugin.py
+++ b/src/bigfoot/_base_plugin.py
@@ -35,6 +35,7 @@ class BasePlugin(ABC):
     """
 
     supports_guard: ClassVar[bool] = True
+    guard_prefixes: ClassVar[tuple[str, ...]] = ()
 
     # Shared patching infrastructure -- each subclass gets its own via __init_subclass__
     _install_count: ClassVar[int] = 0

--- a/src/bigfoot/_context.py
+++ b/src/bigfoot/_context.py
@@ -104,6 +104,7 @@ def get_verifier_or_raise(
                 level = _guard_level.get()
                 if level == "warn":
                     import warnings  # noqa: PLC0415
+
                     from bigfoot._errors import GuardedCallWarning  # noqa: PLC0415
 
                     warnings.warn(

--- a/src/bigfoot/_context.py
+++ b/src/bigfoot/_context.py
@@ -10,6 +10,7 @@ import contextvars
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from bigfoot._firewall_request import FirewallRequest
     from bigfoot._verifier import StrictVerifier
 
 # ---------------------------------------------------------------------------
@@ -30,10 +31,6 @@ _current_test_verifier: contextvars.ContextVar[StrictVerifier | None] = contextv
 
 _guard_active: contextvars.ContextVar[bool] = contextvars.ContextVar(
     "bigfoot_guard_active", default=False
-)
-
-_guard_allowlist: contextvars.ContextVar[frozenset[str]] = contextvars.ContextVar(
-    "bigfoot_guard_allowlist", default=frozenset()
 )
 
 _guard_level: contextvars.ContextVar[str] = contextvars.ContextVar(
@@ -64,65 +61,81 @@ def get_active_verifier() -> StrictVerifier | None:
     return _active_verifier.get()
 
 
-def get_verifier_or_raise(source_id: str) -> StrictVerifier:
+def get_verifier_or_raise(
+    source_id: str,
+    firewall_request: FirewallRequest | None = None,
+) -> StrictVerifier:
     """Return the active verifier, or handle guard mode, or raise.
 
-    Called by interceptors when they fire. Decision tree:
+    Decision tree:
 
-    1. Sandbox active (_active_verifier set): return verifier.
-    2. Guard-eligible plugin (source_id prefix in GUARD_ELIGIBLE_PREFIXES):
-       a. Guard active + not in allowlist: raise GuardedCallError (blocked).
-       b. Guard active + in allowlist, or guard not active but patches
-          installed: raise GuardPassThrough (call original).
-    3. Non-guard-eligible plugin (e.g., "mock:", "logging:"):
-       raise SandboxNotActiveError (existing behavior, guard is irrelevant).
-    4. No sandbox, no guard: raise SandboxNotActiveError.
+    1. Sandbox active: return verifier (firewall not consulted).
+    2. Guard-eligible plugin (determined by supports_guard ClassVar):
+       a. Guard active + firewall_request provided:
+          - Evaluate request against firewall stack.
+          - ALLOW: raise GuardPassThrough (call original).
+          - DENY + level "warn": warn and raise GuardPassThrough.
+          - DENY + level "error": raise GuardedCallError.
+       b. Guard active + no firewall_request (should not happen post-migration,
+          but safe fallback): raise GuardedCallError.
+       c. Guard not active but patches installed: raise GuardPassThrough.
+    3. Non-guard-eligible plugin: raise SandboxNotActiveError.
     """
     verifier = _active_verifier.get()
     if verifier is not None:
         return verifier
 
-    # No sandbox active. Check if this is a guard-eligible plugin.
-    from bigfoot._registry import GUARD_ELIGIBLE_PREFIXES  # noqa: PLC0415
-
+    # Determine guard eligibility from plugin ClassVar, not GUARD_ELIGIBLE_PREFIXES
     plugin_name = source_id.split(":")[0]
-    is_guard_eligible = plugin_name in GUARD_ELIGIBLE_PREFIXES
 
-    if is_guard_eligible:
+    # Use the new unified eligibility check
+    from bigfoot._registry import is_guard_eligible  # noqa: PLC0415
+
+    if is_guard_eligible(plugin_name):
         if _guard_active.get():
-            # Guard active: check allowlist
-            allowlist = _guard_allowlist.get()
-            if plugin_name not in allowlist:
+            if firewall_request is not None:
+                from bigfoot._firewall import Disposition, get_firewall_stack  # noqa: PLC0415
+
+                disposition = get_firewall_stack().evaluate(firewall_request)
+                if disposition == Disposition.ALLOW:
+                    raise GuardPassThrough()
+
+                # DENY
                 level = _guard_level.get()
                 if level == "warn":
                     import warnings  # noqa: PLC0415
-
                     from bigfoot._errors import GuardedCallWarning  # noqa: PLC0415
 
                     warnings.warn(
-                        f"{source_id!r} called outside sandbox. "
-                        f'Silence with @pytest.mark.allow("{plugin_name}") or '
-                        f'set guard = "error" in [tool.bigfoot] to make this an error.',
+                        f"{source_id!r} blocked by firewall. "
+                        f"See GuardedCallError docs for fix options.",
                         GuardedCallWarning,
                         stacklevel=4,
                     )
                     raise GuardPassThrough()
+
                 # level == "error"
                 from bigfoot._errors import GuardedCallError  # noqa: PLC0415
 
                 raise GuardedCallError(
-                    source_id=source_id, plugin_name=plugin_name,
+                    source_id=source_id,
+                    plugin_name=plugin_name,
+                    firewall_request=firewall_request,
                 )
-            # In allowlist: pass through to original
-            raise GuardPassThrough()
+            else:
+                # No firewall_request: fail closed
+                from bigfoot._errors import GuardedCallError  # noqa: PLC0415
+
+                raise GuardedCallError(
+                    source_id=source_id,
+                    plugin_name=plugin_name,
+                    firewall_request=None,
+                )
+
         if _guard_patches_installed.get():
-            # Patches installed but guard not active (fixture teardown).
-            # Pass through to original.
             raise GuardPassThrough()
 
-    # Non-guard-eligible plugin, or no guard infrastructure active.
     from bigfoot._errors import SandboxNotActiveError  # noqa: PLC0415
-
     raise SandboxNotActiveError(source_id=source_id)
 
 

--- a/src/bigfoot/_context.py
+++ b/src/bigfoot/_context.py
@@ -69,21 +69,36 @@ def get_verifier_or_raise(
 
     Decision tree:
 
-    1. Sandbox active: return verifier (firewall not consulted).
-    2. Guard-eligible plugin (determined by supports_guard ClassVar):
+    1. Guard-eligible plugin + guard active + firewall ALLOW:
+       raise GuardPassThrough (bypasses sandbox -- allowed calls are invisible).
+    2. Sandbox active: return verifier.
+    3. Guard-eligible plugin (determined by supports_guard ClassVar):
        a. Guard active + firewall_request provided:
-          - Evaluate request against firewall stack.
-          - ALLOW: raise GuardPassThrough (call original).
           - DENY + level "warn": warn and raise GuardPassThrough.
           - DENY + level "error": raise GuardedCallError.
        b. Guard active + no firewall_request (should not happen post-migration,
           but safe fallback): raise GuardedCallError.
        c. Guard not active but patches installed: raise GuardPassThrough.
-    3. Non-guard-eligible plugin: raise SandboxNotActiveError.
+    4. Non-guard-eligible plugin: raise SandboxNotActiveError.
     """
+    # Check for active sandbox FIRST: when a sandbox is active, all calls
+    # should go through the sandbox's mock/intercept pipeline.  The firewall
+    # is only relevant in guard mode (outside a sandbox).
     verifier = _active_verifier.get()
     if verifier is not None:
         return verifier
+
+    # No sandbox active -- check firewall for guard mode.
+    if firewall_request is not None and _guard_active.get():
+        plugin_name = source_id.split(":")[0]
+        from bigfoot._registry import is_guard_eligible  # noqa: PLC0415
+
+        if is_guard_eligible(plugin_name):
+            from bigfoot._firewall import Disposition, get_firewall_stack  # noqa: PLC0415
+
+            disposition = get_firewall_stack().evaluate(firewall_request)
+            if disposition == Disposition.ALLOW:
+                raise GuardPassThrough()
 
     # Determine guard eligibility from plugin ClassVar, not GUARD_ELIGIBLE_PREFIXES
     plugin_name = source_id.split(":")[0]
@@ -97,10 +112,7 @@ def get_verifier_or_raise(
                 from bigfoot._firewall import Disposition, get_firewall_stack  # noqa: PLC0415
 
                 disposition = get_firewall_stack().evaluate(firewall_request)
-                if disposition == Disposition.ALLOW:
-                    raise GuardPassThrough()
-
-                # DENY
+                # ALLOW was already handled above, so this is DENY
                 level = _guard_level.get()
                 if level == "warn":
                     import warnings  # noqa: PLC0415

--- a/src/bigfoot/_errors.py
+++ b/src/bigfoot/_errors.py
@@ -5,7 +5,10 @@ This module imports NOTHING from other bigfoot modules to prevent circular impor
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bigfoot._firewall_request import FirewallRequest
 
 
 class BigfootError(Exception):
@@ -232,47 +235,194 @@ class BigfootConfigError(BigfootError):
 
 
 class GuardedCallError(BigfootError):
-    """Raised when an I/O call is intercepted during guard mode without
-    an active sandbox or allow() permission.
+    """Raised when a call is blocked by the bigfoot firewall.
 
-    This error means your test (or code it calls) made a real external
-    call that bigfoot's guard mode blocked.
+    The error message shows:
+    1. Exactly what was attempted (URL, host, command, path)
+    2. The most specific allow rule to fix it (not blanket allow)
+    3. All three configuration syntaxes (mark, context manager, TOML)
+    4. Link to docs
     """
 
-    def __init__(self, source_id: str, plugin_name: str) -> None:
+    def __init__(
+        self,
+        source_id: str,
+        plugin_name: str,
+        firewall_request: FirewallRequest | None = None,
+    ) -> None:
         self.source_id = source_id
         self.plugin_name = plugin_name
+        self.firewall_request = firewall_request
         super().__init__(self._build_message())
 
     def _build_message(self) -> str:
-        from bigfoot._registry import GUARD_ELIGIBLE_PREFIXES  # noqa: PLC0415
-
-        valid_names = ", ".join(sorted(GUARD_ELIGIBLE_PREFIXES))
+        req = self.firewall_request
         lines = [
-            f"GuardedCallError: {self.source_id!r} blocked by bigfoot guard mode.",
+            f"GuardedCallError: {self.source_id!r} blocked by bigfoot firewall.",
             "",
-            "  Fix: allow this plugin to make real calls:",
-            "",
-            f'    @pytest.mark.allow("{self.plugin_name}")',
-            "    def test_something():",
-            "        ...",
-            "",
-            "  Or use a context manager (scoped to a block):",
-            "",
-            f'    with bigfoot.allow("{self.plugin_name}"):',
-            "        ...",
-            "",
-            "  Or mock the call with a sandbox:",
-            "",
-            "    with bigfoot:",
-            "        ...",
-            "",
-            "  Valid plugin names for allow():",
-            f"    {valid_names}",
-            "",
-            "  Docs: https://bigfoot.readthedocs.io/guides/guard-mode/",
         ]
+
+        # Section 1: What was attempted
+        lines.append("  Attempted:")
+        if req is not None:
+            lines.append(f"    {self._describe_request(req)}")
+        else:
+            lines.append(f"    {self.source_id} (no request details available)")
+        lines.append("")
+
+        # Section 2: Recommended fix (most specific)
+        mark_fix, cm_fix, toml_fix = self._recommend_fix(req)
+
+        lines.append("  Fix with @pytest.mark.allow:")
+        lines.append("")
+        lines.append(f"    {mark_fix}")
+        lines.append("    def test_something():")
+        lines.append("        ...")
+        lines.append("")
+        lines.append("  Fix with context manager (scoped to a block):")
+        lines.append("")
+        lines.append(f"    {cm_fix}")
+        lines.append("        ...")
+        lines.append("")
+        lines.append("  Fix in pyproject.toml:")
+        lines.append("")
+        for toml_line in toml_fix:
+            lines.append(f"    {toml_line}")
+        lines.append("")
+
+        # Section 3: Or mock it
+        lines.append("  Or mock the call with a sandbox:")
+        lines.append("")
+        lines.append("    with bigfoot:")
+        lines.append("        ...")
+        lines.append("")
+        lines.append("  Docs: https://bigfoot.readthedocs.io/guides/guard-mode/")
+
         return "\n".join(lines)
+
+    def _describe_request(self, req: FirewallRequest) -> str:
+        """Human-readable description of what was attempted."""
+        from bigfoot._firewall_request import (  # noqa: PLC0415
+            Boto3FirewallRequest,
+            DatabaseFirewallRequest,
+            FileIoFirewallRequest,
+            HttpFirewallRequest,
+            McpFirewallRequest,
+            NetworkFirewallRequest,
+            RedisFirewallRequest,
+            SubprocessFirewallRequest,
+        )
+
+        if isinstance(req, HttpFirewallRequest):
+            url = f"{req.scheme}://{req.host}:{req.port}{req.path}"
+            return f"{req.method} {url}"
+        if isinstance(req, RedisFirewallRequest):
+            return f"redis://{req.host}:{req.port}/{req.db} {req.command}"
+        if isinstance(req, SubprocessFirewallRequest):
+            return f"subprocess: {req.command}" if req.command else f"subprocess: {req.binary}"
+        if isinstance(req, FileIoFirewallRequest):
+            return f"file_io: {req.operation} {req.path}"
+        if isinstance(req, Boto3FirewallRequest):
+            return f"boto3: {req.service}.{req.operation}"
+        if isinstance(req, DatabaseFirewallRequest):
+            return f"sqlite: {req.database_path}"
+        if isinstance(req, McpFirewallRequest):
+            return f"mcp: tool={req.tool_name} uri={req.uri}"
+        if isinstance(req, NetworkFirewallRequest):
+            return f"{req.protocol}://{req.host}:{req.port}"
+        return f"{req.protocol}: (details unavailable)"
+
+    def _recommend_fix(
+        self, req: FirewallRequest | None,
+    ) -> tuple[str, str, list[str]]:
+        """Generate the most specific fix for mark, context manager, and TOML.
+
+        Returns (mark_str, cm_str, toml_lines).
+        """
+        if req is None:
+            # Fallback: coarse plugin-level fix
+            return (
+                f'@pytest.mark.allow("{self.plugin_name}")',
+                f'with bigfoot.allow("{self.plugin_name}"):',
+                [
+                    "[tool.bigfoot.firewall]",
+                    f'allow = ["{self.plugin_name}:*"]',
+                ],
+            )
+
+        from bigfoot._firewall_request import (  # noqa: PLC0415
+            Boto3FirewallRequest,
+            FileIoFirewallRequest,
+            HttpFirewallRequest,
+            RedisFirewallRequest,
+            SubprocessFirewallRequest,
+        )
+
+        if isinstance(req, HttpFirewallRequest):
+            m_str = f'M(protocol="http", host="{req.host}", path="{req.path}")'
+            return (
+                f"@pytest.mark.allow({m_str})",
+                f"with bigfoot.allow({m_str}):",
+                [
+                    "[tool.bigfoot.firewall]",
+                    f'allow = ["{req.scheme}://{req.host}{req.path}"]',
+                ],
+            )
+
+        if isinstance(req, RedisFirewallRequest):
+            m_str = f'M(protocol="redis", host="{req.host}", port={req.port})'
+            return (
+                f"@pytest.mark.allow({m_str})",
+                f"with bigfoot.allow({m_str}):",
+                [
+                    "[tool.bigfoot.firewall]",
+                    f'allow = ["redis://{req.host}:{req.port}"]',
+                ],
+            )
+
+        if isinstance(req, SubprocessFirewallRequest):
+            m_str = f'M(protocol="subprocess", binary="{req.binary}")'
+            return (
+                f"@pytest.mark.allow({m_str})",
+                f"with bigfoot.allow({m_str}):",
+                [
+                    "[tool.bigfoot.firewall.allow.subprocess]",
+                    f'commands = ["{req.binary}"]',
+                ],
+            )
+
+        if isinstance(req, FileIoFirewallRequest):
+            m_str = f'M(protocol="file_io", path="{req.path}", operation="{req.operation}")'
+            return (
+                f"@pytest.mark.allow({m_str})",
+                f"with bigfoot.allow({m_str}):",
+                [
+                    "[tool.bigfoot.firewall]",
+                    f'allow = ["file_io:*"]  # or restrict to specific paths',
+                ],
+            )
+
+        if isinstance(req, Boto3FirewallRequest):
+            m_str = f'M(protocol="boto3", service="{req.service}", operation="{req.operation}")'
+            return (
+                f"@pytest.mark.allow({m_str})",
+                f"with bigfoot.allow({m_str}):",
+                [
+                    "[tool.bigfoot.firewall]",
+                    f'allow = ["boto3:*"]  # or restrict to specific services',
+                ],
+            )
+
+        # Generic network protocol
+        m_str = f'M(protocol="{req.protocol}")'
+        return (
+            f"@pytest.mark.allow({m_str})",
+            f"with bigfoot.allow({m_str}):",
+            [
+                "[tool.bigfoot.firewall]",
+                f'allow = ["{req.protocol}:*"]',
+            ],
+        )
 
 
 class GuardedCallWarning(UserWarning):

--- a/src/bigfoot/_errors.py
+++ b/src/bigfoot/_errors.py
@@ -398,7 +398,7 @@ class GuardedCallError(BigfootError):
                 f"with bigfoot.allow({m_str}):",
                 [
                     "[tool.bigfoot.firewall]",
-                    f'allow = ["file_io:*"]  # or restrict to specific paths',
+                    'allow = ["file_io:*"]  # or restrict to specific paths',
                 ],
             )
 
@@ -409,7 +409,7 @@ class GuardedCallError(BigfootError):
                 f"with bigfoot.allow({m_str}):",
                 [
                     "[tool.bigfoot.firewall]",
-                    f'allow = ["boto3:*"]  # or restrict to specific services',
+                    'allow = ["boto3:*"]  # or restrict to specific services',
                 ],
             )
 

--- a/src/bigfoot/_errors.py
+++ b/src/bigfoot/_errors.py
@@ -386,8 +386,8 @@ class GuardedCallError(BigfootError):
                 f"@pytest.mark.allow({m_str})",
                 f"with bigfoot.allow({m_str}):",
                 [
-                    "[tool.bigfoot.firewall.allow.subprocess]",
-                    f'commands = ["{req.binary}"]',
+                    "[tool.bigfoot.firewall]",
+                    f'allow = ["subprocess:{req.binary}"]',
                 ],
             )
 

--- a/src/bigfoot/_firewall.py
+++ b/src/bigfoot/_firewall.py
@@ -1,0 +1,113 @@
+"""Firewall engine: rule stack with push/pop/evaluate."""
+
+from __future__ import annotations
+
+import contextvars
+import enum
+from collections.abc import Generator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bigfoot._firewall_request import FirewallRequest
+    from bigfoot._match import M
+
+
+class Disposition(enum.Enum):
+    """The action a firewall rule takes when it matches a request."""
+    ALLOW = "allow"
+    DENY = "deny"
+
+
+@dataclass(frozen=True, slots=True)
+class FirewallRule:
+    """A single firewall rule: a pattern and what to do when it matches."""
+    pattern: M
+    disposition: Disposition
+
+
+@dataclass(frozen=True, slots=True)
+class RestrictFrame:
+    """A restriction ceiling on the rule stack.
+
+    During evaluation, scanning stops at a RestrictFrame for any request
+    that does NOT match the restriction pattern. Requests that DO match
+    continue scanning past this frame.
+
+    Semantics:
+    - restrict(M(protocol='http')) means only HTTP requests can proceed
+      past this frame. Redis, socket, etc. requests hit this ceiling
+      and get DENY.
+    - Nested restrict() frames intersect: both must match for the
+      request to pass through.
+    """
+    pattern: M
+
+
+# A stack frame is either a rule or a restriction ceiling.
+StackFrame = FirewallRule | RestrictFrame
+
+
+class FirewallStack:
+    """ContextVar-backed stack of firewall rules.
+
+    Frames are ordered outermost (index 0) to innermost (index -1).
+    Evaluation scans from innermost to outermost. First matching rule wins.
+    Default disposition is DENY.
+    """
+
+    __slots__ = ("_frames",)
+
+    def __init__(self, frames: tuple[StackFrame, ...] = ()) -> None:
+        self._frames = frames
+
+    @property
+    def frames(self) -> tuple[StackFrame, ...]:
+        return self._frames
+
+    def push(self, *new_frames: StackFrame) -> FirewallStack:
+        """Return a new stack with new_frames appended (innermost)."""
+        return FirewallStack(self._frames + new_frames)
+
+    def evaluate(self, request: FirewallRequest) -> Disposition:
+        """Evaluate with restrict ceiling semantics (two-phase algorithm).
+
+        Phase 1: Check all RestrictFrames. If ANY restrict frame's pattern
+        does NOT match the request, return DENY immediately. Restrict frames
+        form a conjunction (all must pass).
+
+        Phase 2: Scan FirewallRules innermost to outermost. First match wins.
+        Default DENY.
+
+        See Appendix B for a detailed walkthrough of WHY a two-phase approach
+        is needed -- a single-pass scan allows inner allow() rules to
+        override restrict() ceilings, which defeats their purpose.
+        """
+        # Phase 1: Restriction check (all restrict frames must pass)
+        for frame in self._frames:
+            if isinstance(frame, RestrictFrame):
+                if not frame.pattern.matches(request):
+                    return Disposition.DENY
+
+        # Phase 2: Rule scan (innermost first)
+        for frame in reversed(self._frames):
+            if isinstance(frame, FirewallRule):
+                if frame.pattern.matches(request):
+                    return frame.disposition
+
+        return Disposition.DENY
+
+
+# ---------------------------------------------------------------------------
+# Module-level ContextVar
+# ---------------------------------------------------------------------------
+
+_firewall_stack: contextvars.ContextVar[FirewallStack] = contextvars.ContextVar(
+    "bigfoot_firewall_stack", default=FirewallStack()
+)
+
+
+def get_firewall_stack() -> FirewallStack:
+    """Return the current firewall stack."""
+    return _firewall_stack.get()

--- a/src/bigfoot/_firewall.py
+++ b/src/bigfoot/_firewall.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import contextvars
 import enum
-from collections.abc import Generator
-from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/bigfoot/_firewall_request.py
+++ b/src/bigfoot/_firewall_request.py
@@ -1,0 +1,144 @@
+"""Protocol-typed firewall request classes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class FirewallRequest:
+    """Abstract base for all firewall requests.
+
+    Every subclass MUST set ``protocol`` as a class-level string constant.
+    This is used by M() to filter rules by protocol before field matching.
+    """
+    protocol: str
+
+
+# ---------------------------------------------------------------------------
+# Network base
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True, slots=True)
+class NetworkFirewallRequest(FirewallRequest):
+    """Base for protocols that connect to host:port."""
+    host: str = ""
+    port: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Protocol-specific subclasses
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True, slots=True)
+class HttpFirewallRequest(NetworkFirewallRequest):
+    protocol: str = "http"  # always "http" regardless of scheme
+    scheme: str = ""        # "http" or "https"
+    path: str = ""
+    method: str = ""
+
+@dataclass(frozen=True, slots=True)
+class RedisFirewallRequest(NetworkFirewallRequest):
+    protocol: str = "redis"
+    db: int = 0
+    command: str = ""
+
+@dataclass(frozen=True, slots=True)
+class PostgresFirewallRequest(NetworkFirewallRequest):
+    """Covers both psycopg2 and asyncpg. protocol is "psycopg2" or "asyncpg"."""
+    dbname: str = ""
+
+@dataclass(frozen=True, slots=True)
+class SocketFirewallRequest(NetworkFirewallRequest):
+    protocol: str = "socket"
+    family: str = ""  # "AF_INET", "AF_INET6", "AF_UNIX"
+
+@dataclass(frozen=True, slots=True)
+class DnsFirewallRequest(FirewallRequest):
+    protocol: str = "dns"
+    hostname: str = ""
+    port: int = 0
+    rdtype: str = ""  # "A", "AAAA", "CNAME", etc.
+
+@dataclass(frozen=True, slots=True)
+class SmtpFirewallRequest(NetworkFirewallRequest):
+    protocol: str = "smtp"
+
+@dataclass(frozen=True, slots=True)
+class SshFirewallRequest(NetworkFirewallRequest):
+    protocol: str = "ssh"
+    username: str = ""
+
+@dataclass(frozen=True, slots=True)
+class GrpcFirewallRequest(NetworkFirewallRequest):
+    protocol: str = "grpc"
+    method: str = ""     # full method path, e.g. "/pkg.Service/Method"
+    call_type: str = ""  # "unary", "server_streaming", etc.
+
+@dataclass(frozen=True, slots=True)
+class PikaFirewallRequest(NetworkFirewallRequest):
+    protocol: str = "pika"
+    virtual_host: str = ""
+    exchange: str = ""
+    routing_key: str = ""
+
+@dataclass(frozen=True, slots=True)
+class ElasticsearchFirewallRequest(NetworkFirewallRequest):
+    protocol: str = "elasticsearch"
+    index: str = ""
+    operation: str = ""  # "search", "index", "delete", etc.
+
+@dataclass(frozen=True, slots=True)
+class MongoFirewallRequest(NetworkFirewallRequest):
+    protocol: str = "mongo"
+    database: str = ""
+    collection: str = ""
+    operation: str = ""  # "find", "insert_one", etc.
+
+@dataclass(frozen=True, slots=True)
+class MemcacheFirewallRequest(NetworkFirewallRequest):
+    protocol: str = "memcache"
+    command: str = ""  # "get", "set", "delete", etc.
+
+@dataclass(frozen=True, slots=True)
+class WebSocketFirewallRequest(NetworkFirewallRequest):
+    """Constructed by parsing the WebSocket URI."""
+    protocol: str = "websocket"
+    scheme: str = ""   # "ws" or "wss"
+    path: str = ""
+
+@dataclass(frozen=True, slots=True)
+class Boto3FirewallRequest(FirewallRequest):
+    """No host -- AWS manages endpoints."""
+    protocol: str = "boto3"
+    service: str = ""     # "s3", "dynamodb", etc.
+    operation: str = ""   # "PutObject", "GetItem", etc.
+
+@dataclass(frozen=True, slots=True)
+class McpFirewallRequest(FirewallRequest):
+    protocol: str = "mcp"
+    tool_name: str = ""
+    uri: str = ""  # resource or prompt URI
+
+# ---------------------------------------------------------------------------
+# Non-network protocols
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True, slots=True)
+class SubprocessFirewallRequest(FirewallRequest):
+    protocol: str = "subprocess"
+    command: str = ""   # full command string (joined args)
+    binary: str = ""    # executable name (e.g., "git", "curl")
+
+@dataclass(frozen=True, slots=True)
+class FileIoFirewallRequest(FirewallRequest):
+    protocol: str = "file_io"
+    path: str = ""
+    operation: str = ""  # "read", "write", "delete", "stat", etc.
+    mode: str = ""       # file mode string if applicable
+
+@dataclass(frozen=True, slots=True)
+class DatabaseFirewallRequest(FirewallRequest):
+    """For sqlite (DatabasePlugin)."""
+    protocol: str = "database"
+    database_path: str = ""

--- a/src/bigfoot/_glob.py
+++ b/src/bigfoot/_glob.py
@@ -1,0 +1,106 @@
+"""Custom glob matching for bigfoot firewall patterns.
+
+fnmatch is insufficient because:
+- It treats * and ** identically
+- It has no concept of subdomain boundary anchoring
+- Case sensitivity is platform-dependent
+
+This module provides:
+- bigfoot_match(): general-purpose matching
+- Proper anchoring: *.example.com must NOT match evil-example.com
+- Case-insensitive host matching (RFC 4343)
+- * matches within a segment; ** matches across segments (for paths)
+"""
+
+from __future__ import annotations
+
+from fnmatch import fnmatchcase
+
+
+def _match_host_glob(pattern: str, value: str) -> bool:
+    """Match a hostname glob pattern with proper subdomain anchoring.
+
+    *.example.com matches:
+        sub.example.com         YES
+        deep.sub.example.com    YES
+        example.com             NO
+        evil-example.com        NO
+    """
+    pattern = pattern.lower()
+    value = value.lower()
+
+    if pattern.startswith("*."):
+        suffix = pattern[2:]  # "example.com"
+        if value == suffix:
+            return False  # *.example.com does NOT match example.com
+        return value.endswith("." + suffix)
+
+    return fnmatchcase(value.lower(), pattern.lower())
+
+
+def bigfoot_match(
+    pattern: str,
+    value: str,
+    *,
+    case_sensitive: bool = True,
+) -> bool:
+    """Match a glob pattern against a value with proper anchoring.
+
+    Args:
+        pattern: Glob pattern. Supports * (one segment) and ** (across segments).
+        value: The actual string to match against.
+        case_sensitive: If False, lowercase both sides before matching.
+            Hostnames should always be case-insensitive (RFC 4343).
+
+    Rules:
+        - "*.example.com" matches "sub.example.com" but NOT "example.com"
+          and NOT "evil-example.com"
+        - "/api/**" matches "/api/v1/users" and "/api/v2/items/123"
+        - "/api/*" matches "/api/v1" but NOT "/api/v1/users"
+        - Exact strings (no wildcards) use equality
+    """
+    if not case_sensitive:
+        pattern = pattern.lower()
+        value = value.lower()
+
+    # No wildcards: exact match
+    if "*" not in pattern and "?" not in pattern and "[" not in pattern:
+        return pattern == value
+
+    # Host-style patterns: *.example.com must be anchored at subdomain boundary
+    if pattern.startswith("*.") and "/" not in pattern:
+        return _match_host_glob(pattern, value)
+
+    # Path-style patterns with **: match across path segments
+    if "**" in pattern:
+        # Convert ** to match-anything, * to match-within-segment
+        # Split on ** first, then handle * within each part
+        # IMPORTANT: Use re.escape() on non-wildcard portions before constructing
+        # the regex. Split pattern on *, escape each literal part, rejoin with
+        # regex wildcards. This prevents regex injection from literal characters
+        # like dots, brackets, etc.
+        import re  # noqa: PLC0415
+
+        parts = pattern.split("**")
+        regex_parts = []
+        for part in parts:
+            # Within each part, * matches anything except /
+            # Escape literal portions, then replace escaped \* back with [^/]*
+            sub_parts = part.split("*")
+            escaped = [re.escape(sp) for sp in sub_parts]
+            converted = "[^/]*".join(escaped)
+            regex_parts.append(converted)
+        regex = ".*".join(regex_parts)
+        return re.fullmatch(regex, value) is not None
+
+    # Path-style pattern with single * only: * must not cross /
+    if "/" in pattern:
+        import re  # noqa: PLC0415
+
+        sub_parts = pattern.split("*")
+        escaped = [re.escape(sp) for sp in sub_parts]
+        regex = "[^/]*".join(escaped)
+        return re.fullmatch(regex, value) is not None
+
+    # Non-path glob: standard fnmatchcase
+    return fnmatchcase(value, pattern)

--- a/src/bigfoot/_guard.py
+++ b/src/bigfoot/_guard.py
@@ -1,79 +1,123 @@
-"""Guard mode allow/deny context managers."""
+"""Guard mode allow/deny/restrict context managers."""
 
 from __future__ import annotations
 
 from collections.abc import Generator
 from contextlib import contextmanager
 
-from bigfoot._context import _guard_allowlist
+from bigfoot._firewall import (
+    Disposition,
+    FirewallRule,
+    RestrictFrame,
+    _firewall_stack,
+)
+from bigfoot._match import M
+
+
+def _coerce_to_m(rule: str | M) -> M:
+    """Convert a bare string to M(protocol=name), pass M through."""
+    if isinstance(rule, str):
+        return M(protocol=rule)
+    return rule
 
 
 @contextmanager
-def allow(*plugin_names: str) -> Generator[None, None, None]:
-    """Permit specific plugin categories to bypass both guard mode and sandbox mode.
+def allow(*rules: str | M) -> Generator[None, None, None]:
+    """Push ALLOW rules onto the firewall stack.
 
-    Usage::
-
+    Usage:
+        # Coarse: allow entire protocol
         with bigfoot.allow("dns", "socket"):
-            boto3.client("s3")  # DNS + socket calls pass through
+            ...
 
-    When a plugin is in the allowlist, its interceptor calls the original
-    function immediately, regardless of whether guard mode or a sandbox is
-    active. No timeline recording: allowed calls are invisible to bigfoot.
+        # Granular: allow specific host pattern
+        with bigfoot.allow(M(protocol="http", host="*.example.com")):
+            ...
 
-    Nestable: inner allow() adds to the outer allowlist.
+        # Mixed:
+        with bigfoot.allow("dns", M(protocol="http", host="*.example.com")):
+            ...
     """
-    from bigfoot._errors import BigfootConfigError  # noqa: PLC0415
-    from bigfoot._registry import GUARD_ELIGIBLE_PREFIXES, VALID_PLUGIN_NAMES  # noqa: PLC0415
+    if not rules:
+        raise ValueError("allow() requires at least one rule")
 
-    valid = VALID_PLUGIN_NAMES | GUARD_ELIGIBLE_PREFIXES
-    unknown = set(plugin_names) - valid
-    if unknown:
-        raise BigfootConfigError(
-            f"Unknown plugin name(s) in allow(): {sorted(unknown)}. "
-            f"Valid names: {sorted(valid)}"
-        )
+    frames = tuple(
+        FirewallRule(pattern=_coerce_to_m(r), disposition=Disposition.ALLOW)
+        for r in rules
+    )
 
-    current = _guard_allowlist.get()
-    merged = current | frozenset(plugin_names)
-    token = _guard_allowlist.set(merged)
+    current = _firewall_stack.get()
+    new_stack = current.push(*frames)
+    token = _firewall_stack.set(new_stack)
     try:
         yield
     finally:
-        _guard_allowlist.reset(token)
+        _firewall_stack.reset(token)
 
 
 @contextmanager
-def deny(*plugin_names: str) -> Generator[None, None, None]:
-    """Remove specific plugins from the allowlist within a nested context.
+def deny(*rules: str | M) -> Generator[None, None, None]:
+    """Push DENY rules onto the firewall stack.
 
-    Usage::
-
-        with bigfoot.allow("dns", "socket"):
-            # dns and socket pass through
-            with bigfoot.deny("socket"):
-                # only dns passes through; socket is guarded again
-                socket.connect(...)  # raises GuardedCallError
-            # socket is allowed again here
-
-    Nestable: inner deny() narrows the outer allowlist. On exit, the
-    previous allowlist is restored.
+    Usage:
+        with bigfoot.allow("redis"):
+            with bigfoot.deny(M(protocol="redis", command="FLUSHALL")):
+                # Redis allowed except FLUSHALL
+                ...
     """
-    from bigfoot._errors import BigfootConfigError  # noqa: PLC0415
-    from bigfoot._registry import GUARD_ELIGIBLE_PREFIXES, VALID_PLUGIN_NAMES  # noqa: PLC0415
+    if not rules:
+        raise ValueError("deny() requires at least one rule")
 
-    valid = VALID_PLUGIN_NAMES | GUARD_ELIGIBLE_PREFIXES
-    unknown = set(plugin_names) - valid
-    if unknown:
-        raise BigfootConfigError(
-            f"Unknown plugin name(s) in deny(): {sorted(unknown)}. "
-            f"Valid names: {sorted(valid)}"
-        )
+    frames = tuple(
+        FirewallRule(pattern=_coerce_to_m(r), disposition=Disposition.DENY)
+        for r in rules
+    )
 
-    current = _guard_allowlist.get()
-    narrowed = current - frozenset(plugin_names)
-    token = _guard_allowlist.set(narrowed)
+    current = _firewall_stack.get()
+    new_stack = current.push(*frames)
+    token = _firewall_stack.set(new_stack)
     try:
         yield
     finally:
-        _guard_allowlist.reset(token)
+        _firewall_stack.reset(token)
+
+
+@contextmanager
+def restrict(*rules: str | M) -> Generator[None, None, None]:
+    """Push a restriction ceiling onto the firewall stack.
+
+    Only requests matching the restriction pattern can proceed past this frame.
+    Inner allow() calls work within the restriction's scope but cannot widen it.
+
+    Usage:
+        # Only HTTP allowed; inner allow("redis") is silently blocked
+        with bigfoot.restrict(M(protocol="http")):
+            with bigfoot.allow(M(protocol="http", host="*.example.com")):
+                # Only *.example.com HTTP passes
+                ...
+
+    Multiple rules are OR'd together into a single restriction pattern:
+        with bigfoot.restrict("http", "dns"):
+            # Only HTTP and DNS can pass this ceiling
+            ...
+    """
+    if not rules:
+        raise ValueError("restrict() requires at least one rule")
+
+    if len(rules) == 1:
+        pattern = _coerce_to_m(rules[0])
+    else:
+        # OR them together: restrict("http", "dns") means either HTTP or DNS
+        combined = _coerce_to_m(rules[0])
+        for r in rules[1:]:
+            combined = combined | _coerce_to_m(r)
+        pattern = combined
+
+    frame = RestrictFrame(pattern=pattern)
+    current = _firewall_stack.get()
+    new_stack = current.push(frame)
+    token = _firewall_stack.set(new_stack)
+    try:
+        yield
+    finally:
+        _firewall_stack.reset(token)

--- a/src/bigfoot/_match.py
+++ b/src/bigfoot/_match.py
@@ -152,7 +152,7 @@ class _ExactMatcher(_FieldMatcher):
         self._value = value
 
     def matches(self, actual: Any) -> bool:  # noqa: ANN401
-        return self._value == actual
+        return bool(self._value == actual)
 
     def __repr__(self) -> str:
         return repr(self._value)
@@ -222,7 +222,7 @@ class _EqualityMatcher(_FieldMatcher):
         self._value = value
 
     def matches(self, actual: Any) -> bool:  # noqa: ANN401
-        return self._value == actual
+        return bool(self._value == actual)
 
     def __repr__(self) -> str:
         return repr(self._value)

--- a/src/bigfoot/_match.py
+++ b/src/bigfoot/_match.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import ipaddress
 import re
-from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -50,7 +49,7 @@ class M:
     # Fields that get path normalization at construction time
     _PATH_FIELDS: frozenset[str] = frozenset({"path", "database_path", "uri"})
 
-    def __init__(self, protocol: str | None = None, **kwargs: Any) -> None:
+    def __init__(self, protocol: str | None = None, **kwargs: Any) -> None:  # noqa: ANN401
         self._protocol = protocol
         self._field_matchers: dict[str, _FieldMatcher] = {}
 
@@ -142,7 +141,7 @@ class _FieldMatcher:
     """Base protocol for field-level matching."""
     __slots__ = ()
 
-    def matches(self, actual: Any) -> bool:
+    def matches(self, actual: Any) -> bool:  # noqa: ANN401
         raise NotImplementedError
 
 
@@ -152,7 +151,7 @@ class _ExactMatcher(_FieldMatcher):
     def __init__(self, value: str) -> None:
         self._value = value
 
-    def matches(self, actual: Any) -> bool:
+    def matches(self, actual: Any) -> bool:  # noqa: ANN401
         return self._value == actual
 
     def __repr__(self) -> str:
@@ -165,7 +164,7 @@ class _GlobMatcher(_FieldMatcher):
     def __init__(self, pattern: str) -> None:
         self._pattern = pattern
 
-    def matches(self, actual: Any) -> bool:
+    def matches(self, actual: Any) -> bool:  # noqa: ANN401
         from bigfoot._glob import bigfoot_match  # noqa: PLC0415
         return bigfoot_match(self._pattern, str(actual))
 
@@ -179,7 +178,7 @@ class _CidrMatcher(_FieldMatcher):
     def __init__(self, cidr: str) -> None:
         self._network = ipaddress.ip_network(cidr, strict=False)
 
-    def matches(self, actual: Any) -> bool:
+    def matches(self, actual: Any) -> bool:  # noqa: ANN401
         try:
             return ipaddress.ip_address(actual) in self._network
         except ValueError:
@@ -196,7 +195,7 @@ class _RegexMatcher(_FieldMatcher):
         self._pattern = pattern
         self._compiled = re.compile(pattern)
 
-    def matches(self, actual: Any) -> bool:
+    def matches(self, actual: Any) -> bool:  # noqa: ANN401
         return self._compiled.fullmatch(str(actual)) is not None
 
     def __repr__(self) -> str:
@@ -206,10 +205,10 @@ class _RegexMatcher(_FieldMatcher):
 class _CallableMatcher(_FieldMatcher):
     __slots__ = ("_func",)
 
-    def __init__(self, func: Any) -> None:
+    def __init__(self, func: Any) -> None:  # noqa: ANN401
         self._func = func
 
-    def matches(self, actual: Any) -> bool:
+    def matches(self, actual: Any) -> bool:  # noqa: ANN401
         return bool(self._func(actual))
 
     def __repr__(self) -> str:
@@ -219,10 +218,10 @@ class _CallableMatcher(_FieldMatcher):
 class _EqualityMatcher(_FieldMatcher):
     __slots__ = ("_value",)
 
-    def __init__(self, value: Any) -> None:
+    def __init__(self, value: Any) -> None:  # noqa: ANN401
         self._value = value
 
-    def matches(self, actual: Any) -> bool:
+    def matches(self, actual: Any) -> bool:  # noqa: ANN401
         return self._value == actual
 
     def __repr__(self) -> str:

--- a/src/bigfoot/_match.py
+++ b/src/bigfoot/_match.py
@@ -1,0 +1,277 @@
+"""M() pattern object for defining firewall rules."""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bigfoot._firewall_request import FirewallRequest
+
+# Fields where glob auto-detection applies (strings containing * are globs).
+# All other string fields use exact match by default.
+GLOB_FIELDS: frozenset[str] = frozenset({
+    "host", "hostname", "path", "uri", "database_path",
+})
+
+
+class M:
+    """Match pattern for firewall rules.
+
+    Usage:
+        M(protocol="http")                          # match all HTTP
+        M(protocol="http", host="*.example.com")    # glob on host
+        M(protocol="http", method="GET")             # exact on method
+        M(protocol="redis", host__cidr="10.0.0.0/8") # CIDR match
+        M(protocol="http", path__regex=r"/api/v\d+/.*") # regex match
+        M(protocol="subprocess", binary=lambda b: b in {"git", "curl"})
+
+    Composition:
+        M(protocol="http") | M(protocol="dns")      # match either
+        M(protocol="http") & M(host="*.example.com") # match both
+        ~M(protocol="redis", command="FLUSHALL")     # negate
+
+    Duck-typed value matching protocol:
+    1. str + field in GLOB_FIELDS + contains '*': glob match
+    2. str + field NOT in GLOB_FIELDS: exact match
+    3. __cidr suffix: CIDR network containment
+    4. __regex suffix: re.fullmatch
+    5. __glob suffix: explicit glob (for fields not in GLOB_FIELDS)
+    6. callable(value): call with actual, check truthiness
+    7. Otherwise: pattern == actual (supports dirty-equals, custom __eq__)
+    """
+
+    __slots__ = ("_protocol", "_field_matchers")
+
+    # Fields that get host normalization at construction time
+    _HOST_FIELDS: frozenset[str] = frozenset({"host", "hostname"})
+    # Fields that get path normalization at construction time
+    _PATH_FIELDS: frozenset[str] = frozenset({"path", "database_path", "uri"})
+
+    def __init__(self, protocol: str | None = None, **kwargs: Any) -> None:
+        self._protocol = protocol
+        self._field_matchers: dict[str, _FieldMatcher] = {}
+
+        # Normalize pattern values at construction time so patterns and
+        # requests are always compared in normalized form.
+        normalized_kwargs: dict[str, Any] = {}
+        for key, value in kwargs.items():
+            # Extract the base field name (strip __cidr, __regex, __glob suffixes)
+            base_key = key
+            for suffix in ("__cidr", "__regex", "__glob"):
+                if key.endswith(suffix):
+                    base_key = key[: -len(suffix)]
+                    break
+
+            # Only normalize plain string values (not callables, not suffix-modified)
+            if isinstance(value, str) and base_key == key:
+                if base_key in self._HOST_FIELDS:
+                    from bigfoot._normalize import normalize_host  # noqa: PLC0415
+                    value = normalize_host(value)
+                elif base_key in self._PATH_FIELDS:
+                    from bigfoot._normalize import normalize_path  # noqa: PLC0415
+                    # Only normalize non-glob paths (globs contain * which should not be resolved)
+                    if "*" not in value:
+                        value = normalize_path(value)
+            normalized_kwargs[key] = value
+
+        for key, value in normalized_kwargs.items():
+            if key.endswith("__cidr"):
+                field_name = key[: -len("__cidr")]
+                self._field_matchers[field_name] = _CidrMatcher(value)
+            elif key.endswith("__regex"):
+                field_name = key[: -len("__regex")]
+                self._field_matchers[field_name] = _RegexMatcher(value)
+            elif key.endswith("__glob"):
+                field_name = key[: -len("__glob")]
+                self._field_matchers[field_name] = _GlobMatcher(value)
+            elif callable(value) and not isinstance(value, str):
+                self._field_matchers[key] = _CallableMatcher(value)
+            elif isinstance(value, str) and key in GLOB_FIELDS and "*" in value:
+                self._field_matchers[key] = _GlobMatcher(value)
+            elif isinstance(value, str):
+                self._field_matchers[key] = _ExactMatcher(value)
+            else:
+                # Duck-typed: dirty-equals, int, etc.
+                self._field_matchers[key] = _EqualityMatcher(value)
+
+    def matches(self, request: FirewallRequest) -> bool:
+        """Return True if this pattern matches the given request."""
+        # Protocol filter: if set, request.protocol must match
+        if self._protocol is not None and request.protocol != self._protocol:
+            return False
+
+        # Every field matcher must match its corresponding request field
+        for field_name, matcher in self._field_matchers.items():
+            actual = getattr(request, field_name, _MISSING)
+            if actual is _MISSING:
+                return False
+            if not matcher.matches(actual):
+                return False
+
+        return True
+
+    def __and__(self, other: M) -> M:
+        return _AndPattern(self, other)
+
+    def __or__(self, other: M) -> M:
+        return _OrPattern(self, other)
+
+    def __invert__(self) -> M:
+        return _NotPattern(self)
+
+    def __repr__(self) -> str:
+        parts = []
+        if self._protocol is not None:
+            parts.append(f"protocol={self._protocol!r}")
+        for field_name, matcher in self._field_matchers.items():
+            parts.append(f"{field_name}={matcher!r}")
+        return f"M({', '.join(parts)})"
+
+
+_MISSING = object()
+
+
+# ---------------------------------------------------------------------------
+# Field matcher implementations
+# ---------------------------------------------------------------------------
+
+class _FieldMatcher:
+    """Base protocol for field-level matching."""
+    __slots__ = ()
+
+    def matches(self, actual: Any) -> bool:
+        raise NotImplementedError
+
+
+class _ExactMatcher(_FieldMatcher):
+    __slots__ = ("_value",)
+
+    def __init__(self, value: str) -> None:
+        self._value = value
+
+    def matches(self, actual: Any) -> bool:
+        return self._value == actual
+
+    def __repr__(self) -> str:
+        return repr(self._value)
+
+
+class _GlobMatcher(_FieldMatcher):
+    __slots__ = ("_pattern",)
+
+    def __init__(self, pattern: str) -> None:
+        self._pattern = pattern
+
+    def matches(self, actual: Any) -> bool:
+        from bigfoot._glob import bigfoot_match  # noqa: PLC0415
+        return bigfoot_match(self._pattern, str(actual))
+
+    def __repr__(self) -> str:
+        return f"glob({self._pattern!r})"
+
+
+class _CidrMatcher(_FieldMatcher):
+    __slots__ = ("_network",)
+
+    def __init__(self, cidr: str) -> None:
+        self._network = ipaddress.ip_network(cidr, strict=False)
+
+    def matches(self, actual: Any) -> bool:
+        try:
+            return ipaddress.ip_address(actual) in self._network
+        except ValueError:
+            return False
+
+    def __repr__(self) -> str:
+        return f"cidr({self._network!r})"
+
+
+class _RegexMatcher(_FieldMatcher):
+    __slots__ = ("_pattern", "_compiled")
+
+    def __init__(self, pattern: str) -> None:
+        self._pattern = pattern
+        self._compiled = re.compile(pattern)
+
+    def matches(self, actual: Any) -> bool:
+        return self._compiled.fullmatch(str(actual)) is not None
+
+    def __repr__(self) -> str:
+        return f"regex({self._pattern!r})"
+
+
+class _CallableMatcher(_FieldMatcher):
+    __slots__ = ("_func",)
+
+    def __init__(self, func: Any) -> None:
+        self._func = func
+
+    def matches(self, actual: Any) -> bool:
+        return bool(self._func(actual))
+
+    def __repr__(self) -> str:
+        return f"callable({self._func!r})"
+
+
+class _EqualityMatcher(_FieldMatcher):
+    __slots__ = ("_value",)
+
+    def __init__(self, value: Any) -> None:
+        self._value = value
+
+    def matches(self, actual: Any) -> bool:
+        return self._value == actual
+
+    def __repr__(self) -> str:
+        return repr(self._value)
+
+
+# ---------------------------------------------------------------------------
+# Composite patterns
+# ---------------------------------------------------------------------------
+
+class _AndPattern(M):
+    """Intersection: both patterns must match."""
+    __slots__ = ("_left", "_right")
+
+    def __init__(self, left: M, right: M) -> None:
+        self._left = left
+        self._right = right
+
+    def matches(self, request: FirewallRequest) -> bool:
+        return self._left.matches(request) and self._right.matches(request)
+
+    def __repr__(self) -> str:
+        return f"({self._left!r} & {self._right!r})"
+
+
+class _OrPattern(M):
+    """Union: either pattern may match."""
+    __slots__ = ("_left", "_right")
+
+    def __init__(self, left: M, right: M) -> None:
+        self._left = left
+        self._right = right
+
+    def matches(self, request: FirewallRequest) -> bool:
+        return self._left.matches(request) or self._right.matches(request)
+
+    def __repr__(self) -> str:
+        return f"({self._left!r} | {self._right!r})"
+
+
+class _NotPattern(M):
+    """Negation: pattern must NOT match."""
+    __slots__ = ("_inner",)
+
+    def __init__(self, inner: M) -> None:
+        self._inner = inner
+
+    def matches(self, request: FirewallRequest) -> bool:
+        return not self._inner.matches(request)
+
+    def __repr__(self) -> str:
+        return f"(~{self._inner!r})"

--- a/src/bigfoot/_normalize.py
+++ b/src/bigfoot/_normalize.py
@@ -1,0 +1,110 @@
+"""Normalization for URLs, hostnames, and paths before firewall matching.
+
+All normalization happens when constructing FirewallRequest objects,
+BEFORE they reach the firewall engine. This prevents bypass via
+encoding tricks, path traversal, or hostname aliasing.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from urllib.parse import unquote, urlparse
+
+# Localhost equivalence: these all refer to the local machine
+_LOCALHOST_ALIASES: frozenset[str] = frozenset({
+    "localhost",
+    "127.0.0.1",
+    "::1",
+    "0.0.0.0",
+    "[::1]",
+})
+
+
+def normalize_host(host: str) -> str:
+    """Normalize a hostname for consistent matching.
+
+    - Lowercase (RFC 4343)
+    - Strip brackets from IPv6 (e.g., [::1] -> ::1)
+    - Resolve localhost aliases to canonical "localhost"
+    """
+    host = host.lower().strip()
+    if host.startswith("[") and host.endswith("]"):
+        host = host[1:-1]
+
+    if host in _LOCALHOST_ALIASES:
+        return "localhost"
+
+    # Try to parse as IP and normalize
+    try:
+        addr = ipaddress.ip_address(host)
+        normalized = str(addr)
+        if normalized in _LOCALHOST_ALIASES:
+            return "localhost"
+        return normalized
+    except ValueError:
+        pass
+
+    return host
+
+
+def normalize_path(path: str) -> str:
+    """Normalize a URL path.
+
+    - Decode percent-encoding
+    - Resolve .. and . segments
+    - Collapse // to /
+    - Strip trailing slash (except root /)
+    """
+    path = unquote(path)
+
+    # Collapse double slashes
+    while "//" in path:
+        path = path.replace("//", "/")
+
+    # Resolve . and ..
+    segments = path.split("/")
+    resolved: list[str] = []
+    for seg in segments:
+        if seg == ".":
+            continue
+        if seg == "..":
+            if resolved and resolved[-1] != "":
+                resolved.pop()
+        else:
+            resolved.append(seg)
+
+    result = "/".join(resolved)
+    if not result.startswith("/"):
+        result = "/" + result
+
+    # Strip trailing slash (except root)
+    if result != "/" and result.endswith("/"):
+        result = result[:-1]
+
+    return result
+
+
+def normalize_url(url: str) -> tuple[str, str, int, str]:
+    """Parse and normalize a URL into (scheme, host, port, path).
+
+    Default ports:
+        http -> 80, https -> 443, ws -> 80, wss -> 443,
+        redis -> 6379, postgresql -> 5432
+    """
+    parsed = urlparse(url)
+
+    scheme = (parsed.scheme or "http").lower()
+    host = normalize_host(parsed.hostname or "")
+
+    default_ports = {
+        "http": 80, "https": 443,
+        "ws": 80, "wss": 443,
+        "redis": 6379, "rediss": 6380,
+        "postgresql": 5432, "postgres": 5432,
+        "smtp": 25,
+        "ssh": 22,
+    }
+    port = parsed.port or default_ports.get(scheme, 0)
+    path = normalize_path(parsed.path or "/")
+
+    return scheme, host, port, path

--- a/src/bigfoot/_registry.py
+++ b/src/bigfoot/_registry.py
@@ -151,8 +151,8 @@ def is_guard_eligible(plugin_name: str) -> bool:
                         eligible.add(prefix)
             except Exception:
                 pass
-        is_guard_eligible._cache = frozenset(eligible)
-    return plugin_name in is_guard_eligible._cache
+        is_guard_eligible._cache = frozenset(eligible)  # type: ignore[attr-defined]
+    return plugin_name in is_guard_eligible._cache  # type: ignore[attr-defined]
 
 
 def _clear_guard_eligible_cache() -> None:

--- a/src/bigfoot/_registry.py
+++ b/src/bigfoot/_registry.py
@@ -121,42 +121,6 @@ PLUGIN_REGISTRY: tuple[PluginEntry, ...] = (
 
 VALID_PLUGIN_NAMES: frozenset[str] = frozenset(e.name for e in PLUGIN_REGISTRY)
 
-# Source-ID prefixes used by guard-eligible plugins (supports_guard=True,
-# default_enabled=True). Guard mode blocks calls whose source_id starts with
-# one of these prefixes. Prefixes that don't match registry names (e.g., "db"
-# for the "database" plugin) are included explicitly.
-#
-# Non-guard plugins (logging, jwt, crypto, celery) and opt-in plugins
-# (file_io, native) are NOT included. MockPlugin source_ids start with
-# "mock:" which is also not included.
-GUARD_ELIGIBLE_PREFIXES: frozenset[str] = frozenset({
-    "http",          # HttpPlugin
-    "subprocess",    # SubprocessPlugin, PopenPlugin
-    "smtp",          # SmtpPlugin
-    "socket",        # SocketPlugin
-    "db",            # DatabasePlugin (source_id: "db:connect", "db:execute", ...)
-    "database",      # DatabasePlugin (registry name, for allow() compatibility)
-    "websocket",     # AsyncWebSocketPlugin, SyncWebSocketPlugin
-    "async_websocket",  # registry name
-    "sync_websocket",   # registry name
-    "redis",         # RedisPlugin
-    "psycopg2",      # Psycopg2Plugin
-    "asyncpg",       # AsyncpgPlugin
-    "asyncio",       # AsyncSubprocessPlugin (source_id: "asyncio:subprocess:spawn")
-    "async_subprocess",  # registry name
-    "dns",           # DnsPlugin
-    "memcache",      # MemcachePlugin
-    "boto3",         # Boto3Plugin
-    "elasticsearch", # ElasticsearchPlugin
-    "mongo",         # MongoPlugin
-    "pika",          # PikaPlugin
-    "ssh",           # SshPlugin
-    "grpc",          # GrpcPlugin
-    "mcp",           # McpPlugin
-    "popen",         # PopenPlugin (registry name)
-})
-
-
 def get_plugin_class(entry: PluginEntry) -> type[BasePlugin]:
     """Import and return the plugin class for a registry entry."""
     import importlib
@@ -164,6 +128,37 @@ def get_plugin_class(entry: PluginEntry) -> type[BasePlugin]:
     module = importlib.import_module(entry.import_path)
     cls: type[BasePlugin] = getattr(module, entry.class_name)
     return cls
+
+
+def is_guard_eligible(plugin_name: str) -> bool:
+    """Check if a plugin name corresponds to a guard-eligible plugin.
+
+    Derives eligibility from the plugin's supports_guard ClassVar.
+    Replaces the old GUARD_ELIGIBLE_PREFIXES set.
+    """
+    # Build a cache on first call
+    if not hasattr(is_guard_eligible, "_cache"):
+        eligible: set[str] = set()
+        for entry in PLUGIN_REGISTRY:
+            if not entry.default_enabled:
+                continue
+            try:
+                cls = get_plugin_class(entry)
+                if getattr(cls, "supports_guard", True):
+                    eligible.add(entry.name)
+                    # Also add source_id prefixes that differ from registry name
+                    for prefix in getattr(cls, "guard_prefixes", ()):
+                        eligible.add(prefix)
+            except Exception:
+                pass
+        is_guard_eligible._cache = frozenset(eligible)
+    return plugin_name in is_guard_eligible._cache
+
+
+def _clear_guard_eligible_cache() -> None:
+    """Clear the is_guard_eligible cache. For testing only."""
+    if hasattr(is_guard_eligible, "_cache"):
+        del is_guard_eligible._cache
 
 
 def resolve_enabled_plugins(

--- a/src/bigfoot/plugins/async_subprocess_plugin.py
+++ b/src/bigfoot/plugins/async_subprocess_plugin.py
@@ -11,7 +11,7 @@ import asyncio.subprocess
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
-from bigfoot._context import GuardPassThrough, _guard_allowlist, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import ConflictError
 from bigfoot._state_machine_plugin import StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
@@ -174,12 +174,6 @@ class AsyncSubprocessPlugin(StateMachinePlugin):
             *args: Any,  # noqa: ANN401
             **kwargs: Any,  # noqa: ANN401
         ) -> _AsyncFakeProcess:
-            # Check allowlist FIRST - bypasses both guard and sandbox
-            if "async_subprocess" in _guard_allowlist.get():
-                return cast(
-                    _AsyncFakeProcess,
-                    await _ORIGINAL_CREATE_SUBPROCESS_EXEC(program, *args, **kwargs),
-                )
             try:
                 plugin = _find_async_subprocess_plugin()
             except GuardPassThrough:
@@ -206,12 +200,6 @@ class AsyncSubprocessPlugin(StateMachinePlugin):
             cmd: str,
             **kwargs: Any,  # noqa: ANN401
         ) -> _AsyncFakeProcess:
-            # Check allowlist FIRST - bypasses both guard and sandbox
-            if "async_subprocess" in _guard_allowlist.get():
-                return cast(
-                    _AsyncFakeProcess,
-                    await _ORIGINAL_CREATE_SUBPROCESS_SHELL(cmd, **kwargs),
-                )
             try:
                 plugin = _find_async_subprocess_plugin()
             except GuardPassThrough:

--- a/src/bigfoot/plugins/async_subprocess_plugin.py
+++ b/src/bigfoot/plugins/async_subprocess_plugin.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import ConflictError
+from bigfoot._firewall_request import SubprocessFirewallRequest
 from bigfoot._state_machine_plugin import StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
 
@@ -49,8 +50,10 @@ _bigfoot_create_subprocess_shell: Callable[..., Any] | None = None
 # ---------------------------------------------------------------------------
 
 
-def _find_async_subprocess_plugin() -> "AsyncSubprocessPlugin":
-    verifier = get_verifier_or_raise(_SOURCE_SPAWN)
+def _find_async_subprocess_plugin(
+    firewall_request: SubprocessFirewallRequest | None = None,
+) -> "AsyncSubprocessPlugin":
+    verifier = get_verifier_or_raise(_SOURCE_SPAWN, firewall_request=firewall_request)
     for plugin in verifier._plugins:
         if isinstance(plugin, AsyncSubprocessPlugin):
             return plugin
@@ -175,7 +178,11 @@ class AsyncSubprocessPlugin(StateMachinePlugin):
             **kwargs: Any,  # noqa: ANN401
         ) -> _AsyncFakeProcess:
             try:
-                plugin = _find_async_subprocess_plugin()
+                command = [program, *[str(a) for a in args]]
+                binary = program
+                command_str = " ".join(command)
+                fw_request = SubprocessFirewallRequest(command=command_str, binary=binary)
+                plugin = _find_async_subprocess_plugin(firewall_request=fw_request)
             except GuardPassThrough:
                 return cast(
                     _AsyncFakeProcess,
@@ -201,7 +208,9 @@ class AsyncSubprocessPlugin(StateMachinePlugin):
             **kwargs: Any,  # noqa: ANN401
         ) -> _AsyncFakeProcess:
             try:
-                plugin = _find_async_subprocess_plugin()
+                binary = cmd.split()[0] if cmd else ""
+                fw_request = SubprocessFirewallRequest(command=cmd, binary=binary)
+                plugin = _find_async_subprocess_plugin(firewall_request=fw_request)
             except GuardPassThrough:
                 return cast(
                     _AsyncFakeProcess,

--- a/src/bigfoot/plugins/asyncpg_plugin.py
+++ b/src/bigfoot/plugins/asyncpg_plugin.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
-from bigfoot._context import GuardPassThrough, _guard_allowlist, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._state_machine_plugin import SessionHandle, StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
 
@@ -113,9 +113,6 @@ async def _patched_asyncpg_connect(
 ) -> _FakeAsyncpgConnection:
     _original = AsyncpgPlugin._original_connect
     assert _original is not None
-    # Check allowlist FIRST - bypasses both guard and sandbox
-    if "asyncpg" in _guard_allowlist.get():
-        return cast(_FakeAsyncpgConnection, await _original(dsn, **kwargs))
     try:
         plugin = _get_asyncpg_plugin()
     except GuardPassThrough:

--- a/src/bigfoot/plugins/asyncpg_plugin.py
+++ b/src/bigfoot/plugins/asyncpg_plugin.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 try:
-    import asyncpg
+    import asyncpg  # type: ignore[import-untyped]
 
     _ASYNCPG_AVAILABLE = True
 except ImportError:  # pragma: no cover

--- a/src/bigfoot/plugins/asyncpg_plugin.py
+++ b/src/bigfoot/plugins/asyncpg_plugin.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 try:
-    import asyncpg  # type: ignore[import-untyped]
+    import asyncpg
 
     _ASYNCPG_AVAILABLE = True
 except ImportError:  # pragma: no cover
@@ -118,7 +118,7 @@ async def _patched_asyncpg_connect(
     assert _original is not None
     # Parse connection parameters for firewall request
     host = str(kwargs.get("host", ""))
-    port = int(kwargs.get("port", 0)) if "port" in kwargs else 0
+    port = int(kwargs.get("port", 0)) if "port" in kwargs else 0  # type: ignore[call-overload]
     dbname = str(kwargs.get("database", ""))
     fw_request = PostgresFirewallRequest(protocol="asyncpg", host=host, port=port, dbname=dbname)
     try:

--- a/src/bigfoot/plugins/asyncpg_plugin.py
+++ b/src/bigfoot/plugins/asyncpg_plugin.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from bigfoot._context import GuardPassThrough, get_verifier_or_raise
+from bigfoot._firewall_request import PostgresFirewallRequest
 from bigfoot._state_machine_plugin import SessionHandle, StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
 
@@ -38,8 +39,10 @@ _SOURCE_CLOSE = "asyncpg:close"
 # ---------------------------------------------------------------------------
 
 
-def _get_asyncpg_plugin() -> "AsyncpgPlugin":
-    verifier = get_verifier_or_raise(_SOURCE_CONNECT)
+def _get_asyncpg_plugin(
+    firewall_request: PostgresFirewallRequest | None = None,
+) -> "AsyncpgPlugin":
+    verifier = get_verifier_or_raise(_SOURCE_CONNECT, firewall_request=firewall_request)
     for plugin in verifier._plugins:
         if isinstance(plugin, AsyncpgPlugin):
             return plugin
@@ -113,8 +116,13 @@ async def _patched_asyncpg_connect(
 ) -> _FakeAsyncpgConnection:
     _original = AsyncpgPlugin._original_connect
     assert _original is not None
+    # Parse connection parameters for firewall request
+    host = str(kwargs.get("host", ""))
+    port = int(kwargs.get("port", 0)) if "port" in kwargs else 0
+    dbname = str(kwargs.get("database", ""))
+    fw_request = PostgresFirewallRequest(protocol="asyncpg", host=host, port=port, dbname=dbname)
     try:
-        plugin = _get_asyncpg_plugin()
+        plugin = _get_asyncpg_plugin(firewall_request=fw_request)
     except GuardPassThrough:
         return cast(_FakeAsyncpgConnection, await _original(dsn, **kwargs))
     fake_conn = _FakeAsyncpgConnection(plugin)

--- a/src/bigfoot/plugins/boto3_plugin.py
+++ b/src/bigfoot/plugins/boto3_plugin.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from bigfoot._base_plugin import BasePlugin
-from bigfoot._context import GuardPassThrough, _guard_allowlist, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import UnmockedInteractionError
 from bigfoot._timeline import Interaction
 
@@ -109,9 +109,6 @@ def _patched_make_api_call(
 ) -> Any:  # noqa: ANN401
     _original = Boto3Plugin._original_make_api_call
     assert _original is not None
-    # Check allowlist FIRST - bypasses both guard and sandbox
-    if "boto3" in _guard_allowlist.get():
-        return _original(client_self, operation_name, api_params)
     try:
         plugin = _get_boto3_plugin()
     except GuardPassThrough:

--- a/src/bigfoot/plugins/boto3_plugin.py
+++ b/src/bigfoot/plugins/boto3_plugin.py
@@ -5,6 +5,7 @@ Uses a per-service:operation FIFO queue.
 
 from __future__ import annotations
 
+import os
 import threading
 import traceback
 from collections import deque
@@ -173,6 +174,17 @@ class Boto3Plugin(BasePlugin):
     """
 
     _original_make_api_call: ClassVar[Callable[..., Any] | None] = None
+    _saved_env: ClassVar[dict[str, str | None]] = {}
+
+    # Env vars that must be set to prevent botocore's credential provider
+    # from hitting the EC2 metadata service (169.254.169.254).
+    _CREDENTIAL_ENV_VARS: ClassVar[dict[str, str]] = {
+        "AWS_ACCESS_KEY_ID": "testing",
+        "AWS_SECRET_ACCESS_KEY": "testing",
+        "AWS_SECURITY_TOKEN": "testing",
+        "AWS_SESSION_TOKEN": "testing",
+        "AWS_DEFAULT_REGION": "us-east-1",
+    }
 
     def __init__(self, verifier: StrictVerifier) -> None:
         super().__init__(verifier)
@@ -237,19 +249,37 @@ class Boto3Plugin(BasePlugin):
     # ------------------------------------------------------------------
 
     def install_patches(self) -> None:
-        """Install botocore._make_api_call patch."""
+        """Install botocore._make_api_call patch and set dummy AWS credentials.
+
+        Setting dummy credentials prevents botocore's credential provider from
+        hitting the EC2 metadata service (169.254.169.254), which would leak DNS
+        and HTTP calls to other plugin interceptors.
+        """
         if not _BOTO3_AVAILABLE:
             raise ImportError(
                 "Install bigfoot[boto3] to use Boto3Plugin: pip install bigfoot[boto3]"
             )
+        # Save current env values and inject dummy credentials
+        for key, value in self._CREDENTIAL_ENV_VARS.items():
+            Boto3Plugin._saved_env[key] = os.environ.get(key)
+            os.environ[key] = value
+
         Boto3Plugin._original_make_api_call = botocore.client.BaseClient._make_api_call
         botocore.client.BaseClient._make_api_call = _patched_make_api_call
 
     def restore_patches(self) -> None:
-        """Restore original botocore._make_api_call."""
+        """Restore original botocore._make_api_call and AWS credential env vars."""
         if Boto3Plugin._original_make_api_call is not None:
             botocore.client.BaseClient._make_api_call = Boto3Plugin._original_make_api_call
             Boto3Plugin._original_make_api_call = None
+
+        # Restore original env values
+        for key, original_value in Boto3Plugin._saved_env.items():
+            if original_value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = original_value
+        Boto3Plugin._saved_env.clear()
 
     # ------------------------------------------------------------------
     # BasePlugin abstract method implementations

--- a/src/bigfoot/plugins/boto3_plugin.py
+++ b/src/bigfoot/plugins/boto3_plugin.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 from bigfoot._base_plugin import BasePlugin
 from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import UnmockedInteractionError
+from bigfoot._firewall_request import Boto3FirewallRequest
 from bigfoot._timeline import Interaction
 
 if TYPE_CHECKING:
@@ -63,8 +64,10 @@ class Boto3MockConfig:
 # ---------------------------------------------------------------------------
 
 
-def _get_boto3_plugin() -> Boto3Plugin | None:
-    verifier = get_verifier_or_raise("boto3:_make_api_call")
+def _get_boto3_plugin(
+    firewall_request: Boto3FirewallRequest | None = None,
+) -> Boto3Plugin | None:
+    verifier = get_verifier_or_raise("boto3:_make_api_call", firewall_request=firewall_request)
     for plugin in verifier._plugins:
         if isinstance(plugin, Boto3Plugin):
             return plugin
@@ -109,17 +112,19 @@ def _patched_make_api_call(
 ) -> Any:  # noqa: ANN401
     _original = Boto3Plugin._original_make_api_call
     assert _original is not None
+    meta = getattr(client_self, "meta", None)
+    service_model = getattr(meta, "service_model", None) if meta else None
+    service_name_fw: str = (
+        getattr(service_model, "service_name", "unknown") if service_model else "unknown"
+    )
+    fw_request = Boto3FirewallRequest(service=service_name_fw, operation=operation_name)
     try:
-        plugin = _get_boto3_plugin()
+        plugin = _get_boto3_plugin(firewall_request=fw_request)
     except GuardPassThrough:
         return _original(client_self, operation_name, api_params)
     if plugin is None:
         return _original(client_self, operation_name, api_params)
-    meta = getattr(client_self, "meta", None)
-    service_model = getattr(meta, "service_model", None) if meta else None
-    service_name: str = (
-        getattr(service_model, "service_name", "unknown") if service_model else "unknown"
-    )
+    service_name = service_name_fw
     queue_key = f"{service_name}:{operation_name}"
     source_id = f"boto3:{queue_key}"
 

--- a/src/bigfoot/plugins/database_plugin.py
+++ b/src/bigfoot/plugins/database_plugin.py
@@ -4,7 +4,7 @@ import sqlite3
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
-from bigfoot._context import GuardPassThrough, _guard_allowlist, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._state_machine_plugin import SessionHandle, StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
 
@@ -152,9 +152,6 @@ class _FakeConnection:
 def _patched_connect(database: str, **_kwargs: object) -> _FakeConnection:
     _original = DatabasePlugin._original_connect
     assert _original is not None
-    # Check allowlist FIRST - bypasses both guard and sandbox
-    if "database" in _guard_allowlist.get() or "db" in _guard_allowlist.get():
-        return cast(_FakeConnection, _original(database, **_kwargs))
     try:
         plugin = _get_database_plugin()
     except GuardPassThrough:

--- a/src/bigfoot/plugins/database_plugin.py
+++ b/src/bigfoot/plugins/database_plugin.py
@@ -175,6 +175,9 @@ class DatabasePlugin(StateMachinePlugin):
     States: connected -> in_transaction -> connected/closed
     """
 
+    # source_id prefixes that differ from the registry name ("database")
+    guard_prefixes: ClassVar[tuple[str, ...]] = ("db",)
+
     # Saved original, restored when count reaches 0.
     _original_connect: ClassVar[Callable[..., Any] | None] = None
 

--- a/src/bigfoot/plugins/database_plugin.py
+++ b/src/bigfoot/plugins/database_plugin.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from bigfoot._context import GuardPassThrough, get_verifier_or_raise
+from bigfoot._firewall_request import DatabaseFirewallRequest
 from bigfoot._state_machine_plugin import SessionHandle, StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
 
@@ -27,8 +28,10 @@ _SOURCE_CLOSE = "db:close"
 # ---------------------------------------------------------------------------
 
 
-def _get_database_plugin() -> "DatabasePlugin":
-    verifier = get_verifier_or_raise(_SOURCE_CONNECT)
+def _get_database_plugin(
+    firewall_request: DatabaseFirewallRequest | None = None,
+) -> "DatabasePlugin":
+    verifier = get_verifier_or_raise(_SOURCE_CONNECT, firewall_request=firewall_request)
     for plugin in verifier._plugins:
         if isinstance(plugin, DatabasePlugin):
             return plugin
@@ -152,8 +155,9 @@ class _FakeConnection:
 def _patched_connect(database: str, **_kwargs: object) -> _FakeConnection:
     _original = DatabasePlugin._original_connect
     assert _original is not None
+    fw_request = DatabaseFirewallRequest(database_path=database)
     try:
-        plugin = _get_database_plugin()
+        plugin = _get_database_plugin(firewall_request=fw_request)
     except GuardPassThrough:
         return cast(_FakeConnection, _original(database, **_kwargs))
     fake_conn = _FakeConnection(plugin)

--- a/src/bigfoot/plugins/dns_plugin.py
+++ b/src/bigfoot/plugins/dns_plugin.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from bigfoot._base_plugin import BasePlugin
-from bigfoot._context import GuardPassThrough, _guard_allowlist, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import UnmockedInteractionError
 from bigfoot._timeline import Interaction
 
@@ -78,8 +78,6 @@ def _resolve_dns_plugin() -> DnsPlugin | None:
     3. If no ``DnsPlugin`` is registered on the active verifier, return ``None``.
     4. Otherwise return the plugin instance.
     """
-    if "dns" in _guard_allowlist.get():
-        return None
     try:
         return _get_dns_plugin()
     except GuardPassThrough:

--- a/src/bigfoot/plugins/dns_plugin.py
+++ b/src/bigfoot/plugins/dns_plugin.py
@@ -157,7 +157,9 @@ def _patched_getaddrinfo(
     proto: int = 0,
     flags: int = 0,
 ) -> Any:  # noqa: ANN401
-    fw_request = DnsFirewallRequest(hostname=host, port=port if isinstance(port, int) else 0, rdtype="")
+    fw_request = DnsFirewallRequest(
+        hostname=host, port=port if isinstance(port, int) else 0, rdtype="",
+    )
     plugin = _resolve_dns_plugin(firewall_request=fw_request)
     if plugin is None:
         _orig = DnsPlugin._original_getaddrinfo

--- a/src/bigfoot/plugins/dns_plugin.py
+++ b/src/bigfoot/plugins/dns_plugin.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 from bigfoot._base_plugin import BasePlugin
 from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import UnmockedInteractionError
+from bigfoot._firewall_request import DnsFirewallRequest
 from bigfoot._timeline import Interaction
 
 if TYPE_CHECKING:
@@ -61,15 +62,19 @@ class DnsMockConfig:
 # ---------------------------------------------------------------------------
 
 
-def _get_dns_plugin() -> DnsPlugin | None:
-    verifier = get_verifier_or_raise("dns:lookup")
+def _get_dns_plugin(
+    firewall_request: DnsFirewallRequest | None = None,
+) -> DnsPlugin | None:
+    verifier = get_verifier_or_raise("dns:lookup", firewall_request=firewall_request)
     for plugin in verifier._plugins:
         if isinstance(plugin, DnsPlugin):
             return plugin
     return None
 
 
-def _resolve_dns_plugin() -> DnsPlugin | None:
+def _resolve_dns_plugin(
+    firewall_request: DnsFirewallRequest | None = None,
+) -> DnsPlugin | None:
     """Return the active DnsPlugin, or ``None`` if the call should pass through.
 
     Centralises the guard-mode / allowlist check shared by all DNS interceptors:
@@ -79,7 +84,7 @@ def _resolve_dns_plugin() -> DnsPlugin | None:
     4. Otherwise return the plugin instance.
     """
     try:
-        return _get_dns_plugin()
+        return _get_dns_plugin(firewall_request=firewall_request)
     except GuardPassThrough:
         return None
 
@@ -152,7 +157,8 @@ def _patched_getaddrinfo(
     proto: int = 0,
     flags: int = 0,
 ) -> Any:  # noqa: ANN401
-    plugin = _resolve_dns_plugin()
+    fw_request = DnsFirewallRequest(hostname=host, port=port if isinstance(port, int) else 0, rdtype="")
+    plugin = _resolve_dns_plugin(firewall_request=fw_request)
     if plugin is None:
         _orig = DnsPlugin._original_getaddrinfo
         assert _orig is not None
@@ -168,7 +174,8 @@ def _patched_getaddrinfo(
 
 
 def _patched_gethostbyname(hostname: str) -> Any:  # noqa: ANN401
-    plugin = _resolve_dns_plugin()
+    fw_request = DnsFirewallRequest(hostname=hostname, port=0, rdtype="A")
+    plugin = _resolve_dns_plugin(firewall_request=fw_request)
     if plugin is None:
         _orig = DnsPlugin._original_gethostbyname
         assert _orig is not None
@@ -191,7 +198,8 @@ def _patched_resolver_resolve(
     **kwargs: Any,  # noqa: ANN401
 ) -> Any:  # noqa: ANN401
     """Instance method: Resolver().resolve(qname, rdtype)."""
-    plugin = _resolve_dns_plugin()
+    fw_request = DnsFirewallRequest(hostname=str(qname), port=0, rdtype=str(rdtype))
+    plugin = _resolve_dns_plugin(firewall_request=fw_request)
     if plugin is None:
         _orig = DnsPlugin._original_resolver_resolve
         assert _orig is not None
@@ -215,7 +223,8 @@ def _patched_module_resolve(
     **kwargs: Any,  # noqa: ANN401
 ) -> Any:  # noqa: ANN401
     """Module-level: dns.resolver.resolve(qname, rdtype)."""
-    plugin = _resolve_dns_plugin()
+    fw_request = DnsFirewallRequest(hostname=str(qname), port=0, rdtype=str(rdtype))
+    plugin = _resolve_dns_plugin(firewall_request=fw_request)
     if plugin is None:
         _orig = DnsPlugin._original_resolve
         assert _orig is not None

--- a/src/bigfoot/plugins/elasticsearch_plugin.py
+++ b/src/bigfoot/plugins/elasticsearch_plugin.py
@@ -271,7 +271,7 @@ class ElasticsearchPlugin(BasePlugin):
                         port = parsed.port
                 _es_conn_meta[self_] = (normalize_host(str(host)), int(port))
 
-            es_cls.__init__ = _patched_init  # type: ignore[method-assign]
+            es_cls.__init__ = _patched_init  # type: ignore[assignment,method-assign]
 
         for method_name in _INTERCEPTED_METHODS:
             ElasticsearchPlugin._originals[method_name] = getattr(es_cls, method_name)

--- a/src/bigfoot/plugins/elasticsearch_plugin.py
+++ b/src/bigfoot/plugins/elasticsearch_plugin.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from bigfoot._base_plugin import BasePlugin
-from bigfoot._context import GuardPassThrough, _guard_allowlist, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import UnmockedInteractionError
 from bigfoot._timeline import Interaction
 
@@ -106,11 +106,6 @@ def _make_interceptor(operation: str) -> Any:  # noqa: ANN401
     detail_keys = _OPERATION_DETAILS.get(operation, ())
 
     def interceptor(es_self: object, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
-        # Check allowlist FIRST - bypasses both guard and sandbox
-        if "elasticsearch" in _guard_allowlist.get():
-            original = ElasticsearchPlugin._originals.get(operation)
-            if original is not None:
-                return original(es_self, *args, **kwargs)
         try:
             plugin = _get_elasticsearch_plugin()
         except GuardPassThrough:

--- a/src/bigfoot/plugins/elasticsearch_plugin.py
+++ b/src/bigfoot/plugins/elasticsearch_plugin.py
@@ -117,7 +117,9 @@ def _make_interceptor(operation: str) -> Any:  # noqa: ANN401
         host, port = _es_conn_meta.get(es_self, ("unknown", 0))
         index = kwargs.get("index", "")
         fw_request = ElasticsearchFirewallRequest(
-            host=host, port=port, index=index if isinstance(index, str) else "", operation=operation,
+            host=host, port=port,
+            index=index if isinstance(index, str) else "",
+            operation=operation,
         )
         try:
             plugin = _get_elasticsearch_plugin(firewall_request=fw_request)
@@ -229,7 +231,7 @@ class ElasticsearchPlugin(BasePlugin):
         if ElasticsearchPlugin._original_init is None:
             ElasticsearchPlugin._original_init = es_cls.__init__
 
-            def _patched_init(self_: object, *args: Any, **kwargs: Any) -> None:
+            def _patched_init(self_: object, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
                 assert ElasticsearchPlugin._original_init is not None
                 ElasticsearchPlugin._original_init(self_, *args, **kwargs)
                 # Elasticsearch client accepts hosts as str, list of str, or list of dicts

--- a/src/bigfoot/plugins/elasticsearch_plugin.py
+++ b/src/bigfoot/plugins/elasticsearch_plugin.py
@@ -7,10 +7,13 @@ import traceback
 from collections import deque
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, cast
+from weakref import WeakKeyDictionary
 
 from bigfoot._base_plugin import BasePlugin
 from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import UnmockedInteractionError
+from bigfoot._firewall_request import ElasticsearchFirewallRequest
+from bigfoot._normalize import normalize_host
 from bigfoot._timeline import Interaction
 
 if TYPE_CHECKING:
@@ -26,6 +29,9 @@ try:
     _ELASTICSEARCH_AVAILABLE = True
 except ImportError:  # pragma: no cover
     _ELASTICSEARCH_AVAILABLE = False
+
+# Connection metadata: maps Elasticsearch client instance -> (host, port)
+_es_conn_meta: WeakKeyDictionary[object, tuple[str, int]] = WeakKeyDictionary()
 
 # Methods to intercept and their detail extraction specs.
 # Each entry: (method_name, list of (kwarg_name, detail_key) pairs)
@@ -76,8 +82,10 @@ class ElasticsearchMockConfig:
 # ---------------------------------------------------------------------------
 
 
-def _get_elasticsearch_plugin() -> ElasticsearchPlugin | None:
-    verifier = get_verifier_or_raise("elasticsearch:operation")
+def _get_elasticsearch_plugin(
+    firewall_request: ElasticsearchFirewallRequest | None = None,
+) -> ElasticsearchPlugin | None:
+    verifier = get_verifier_or_raise("elasticsearch:operation", firewall_request=firewall_request)
     for plugin in verifier._plugins:
         if isinstance(plugin, ElasticsearchPlugin):
             return plugin
@@ -106,8 +114,13 @@ def _make_interceptor(operation: str) -> Any:  # noqa: ANN401
     detail_keys = _OPERATION_DETAILS.get(operation, ())
 
     def interceptor(es_self: object, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        host, port = _es_conn_meta.get(es_self, ("unknown", 0))
+        index = kwargs.get("index", "")
+        fw_request = ElasticsearchFirewallRequest(
+            host=host, port=port, index=index if isinstance(index, str) else "", operation=operation,
+        )
         try:
-            plugin = _get_elasticsearch_plugin()
+            plugin = _get_elasticsearch_plugin(firewall_request=fw_request)
         except GuardPassThrough:
             original = ElasticsearchPlugin._originals.get(operation)
             if original is not None:
@@ -168,6 +181,7 @@ class ElasticsearchPlugin(BasePlugin):
     """
 
     _originals: ClassVar[dict[str, Any]] = {}
+    _original_init: ClassVar[Any] = None
 
     def __init__(self, verifier: StrictVerifier) -> None:
         super().__init__(verifier)
@@ -210,6 +224,53 @@ class ElasticsearchPlugin(BasePlugin):
                 "pip install bigfoot[elasticsearch]"
             )
         es_cls = es_lib.Elasticsearch
+
+        # Patch __init__ to capture connection metadata
+        if ElasticsearchPlugin._original_init is None:
+            ElasticsearchPlugin._original_init = es_cls.__init__
+
+            def _patched_init(self_: object, *args: Any, **kwargs: Any) -> None:
+                assert ElasticsearchPlugin._original_init is not None
+                ElasticsearchPlugin._original_init(self_, *args, **kwargs)
+                # Elasticsearch client accepts hosts as str, list of str, or list of dicts
+                hosts = args[0] if args else kwargs.get("hosts", kwargs.get("host", "localhost"))
+                host, port = "localhost", 9200
+                if isinstance(hosts, str):
+                    if ":" in hosts and not hosts.startswith("["):
+                        parts = hosts.rsplit(":", 1)
+                        host = parts[0]
+                        try:
+                            port = int(parts[1].rstrip("/"))
+                        except ValueError:
+                            pass
+                    else:
+                        host = hosts.rstrip("/")
+                elif isinstance(hosts, (list, tuple)) and hosts:
+                    first = hosts[0]
+                    if isinstance(first, dict):
+                        host = first.get("host", "localhost")
+                        port = first.get("port", 9200)
+                    elif isinstance(first, str):
+                        if ":" in first and not first.startswith("["):
+                            parts = first.rsplit(":", 1)
+                            host = parts[0]
+                            try:
+                                port = int(parts[1].rstrip("/"))
+                            except ValueError:
+                                pass
+                        else:
+                            host = first.rstrip("/")
+                # Strip scheme if present (e.g., "http://localhost")
+                if "://" in str(host):
+                    from urllib.parse import urlparse  # noqa: PLC0415
+                    parsed = urlparse(str(host) if not str(host).endswith("/") else str(host))
+                    host = parsed.hostname or "localhost"
+                    if parsed.port:
+                        port = parsed.port
+                _es_conn_meta[self_] = (normalize_host(str(host)), int(port))
+
+            es_cls.__init__ = _patched_init  # type: ignore[method-assign]
+
         for method_name in _INTERCEPTED_METHODS:
             ElasticsearchPlugin._originals[method_name] = getattr(es_cls, method_name)
             setattr(es_cls, method_name, _make_interceptor(method_name))
@@ -220,6 +281,9 @@ class ElasticsearchPlugin(BasePlugin):
         for method_name, original in ElasticsearchPlugin._originals.items():
             setattr(es_cls, method_name, original)
         ElasticsearchPlugin._originals.clear()
+        if ElasticsearchPlugin._original_init is not None:
+            es_cls.__init__ = ElasticsearchPlugin._original_init  # type: ignore[method-assign]
+            ElasticsearchPlugin._original_init = None
 
     # ------------------------------------------------------------------
     # BasePlugin abstract method implementations

--- a/src/bigfoot/plugins/grpc_plugin.py
+++ b/src/bigfoot/plugins/grpc_plugin.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from bigfoot._base_plugin import BasePlugin
-from bigfoot._context import GuardPassThrough, _guard_allowlist, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import UnmockedInteractionError
 from bigfoot._timeline import Interaction
 
@@ -241,9 +241,6 @@ def _patched_insecure_channel(target: str, *args: Any, **kwargs: Any) -> _FakeCh
 
     _original = GrpcPlugin._original_insecure_channel
     assert _original is not None
-    # Check allowlist FIRST - bypasses both guard and sandbox
-    if "grpc" in _guard_allowlist.get():
-        return cast(_FakeChannel, _original(target, *args, **kwargs))
     try:
         get_verifier_or_raise("grpc:channel")
     except GuardPassThrough:
@@ -261,9 +258,6 @@ def _patched_secure_channel(  # noqa: ANN401
 
     _original = GrpcPlugin._original_secure_channel
     assert _original is not None
-    # Check allowlist FIRST - bypasses both guard and sandbox
-    if "grpc" in _guard_allowlist.get():
-        return cast(_FakeChannel, _original(target, credentials, *args, **kwargs))
     try:
         get_verifier_or_raise("grpc:channel")
     except GuardPassThrough:

--- a/src/bigfoot/plugins/grpc_plugin.py
+++ b/src/bigfoot/plugins/grpc_plugin.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 from bigfoot._base_plugin import BasePlugin
 from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import UnmockedInteractionError
+from bigfoot._firewall_request import GrpcFirewallRequest
 from bigfoot._timeline import Interaction
 
 if TYPE_CHECKING:
@@ -64,8 +65,10 @@ class GrpcMockConfig:
 # ---------------------------------------------------------------------------
 
 
-def _get_grpc_plugin() -> GrpcPlugin:
-    verifier = get_verifier_or_raise("grpc:channel")
+def _get_grpc_plugin(
+    firewall_request: GrpcFirewallRequest | None = None,
+) -> GrpcPlugin:
+    verifier = get_verifier_or_raise("grpc:channel", firewall_request=firewall_request)
     for plugin in verifier._plugins:
         if isinstance(plugin, GrpcPlugin):
             return plugin
@@ -236,13 +239,34 @@ class _FakeChannel:
 # ---------------------------------------------------------------------------
 
 
+def _parse_grpc_target(target: str) -> tuple[str, int]:
+    """Parse a gRPC target string into (host, port)."""
+    # Strip scheme if present (e.g., "dns:///host:port")
+    if ":///" in target:
+        target = target.split(":///", 1)[1]
+    elif "://" in target:
+        target = target.split("://", 1)[1]
+    # Split host:port
+    if ":" in target:
+        host, port_str = target.rsplit(":", 1)
+        try:
+            port = int(port_str)
+        except ValueError:
+            host, port = target, 0
+    else:
+        host, port = target, 0
+    return host, port
+
+
 def _patched_insecure_channel(target: str, *args: Any, **kwargs: Any) -> _FakeChannel:  # noqa: ANN401
     from bigfoot._errors import SandboxNotActiveError  # noqa: PLC0415
 
     _original = GrpcPlugin._original_insecure_channel
     assert _original is not None
+    host, port = _parse_grpc_target(target)
+    fw_request = GrpcFirewallRequest(host=host, port=port, method="", call_type="")
     try:
-        get_verifier_or_raise("grpc:channel")
+        get_verifier_or_raise("grpc:channel", firewall_request=fw_request)
     except GuardPassThrough:
         return cast(_FakeChannel, _original(target, *args, **kwargs))
     except SandboxNotActiveError:
@@ -258,8 +282,10 @@ def _patched_secure_channel(  # noqa: ANN401
 
     _original = GrpcPlugin._original_secure_channel
     assert _original is not None
+    host, port = _parse_grpc_target(target)
+    fw_request = GrpcFirewallRequest(host=host, port=port, method="", call_type="")
     try:
-        get_verifier_or_raise("grpc:channel")
+        get_verifier_or_raise("grpc:channel", firewall_request=fw_request)
     except GuardPassThrough:
         return cast(_FakeChannel, _original(target, credentials, *args, **kwargs))
     except SandboxNotActiveError:

--- a/src/bigfoot/plugins/http.py
+++ b/src/bigfoot/plugins/http.py
@@ -29,7 +29,7 @@ except ImportError:  # pragma: no cover
     _AIOHTTP_AVAILABLE = False
 
 from bigfoot._base_plugin import BasePlugin
-from bigfoot._context import GuardPassThrough, _guard_allowlist, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import ConflictError, UnmockedInteractionError
 from bigfoot._timeline import Interaction
 
@@ -569,9 +569,6 @@ class HttpPlugin(BasePlugin):
             transport_self: httpx.HTTPTransport,
             request: httpx.Request,
         ) -> httpx.Response:
-            # Check allowlist FIRST - bypasses both guard and sandbox
-            if "http" in _guard_allowlist.get():
-                return _orig_httpx(transport_self, request)
             try:
                 verifier = get_verifier_or_raise("http:request")
             except GuardPassThrough:
@@ -584,11 +581,6 @@ class HttpPlugin(BasePlugin):
             transport_self: httpx.AsyncHTTPTransport,
             request: httpx.Request,
         ) -> httpx.Response:
-            # Check allowlist FIRST - bypasses both guard and sandbox
-            if "http" in _guard_allowlist.get():
-                return await _orig_httpx_async(
-                    transport_self, request,
-                )
             try:
                 verifier = get_verifier_or_raise("http:request")
             except GuardPassThrough:
@@ -604,9 +596,6 @@ class HttpPlugin(BasePlugin):
             request: requests.PreparedRequest,
             **kwargs: Any,  # noqa: ANN401
         ) -> requests.Response:
-            # Check allowlist FIRST - bypasses both guard and sandbox
-            if "http" in _guard_allowlist.get():
-                return _orig_requests_send(adapter_self, request, **kwargs)
             try:
                 verifier = get_verifier_or_raise("http:request")
             except GuardPassThrough:
@@ -679,14 +668,6 @@ class HttpPlugin(BasePlugin):
         def _bigfoot_urllib_dispatch(
             req: urllib.request.Request,
         ) -> urllib.response.addinfourl:
-            # Check allowlist FIRST - bypasses both guard and sandbox
-            if "http" in _guard_allowlist.get():
-                original_opener = HttpPlugin._original_urllib_opener
-                urllib.request.install_opener(original_opener)
-                try:
-                    return cast(urllib.response.addinfourl, urllib.request.urlopen(req))
-                finally:
-                    HttpPlugin._reinstall_urllib_opener()
             try:
                 verifier = get_verifier_or_raise("http:request")
             except GuardPassThrough:
@@ -717,11 +698,6 @@ class HttpPlugin(BasePlugin):
             str_or_url: Any,  # noqa: ANN401
             **kwargs: Any,  # noqa: ANN401
         ) -> Any:  # noqa: ANN401
-            # Check allowlist FIRST - bypasses both guard and sandbox
-            if "http" in _guard_allowlist.get():
-                return await _orig_aiohttp(
-                    session_self, method, str_or_url, **kwargs,
-                )
             try:
                 verifier = get_verifier_or_raise("http:request")
             except GuardPassThrough:
@@ -1297,14 +1273,6 @@ class HttpPlugin(BasePlugin):
         def _bigfoot_urllib_dispatch_ref(
             req: urllib.request.Request,
         ) -> urllib.response.addinfourl:
-            # Check allowlist FIRST - bypasses both guard and sandbox
-            if "http" in _guard_allowlist.get():
-                original_opener = HttpPlugin._original_urllib_opener
-                urllib.request.install_opener(original_opener)
-                try:
-                    return cast(urllib.response.addinfourl, urllib.request.urlopen(req))
-                finally:
-                    HttpPlugin._reinstall_urllib_opener()
             try:
                 verifier = get_verifier_or_raise("http:request")
             except GuardPassThrough:

--- a/src/bigfoot/plugins/http.py
+++ b/src/bigfoot/plugins/http.py
@@ -574,7 +574,9 @@ class HttpPlugin(BasePlugin):
             url = str(request.url)
             method = request.method
             scheme, host, port, path = normalize_url(url)
-            fw_request = HttpFirewallRequest(host=host, port=port, scheme=scheme, path=path, method=method)
+            fw_request = HttpFirewallRequest(
+                host=host, port=port, scheme=scheme, path=path, method=method,
+            )
             try:
                 verifier = get_verifier_or_raise("http:request", firewall_request=fw_request)
             except GuardPassThrough:
@@ -590,7 +592,9 @@ class HttpPlugin(BasePlugin):
             url = str(request.url)
             method = request.method
             scheme, host, port, path = normalize_url(url)
-            fw_request = HttpFirewallRequest(host=host, port=port, scheme=scheme, path=path, method=method)
+            fw_request = HttpFirewallRequest(
+                host=host, port=port, scheme=scheme, path=path, method=method,
+            )
             try:
                 verifier = get_verifier_or_raise("http:request", firewall_request=fw_request)
             except GuardPassThrough:
@@ -609,7 +613,9 @@ class HttpPlugin(BasePlugin):
             url = request.url or ""
             method = (request.method or "GET").upper()
             scheme, host, port, path = normalize_url(url)
-            fw_request = HttpFirewallRequest(host=host, port=port, scheme=scheme, path=path, method=method)
+            fw_request = HttpFirewallRequest(
+                host=host, port=port, scheme=scheme, path=path, method=method,
+            )
             try:
                 verifier = get_verifier_or_raise("http:request", firewall_request=fw_request)
             except GuardPassThrough:
@@ -685,7 +691,9 @@ class HttpPlugin(BasePlugin):
             url = req.full_url
             method = (req.get_method() or "GET").upper()
             scheme, host, port, path = normalize_url(url)
-            fw_request = HttpFirewallRequest(host=host, port=port, scheme=scheme, path=path, method=method)
+            fw_request = HttpFirewallRequest(
+                host=host, port=port, scheme=scheme, path=path, method=method,
+            )
             try:
                 verifier = get_verifier_or_raise("http:request", firewall_request=fw_request)
             except GuardPassThrough:
@@ -718,7 +726,9 @@ class HttpPlugin(BasePlugin):
         ) -> Any:  # noqa: ANN401
             url = str(str_or_url)
             scheme, host, port, path = normalize_url(url)
-            fw_request = HttpFirewallRequest(host=host, port=port, scheme=scheme, path=path, method=method)
+            fw_request = HttpFirewallRequest(
+                host=host, port=port, scheme=scheme, path=path, method=method,
+            )
             try:
                 verifier = get_verifier_or_raise("http:request", firewall_request=fw_request)
             except GuardPassThrough:
@@ -1297,7 +1307,9 @@ class HttpPlugin(BasePlugin):
             url = req.full_url
             method = (req.get_method() or "GET").upper()
             scheme, host, port, path = normalize_url(url)
-            fw_request = HttpFirewallRequest(host=host, port=port, scheme=scheme, path=path, method=method)
+            fw_request = HttpFirewallRequest(
+                host=host, port=port, scheme=scheme, path=path, method=method,
+            )
             try:
                 verifier = get_verifier_or_raise("http:request", firewall_request=fw_request)
             except GuardPassThrough:

--- a/src/bigfoot/plugins/http.py
+++ b/src/bigfoot/plugins/http.py
@@ -31,6 +31,8 @@ except ImportError:  # pragma: no cover
 from bigfoot._base_plugin import BasePlugin
 from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import ConflictError, UnmockedInteractionError
+from bigfoot._firewall_request import HttpFirewallRequest
+from bigfoot._normalize import normalize_url
 from bigfoot._timeline import Interaction
 
 if TYPE_CHECKING:
@@ -569,8 +571,12 @@ class HttpPlugin(BasePlugin):
             transport_self: httpx.HTTPTransport,
             request: httpx.Request,
         ) -> httpx.Response:
+            url = str(request.url)
+            method = request.method
+            scheme, host, port, path = normalize_url(url)
+            fw_request = HttpFirewallRequest(host=host, port=port, scheme=scheme, path=path, method=method)
             try:
-                verifier = get_verifier_or_raise("http:request")
+                verifier = get_verifier_or_raise("http:request", firewall_request=fw_request)
             except GuardPassThrough:
                 return _orig_httpx(transport_self, request)
             plugin = _find_http_plugin(verifier)
@@ -581,8 +587,12 @@ class HttpPlugin(BasePlugin):
             transport_self: httpx.AsyncHTTPTransport,
             request: httpx.Request,
         ) -> httpx.Response:
+            url = str(request.url)
+            method = request.method
+            scheme, host, port, path = normalize_url(url)
+            fw_request = HttpFirewallRequest(host=host, port=port, scheme=scheme, path=path, method=method)
             try:
-                verifier = get_verifier_or_raise("http:request")
+                verifier = get_verifier_or_raise("http:request", firewall_request=fw_request)
             except GuardPassThrough:
                 return await _orig_httpx_async(
                     transport_self, request,
@@ -596,8 +606,12 @@ class HttpPlugin(BasePlugin):
             request: requests.PreparedRequest,
             **kwargs: Any,  # noqa: ANN401
         ) -> requests.Response:
+            url = request.url or ""
+            method = (request.method or "GET").upper()
+            scheme, host, port, path = normalize_url(url)
+            fw_request = HttpFirewallRequest(host=host, port=port, scheme=scheme, path=path, method=method)
             try:
-                verifier = get_verifier_or_raise("http:request")
+                verifier = get_verifier_or_raise("http:request", firewall_request=fw_request)
             except GuardPassThrough:
                 return _orig_requests_send(adapter_self, request, **kwargs)
             plugin = _find_http_plugin(verifier)
@@ -668,8 +682,12 @@ class HttpPlugin(BasePlugin):
         def _bigfoot_urllib_dispatch(
             req: urllib.request.Request,
         ) -> urllib.response.addinfourl:
+            url = req.full_url
+            method = (req.get_method() or "GET").upper()
+            scheme, host, port, path = normalize_url(url)
+            fw_request = HttpFirewallRequest(host=host, port=port, scheme=scheme, path=path, method=method)
             try:
-                verifier = get_verifier_or_raise("http:request")
+                verifier = get_verifier_or_raise("http:request", firewall_request=fw_request)
             except GuardPassThrough:
                 original_opener = HttpPlugin._original_urllib_opener
                 urllib.request.install_opener(original_opener)
@@ -698,8 +716,11 @@ class HttpPlugin(BasePlugin):
             str_or_url: Any,  # noqa: ANN401
             **kwargs: Any,  # noqa: ANN401
         ) -> Any:  # noqa: ANN401
+            url = str(str_or_url)
+            scheme, host, port, path = normalize_url(url)
+            fw_request = HttpFirewallRequest(host=host, port=port, scheme=scheme, path=path, method=method)
             try:
-                verifier = get_verifier_or_raise("http:request")
+                verifier = get_verifier_or_raise("http:request", firewall_request=fw_request)
             except GuardPassThrough:
                 return await _orig_aiohttp(
                     session_self, method, str_or_url, **kwargs,
@@ -1273,8 +1294,12 @@ class HttpPlugin(BasePlugin):
         def _bigfoot_urllib_dispatch_ref(
             req: urllib.request.Request,
         ) -> urllib.response.addinfourl:
+            url = req.full_url
+            method = (req.get_method() or "GET").upper()
+            scheme, host, port, path = normalize_url(url)
+            fw_request = HttpFirewallRequest(host=host, port=port, scheme=scheme, path=path, method=method)
             try:
-                verifier = get_verifier_or_raise("http:request")
+                verifier = get_verifier_or_raise("http:request", firewall_request=fw_request)
             except GuardPassThrough:
                 original_opener = HttpPlugin._original_urllib_opener
                 urllib.request.install_opener(original_opener)

--- a/src/bigfoot/plugins/mcp_plugin.py
+++ b/src/bigfoot/plugins/mcp_plugin.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from bigfoot._base_plugin import BasePlugin
-from bigfoot._context import GuardPassThrough, _guard_allowlist, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import UnmockedInteractionError
 from bigfoot._timeline import Interaction
 
@@ -97,9 +97,6 @@ async def _patched_call_tool(
 ) -> Any:  # noqa: ANN401
     _original = McpPlugin._original_call_tool
     assert _original is not None
-    # Check allowlist FIRST - bypasses both guard and sandbox
-    if "mcp" in _guard_allowlist.get():
-        return await _original(self, name, arguments, *args, **kwargs)
     try:
         plugin = _get_mcp_plugin()
     except GuardPassThrough:
@@ -151,9 +148,6 @@ async def _patched_read_resource(
 ) -> Any:  # noqa: ANN401
     _original = McpPlugin._original_read_resource
     assert _original is not None
-    # Check allowlist FIRST - bypasses both guard and sandbox
-    if "mcp" in _guard_allowlist.get():
-        return await _original(self, uri, *args, **kwargs)
     try:
         plugin = _get_mcp_plugin()
     except GuardPassThrough:
@@ -205,9 +199,6 @@ async def _patched_get_prompt(
 ) -> Any:  # noqa: ANN401
     _original = McpPlugin._original_get_prompt
     assert _original is not None
-    # Check allowlist FIRST - bypasses both guard and sandbox
-    if "mcp" in _guard_allowlist.get():
-        return await _original(self, name, arguments, *args, **kwargs)
     try:
         plugin = _get_mcp_plugin()
     except GuardPassThrough:
@@ -269,12 +260,6 @@ async def _patched_handle_request(
 
     _original = McpPlugin._original_handle_request
     assert _original is not None
-    # Check allowlist FIRST - bypasses both guard and sandbox
-    if "mcp" in _guard_allowlist.get():
-        await _original(
-            self, message, req, session, lifespan_context, raise_exceptions,
-        )
-        return
     try:
         plugin = _get_mcp_plugin()
     except GuardPassThrough:

--- a/src/bigfoot/plugins/mcp_plugin.py
+++ b/src/bigfoot/plugins/mcp_plugin.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 from bigfoot._base_plugin import BasePlugin
 from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import UnmockedInteractionError
+from bigfoot._firewall_request import McpFirewallRequest
 from bigfoot._timeline import Interaction
 
 if TYPE_CHECKING:
@@ -63,8 +64,10 @@ class McpMockConfig:
 # ---------------------------------------------------------------------------
 
 
-def _get_mcp_plugin() -> McpPlugin | None:
-    verifier = get_verifier_or_raise("mcp:client:call_tool")
+def _get_mcp_plugin(
+    firewall_request: McpFirewallRequest | None = None,
+) -> McpPlugin | None:
+    verifier = get_verifier_or_raise("mcp:client:call_tool", firewall_request=firewall_request)
     for plugin in verifier._plugins:
         if isinstance(plugin, McpPlugin):
             return plugin
@@ -97,8 +100,9 @@ async def _patched_call_tool(
 ) -> Any:  # noqa: ANN401
     _original = McpPlugin._original_call_tool
     assert _original is not None
+    fw_request = McpFirewallRequest(tool_name=name, uri="")
     try:
-        plugin = _get_mcp_plugin()
+        plugin = _get_mcp_plugin(firewall_request=fw_request)
     except GuardPassThrough:
         return await _original(self, name, arguments, *args, **kwargs)
     if plugin is None:
@@ -148,8 +152,9 @@ async def _patched_read_resource(
 ) -> Any:  # noqa: ANN401
     _original = McpPlugin._original_read_resource
     assert _original is not None
+    fw_request = McpFirewallRequest(tool_name="", uri=str(uri))
     try:
-        plugin = _get_mcp_plugin()
+        plugin = _get_mcp_plugin(firewall_request=fw_request)
     except GuardPassThrough:
         return await _original(self, uri, *args, **kwargs)
     if plugin is None:
@@ -199,8 +204,9 @@ async def _patched_get_prompt(
 ) -> Any:  # noqa: ANN401
     _original = McpPlugin._original_get_prompt
     assert _original is not None
+    fw_request = McpFirewallRequest(tool_name="", uri=name)
     try:
-        plugin = _get_mcp_plugin()
+        plugin = _get_mcp_plugin(firewall_request=fw_request)
     except GuardPassThrough:
         return await _original(self, name, arguments, *args, **kwargs)
     if plugin is None:
@@ -260,8 +266,10 @@ async def _patched_handle_request(
 
     _original = McpPlugin._original_handle_request
     assert _original is not None
+    # Server-side: construct a generic firewall request (specific tool/uri not yet known)
+    fw_request = McpFirewallRequest(tool_name="", uri="")
     try:
-        plugin = _get_mcp_plugin()
+        plugin = _get_mcp_plugin(firewall_request=fw_request)
     except GuardPassThrough:
         await _original(
             self, message, req, session, lifespan_context, raise_exceptions,

--- a/src/bigfoot/plugins/memcache_plugin.py
+++ b/src/bigfoot/plugins/memcache_plugin.py
@@ -248,7 +248,7 @@ class MemcachePlugin(BasePlugin):
                     host, port = str(server), 11211
                 _memcache_conn_meta[self_] = (normalize_host(host), port)
 
-            Client.__init__ = _patched_init  # type: ignore[method-assign]
+            Client.__init__ = _patched_init
 
         for method_name in _ALL_INTERCEPTED:
             MemcachePlugin._originals[method_name] = getattr(Client, method_name, None)
@@ -263,7 +263,7 @@ class MemcachePlugin(BasePlugin):
                 setattr(Client, method_name, original)
         MemcachePlugin._originals = {k: None for k in MemcachePlugin._originals}
         if MemcachePlugin._original_init is not None:
-            Client.__init__ = MemcachePlugin._original_init  # type: ignore[method-assign]
+            Client.__init__ = MemcachePlugin._original_init
             MemcachePlugin._original_init = None
 
     # ------------------------------------------------------------------

--- a/src/bigfoot/plugins/memcache_plugin.py
+++ b/src/bigfoot/plugins/memcache_plugin.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from bigfoot._base_plugin import BasePlugin
-from bigfoot._context import GuardPassThrough, _guard_allowlist, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import UnmockedInteractionError
 from bigfoot._timeline import Interaction
 
@@ -107,11 +107,6 @@ def _make_patched_method(method_name: str) -> Any:  # noqa: ANN401
     cmd_upper = method_name.upper()
 
     def _patched(client_self: Any, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
-        # Check allowlist FIRST - bypasses both guard and sandbox
-        if "memcache" in _guard_allowlist.get():
-            original = MemcachePlugin._originals.get(method_name)
-            if original is not None:
-                return original(client_self, *args, **kwargs)
         try:
             plugin = _get_memcache_plugin()
         except GuardPassThrough:

--- a/src/bigfoot/plugins/memcache_plugin.py
+++ b/src/bigfoot/plugins/memcache_plugin.py
@@ -10,10 +10,13 @@ import traceback
 from collections import deque
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, cast
+from weakref import WeakKeyDictionary
 
 from bigfoot._base_plugin import BasePlugin
 from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import UnmockedInteractionError
+from bigfoot._firewall_request import MemcacheFirewallRequest
+from bigfoot._normalize import normalize_host
 from bigfoot._timeline import Interaction
 
 if TYPE_CHECKING:
@@ -29,6 +32,9 @@ try:
     _PYMEMCACHE_AVAILABLE = True
 except ImportError:  # pragma: no cover
     _PYMEMCACHE_AVAILABLE = False
+
+# Connection metadata: maps Client instance -> (host, port)
+_memcache_conn_meta: WeakKeyDictionary[object, tuple[str, int]] = WeakKeyDictionary()
 
 
 # ---------------------------------------------------------------------------
@@ -52,8 +58,10 @@ class MemcacheMockConfig:
 # ---------------------------------------------------------------------------
 
 
-def _get_memcache_plugin() -> MemcachePlugin | None:
-    verifier = get_verifier_or_raise("memcache:command")
+def _get_memcache_plugin(
+    firewall_request: MemcacheFirewallRequest | None = None,
+) -> MemcachePlugin | None:
+    verifier = get_verifier_or_raise("memcache:command", firewall_request=firewall_request)
     for plugin in verifier._plugins:
         if isinstance(plugin, MemcachePlugin):
             return plugin
@@ -107,8 +115,10 @@ def _make_patched_method(method_name: str) -> Any:  # noqa: ANN401
     cmd_upper = method_name.upper()
 
     def _patched(client_self: Any, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        host, port = _memcache_conn_meta.get(client_self, ("unknown", 0))
+        fw_request = MemcacheFirewallRequest(host=host, port=port, command=cmd_upper)
         try:
-            plugin = _get_memcache_plugin()
+            plugin = _get_memcache_plugin(firewall_request=fw_request)
         except GuardPassThrough:
             original = MemcachePlugin._originals.get(method_name)
             if original is not None:
@@ -181,6 +191,7 @@ class MemcachePlugin(BasePlugin):
     """
 
     _originals: ClassVar[dict[str, Any]] = {m: None for m in _ALL_INTERCEPTED}
+    _original_init: ClassVar[Any] = None
 
     def __init__(self, verifier: StrictVerifier) -> None:
         super().__init__(verifier)
@@ -224,6 +235,21 @@ class MemcachePlugin(BasePlugin):
             )
         from pymemcache.client.base import Client
 
+        # Patch __init__ to capture connection metadata
+        if MemcachePlugin._original_init is None:
+            MemcachePlugin._original_init = Client.__init__
+
+            def _patched_init(self_: object, server: Any, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
+                assert MemcachePlugin._original_init is not None
+                MemcachePlugin._original_init(self_, server, *args, **kwargs)
+                if isinstance(server, tuple):
+                    host, port = str(server[0]), int(server[1]) if len(server) > 1 else 11211
+                else:
+                    host, port = str(server), 11211
+                _memcache_conn_meta[self_] = (normalize_host(host), port)
+
+            Client.__init__ = _patched_init  # type: ignore[method-assign]
+
         for method_name in _ALL_INTERCEPTED:
             MemcachePlugin._originals[method_name] = getattr(Client, method_name, None)
             setattr(Client, method_name, _make_patched_method(method_name))
@@ -236,6 +262,9 @@ class MemcachePlugin(BasePlugin):
             if original is not None:
                 setattr(Client, method_name, original)
         MemcachePlugin._originals = {k: None for k in MemcachePlugin._originals}
+        if MemcachePlugin._original_init is not None:
+            Client.__init__ = MemcachePlugin._original_init  # type: ignore[method-assign]
+            MemcachePlugin._original_init = None
 
     # ------------------------------------------------------------------
     # BasePlugin abstract method implementations

--- a/src/bigfoot/plugins/mongo_plugin.py
+++ b/src/bigfoot/plugins/mongo_plugin.py
@@ -169,11 +169,20 @@ def _make_patched_method(operation: str) -> Any:  # noqa: ANN401
     def _patched(collection_self: Any, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
         # Navigate from Collection -> Database -> MongoClient for connection metadata
         client = getattr(getattr(collection_self, "database", None), "client", None)
-        host, port = _mongo_conn_meta.get(client, ("unknown", 0)) if client is not None else ("unknown", 0)
-        database = getattr(collection_self.database, "name", "") if hasattr(collection_self, "database") else ""
+        host, port = (
+            _mongo_conn_meta.get(client, ("unknown", 0))
+            if client is not None
+            else ("unknown", 0)
+        )
+        database = (
+            getattr(collection_self.database, "name", "")
+            if hasattr(collection_self, "database")
+            else ""
+        )
         collection_name = getattr(collection_self, "name", "")
         fw_request = MongoFirewallRequest(
-            host=host, port=port, database=database, collection=collection_name, operation=operation,
+            host=host, port=port, database=database,
+            collection=collection_name, operation=operation,
         )
         try:
             plugin = _get_mongo_plugin(firewall_request=fw_request)
@@ -305,15 +314,18 @@ class MongoPlugin(BasePlugin):
         if MongoPlugin._original_client_init is None:
             MongoPlugin._original_client_init = pymongo.MongoClient.__init__
 
-            def _patched_client_init(self_: object, *args: Any, **kwargs: Any) -> None:
+            def _patched_client_init(self_: object, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
                 assert MongoPlugin._original_client_init is not None
                 MongoPlugin._original_client_init(self_, *args, **kwargs)
                 host_arg = args[0] if args else kwargs.get("host", "localhost")
                 port_arg = kwargs.get("port") or (args[1] if len(args) > 1 else 27017)
                 host = "localhost"
                 port = int(port_arg)
+                if isinstance(host_arg, list):
+                    # pymongo accepts a list of host strings; use the first.
+                    host_arg = host_arg[0] if host_arg else "localhost"
                 if isinstance(host_arg, str):
-                    if host_arg.startswith("mongodb://") or host_arg.startswith("mongodb+srv://"):
+                    if host_arg.startswith(("mongodb://", "mongodb+srv://")):
                         from urllib.parse import urlparse  # noqa: PLC0415
                         parsed = urlparse(host_arg)
                         host = parsed.hostname or "localhost"

--- a/src/bigfoot/plugins/mongo_plugin.py
+++ b/src/bigfoot/plugins/mongo_plugin.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from bigfoot._base_plugin import BasePlugin
-from bigfoot._context import GuardPassThrough, _guard_allowlist, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import UnmockedInteractionError
 from bigfoot._timeline import Interaction
 
@@ -159,11 +159,6 @@ def _make_patched_method(operation: str) -> Any:  # noqa: ANN401
     """Create a patched method for a specific MongoDB collection operation."""
 
     def _patched(collection_self: Any, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
-        # Check allowlist FIRST - bypasses both guard and sandbox
-        if "mongo" in _guard_allowlist.get():
-            original = MongoPlugin._original_methods
-            if original is not None and operation in original:
-                return original[operation](collection_self, *args, **kwargs)
         try:
             plugin = _get_mongo_plugin()
         except GuardPassThrough:

--- a/src/bigfoot/plugins/mongo_plugin.py
+++ b/src/bigfoot/plugins/mongo_plugin.py
@@ -335,7 +335,7 @@ class MongoPlugin(BasePlugin):
                         host = host_arg
                 _mongo_conn_meta[self_] = (normalize_host(host), port)
 
-            pymongo.MongoClient.__init__ = _patched_client_init  # type: ignore[method-assign]
+            pymongo.MongoClient.__init__ = _patched_client_init  # type: ignore[assignment,method-assign]
 
         MongoPlugin._original_methods = {}
         for op in MongoPlugin._INTERCEPTED_OPERATIONS:

--- a/src/bigfoot/plugins/mongo_plugin.py
+++ b/src/bigfoot/plugins/mongo_plugin.py
@@ -7,10 +7,13 @@ import traceback
 from collections import deque
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, cast
+from weakref import WeakKeyDictionary
 
 from bigfoot._base_plugin import BasePlugin
 from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import UnmockedInteractionError
+from bigfoot._firewall_request import MongoFirewallRequest
+from bigfoot._normalize import normalize_host
 from bigfoot._timeline import Interaction
 
 if TYPE_CHECKING:
@@ -27,6 +30,9 @@ try:
     _PYMONGO_AVAILABLE = True
 except ImportError:  # pragma: no cover
     _PYMONGO_AVAILABLE = False
+
+# Connection metadata: maps MongoClient instance -> (host, port)
+_mongo_conn_meta: WeakKeyDictionary[object, tuple[str, int]] = WeakKeyDictionary()
 
 
 # ---------------------------------------------------------------------------
@@ -59,8 +65,10 @@ class MongoMockConfig:
 # ---------------------------------------------------------------------------
 
 
-def _get_mongo_plugin() -> MongoPlugin | None:
-    verifier = get_verifier_or_raise("mongo:operation")
+def _get_mongo_plugin(
+    firewall_request: MongoFirewallRequest | None = None,
+) -> MongoPlugin | None:
+    verifier = get_verifier_or_raise("mongo:operation", firewall_request=firewall_request)
     for plugin in verifier._plugins:
         if isinstance(plugin, MongoPlugin):
             return plugin
@@ -159,8 +167,16 @@ def _make_patched_method(operation: str) -> Any:  # noqa: ANN401
     """Create a patched method for a specific MongoDB collection operation."""
 
     def _patched(collection_self: Any, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        # Navigate from Collection -> Database -> MongoClient for connection metadata
+        client = getattr(getattr(collection_self, "database", None), "client", None)
+        host, port = _mongo_conn_meta.get(client, ("unknown", 0)) if client is not None else ("unknown", 0)
+        database = getattr(collection_self.database, "name", "") if hasattr(collection_self, "database") else ""
+        collection_name = getattr(collection_self, "name", "")
+        fw_request = MongoFirewallRequest(
+            host=host, port=port, database=database, collection=collection_name, operation=operation,
+        )
         try:
-            plugin = _get_mongo_plugin()
+            plugin = _get_mongo_plugin(firewall_request=fw_request)
         except GuardPassThrough:
             original = MongoPlugin._original_methods
             if original is not None and operation in original:
@@ -221,6 +237,7 @@ class MongoPlugin(BasePlugin):
 
     # Saved originals, restored when count reaches 0.
     _original_methods: ClassVar[dict[str, Any] | None] = None
+    _original_client_init: ClassVar[Any] = None
 
     # Operations to intercept
     _INTERCEPTED_OPERATIONS: ClassVar[tuple[str, ...]] = (
@@ -283,6 +300,31 @@ class MongoPlugin(BasePlugin):
             raise ImportError(
                 "Install bigfoot[mongo] to use MongoPlugin: pip install bigfoot[mongo]"
             )
+
+        # Patch MongoClient.__init__ to capture connection metadata
+        if MongoPlugin._original_client_init is None:
+            MongoPlugin._original_client_init = pymongo.MongoClient.__init__
+
+            def _patched_client_init(self_: object, *args: Any, **kwargs: Any) -> None:
+                assert MongoPlugin._original_client_init is not None
+                MongoPlugin._original_client_init(self_, *args, **kwargs)
+                host_arg = args[0] if args else kwargs.get("host", "localhost")
+                port_arg = kwargs.get("port") or (args[1] if len(args) > 1 else 27017)
+                host = "localhost"
+                port = int(port_arg)
+                if isinstance(host_arg, str):
+                    if host_arg.startswith("mongodb://") or host_arg.startswith("mongodb+srv://"):
+                        from urllib.parse import urlparse  # noqa: PLC0415
+                        parsed = urlparse(host_arg)
+                        host = parsed.hostname or "localhost"
+                        if parsed.port:
+                            port = parsed.port
+                    else:
+                        host = host_arg
+                _mongo_conn_meta[self_] = (normalize_host(host), port)
+
+            pymongo.MongoClient.__init__ = _patched_client_init  # type: ignore[method-assign]
+
         MongoPlugin._original_methods = {}
         for op in MongoPlugin._INTERCEPTED_OPERATIONS:
             MongoPlugin._original_methods[op] = getattr(
@@ -300,6 +342,9 @@ class MongoPlugin(BasePlugin):
             for method_name, original in MongoPlugin._original_methods.items():
                 setattr(pymongo.collection.Collection, method_name, original)
             MongoPlugin._original_methods = None
+        if MongoPlugin._original_client_init is not None:
+            pymongo.MongoClient.__init__ = MongoPlugin._original_client_init  # type: ignore[method-assign]
+            MongoPlugin._original_client_init = None
 
     # ------------------------------------------------------------------
     # BasePlugin abstract method implementations

--- a/src/bigfoot/plugins/pika_plugin.py
+++ b/src/bigfoot/plugins/pika_plugin.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from bigfoot._context import GuardPassThrough, _guard_allowlist, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._state_machine_plugin import StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
 
@@ -131,9 +131,6 @@ class _FakeBlockingConnection:
     """Fake pika.BlockingConnection that routes all operations through PikaPlugin."""
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
-        # Check allowlist FIRST - bypasses both guard and sandbox
-        if "pika" in _guard_allowlist.get():
-            return _ORIGINAL_BLOCKING_CONNECTION(*args, **kwargs)
         try:
             _find_pika_plugin()
         except GuardPassThrough:

--- a/src/bigfoot/plugins/pika_plugin.py
+++ b/src/bigfoot/plugins/pika_plugin.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from bigfoot._context import GuardPassThrough, get_verifier_or_raise
+from bigfoot._firewall_request import PikaFirewallRequest
 from bigfoot._state_machine_plugin import StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
 
@@ -45,8 +46,10 @@ _SOURCE_CLOSE = "pika:close"
 # ---------------------------------------------------------------------------
 
 
-def _find_pika_plugin() -> PikaPlugin:
-    verifier = get_verifier_or_raise("pika:connect")
+def _find_pika_plugin(
+    firewall_request: PikaFirewallRequest | None = None,
+) -> PikaPlugin:
+    verifier = get_verifier_or_raise("pika:connect", firewall_request=firewall_request)
     for plugin in verifier._plugins:
         if isinstance(plugin, PikaPlugin):
             return plugin
@@ -131,17 +134,27 @@ class _FakeBlockingConnection:
     """Fake pika.BlockingConnection that routes all operations through PikaPlugin."""
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        # Extract connection parameters for firewall request
+        parameters = args[0] if args else kwargs.get("parameters")
+        if parameters is not None and hasattr(parameters, "host"):
+            _host = parameters.host
+            _port = parameters.port
+            _vhost = parameters.virtual_host
+        else:
+            _host = "localhost"
+            _port = 5672
+            _vhost = "/"
+        _fw = PikaFirewallRequest(
+            host=_host, port=_port, virtual_host=_vhost,
+            exchange="", routing_key="",
+        )
         try:
-            _find_pika_plugin()
+            _find_pika_plugin(firewall_request=_fw)
         except GuardPassThrough:
             return _ORIGINAL_BLOCKING_CONNECTION(*args, **kwargs)
         return super().__new__(cls)
 
     def __init__(self, parameters: Any = None, **kwargs: Any) -> None:  # noqa: ANN401
-        plugin = _find_pika_plugin()
-        plugin._bind_connection(self)
-        handle = plugin._lookup_session(self)
-
         # Extract connection parameters
         if parameters is not None and hasattr(parameters, "host"):
             host = parameters.host
@@ -151,6 +164,14 @@ class _FakeBlockingConnection:
             host = "localhost"
             port = 5672
             virtual_host = "/"
+
+        fw_request = PikaFirewallRequest(
+            host=host, port=port, virtual_host=virtual_host,
+            exchange="", routing_key="",
+        )
+        plugin = _find_pika_plugin(firewall_request=fw_request)
+        plugin._bind_connection(self)
+        handle = plugin._lookup_session(self)
 
         plugin._execute_step(
             handle, "connect", (), {}, _SOURCE_CONNECT,

--- a/src/bigfoot/plugins/popen_plugin.py
+++ b/src/bigfoot/plugins/popen_plugin.py
@@ -12,7 +12,7 @@ restore their respective targets correctly when deactivated.
 import subprocess
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from bigfoot._context import GuardPassThrough, _guard_allowlist, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import ConflictError
 from bigfoot._state_machine_plugin import StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
@@ -99,9 +99,6 @@ class _FakePopen:
         *pos_args: Any,  # noqa: ANN401
         **kwargs: Any,  # noqa: ANN401
     ) -> Any:  # noqa: ANN401
-        # Check allowlist FIRST - bypasses both guard and sandbox
-        if "subprocess" in _guard_allowlist.get() or "popen" in _guard_allowlist.get():
-            return _ORIGINAL_POPEN(args, *pos_args, **kwargs)
         try:
             _find_popen_plugin()
         except GuardPassThrough:

--- a/src/bigfoot/plugins/popen_plugin.py
+++ b/src/bigfoot/plugins/popen_plugin.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import ConflictError
+from bigfoot._firewall_request import SubprocessFirewallRequest
 from bigfoot._state_machine_plugin import StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
 
@@ -48,8 +49,10 @@ _bigfoot_popen_class: Any = None
 # ---------------------------------------------------------------------------
 
 
-def _find_popen_plugin() -> "PopenPlugin":
-    verifier = get_verifier_or_raise(_SOURCE_SPAWN)
+def _find_popen_plugin(
+    firewall_request: SubprocessFirewallRequest | None = None,
+) -> "PopenPlugin":
+    verifier = get_verifier_or_raise(_SOURCE_SPAWN, firewall_request=firewall_request)
     try:
         return next(p for p in verifier._plugins if isinstance(p, PopenPlugin))
     except StopIteration:
@@ -100,7 +103,15 @@ class _FakePopen:
         **kwargs: Any,  # noqa: ANN401
     ) -> Any:  # noqa: ANN401
         try:
-            _find_popen_plugin()
+            if hasattr(args, "__iter__") and not isinstance(args, str):
+                cmd_list = list(args)
+                binary = str(cmd_list[0]) if cmd_list else ""
+                command_str = " ".join(str(c) for c in cmd_list)
+            else:
+                binary = str(args).split()[0] if args else ""
+                command_str = str(args)
+            fw_request = SubprocessFirewallRequest(command=command_str, binary=binary)
+            _find_popen_plugin(firewall_request=fw_request)
         except GuardPassThrough:
             return _ORIGINAL_POPEN(args, *pos_args, **kwargs)
         return super().__new__(cls)

--- a/src/bigfoot/plugins/psycopg2_plugin.py
+++ b/src/bigfoot/plugins/psycopg2_plugin.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 try:
-    import psycopg2
+    import psycopg2  # type: ignore[import-untyped]
 
     _PSYCOPG2_AVAILABLE = True
 except ImportError:  # pragma: no cover

--- a/src/bigfoot/plugins/psycopg2_plugin.py
+++ b/src/bigfoot/plugins/psycopg2_plugin.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
-from bigfoot._context import GuardPassThrough, _guard_allowlist, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._state_machine_plugin import SessionHandle, StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
 
@@ -163,9 +163,6 @@ def _patched_psycopg2_connect(
 ) -> _FakePsycopg2Connection:
     _original = Psycopg2Plugin._original_connect
     assert _original is not None
-    # Check allowlist FIRST - bypasses both guard and sandbox
-    if "psycopg2" in _guard_allowlist.get():
-        return cast(_FakePsycopg2Connection, _original(dsn, **kwargs))
     try:
         plugin = _get_psycopg2_plugin()
     except GuardPassThrough:

--- a/src/bigfoot/plugins/psycopg2_plugin.py
+++ b/src/bigfoot/plugins/psycopg2_plugin.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 try:
-    import psycopg2  # type: ignore[import-untyped]
+    import psycopg2
 
     _PSYCOPG2_AVAILABLE = True
 except ImportError:  # pragma: no cover
@@ -168,7 +168,7 @@ def _patched_psycopg2_connect(
     assert _original is not None
     # Parse connection parameters for firewall request
     host = str(kwargs.get("host", ""))
-    port = int(kwargs.get("port", 0)) if "port" in kwargs else 0
+    port = int(kwargs.get("port", 0)) if "port" in kwargs else 0  # type: ignore[call-overload]
     dbname = str(kwargs.get("dbname", ""))
     fw_request = PostgresFirewallRequest(protocol="psycopg2", host=host, port=port, dbname=dbname)
     try:

--- a/src/bigfoot/plugins/psycopg2_plugin.py
+++ b/src/bigfoot/plugins/psycopg2_plugin.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from bigfoot._context import GuardPassThrough, get_verifier_or_raise
+from bigfoot._firewall_request import PostgresFirewallRequest
 from bigfoot._state_machine_plugin import SessionHandle, StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
 
@@ -37,8 +38,10 @@ _SOURCE_CLOSE = "psycopg2:close"
 # ---------------------------------------------------------------------------
 
 
-def _get_psycopg2_plugin() -> "Psycopg2Plugin":
-    verifier = get_verifier_or_raise(_SOURCE_CONNECT)
+def _get_psycopg2_plugin(
+    firewall_request: PostgresFirewallRequest | None = None,
+) -> "Psycopg2Plugin":
+    verifier = get_verifier_or_raise(_SOURCE_CONNECT, firewall_request=firewall_request)
     for plugin in verifier._plugins:
         if isinstance(plugin, Psycopg2Plugin):
             return plugin
@@ -163,8 +166,13 @@ def _patched_psycopg2_connect(
 ) -> _FakePsycopg2Connection:
     _original = Psycopg2Plugin._original_connect
     assert _original is not None
+    # Parse connection parameters for firewall request
+    host = str(kwargs.get("host", ""))
+    port = int(kwargs.get("port", 0)) if "port" in kwargs else 0
+    dbname = str(kwargs.get("dbname", ""))
+    fw_request = PostgresFirewallRequest(protocol="psycopg2", host=host, port=port, dbname=dbname)
     try:
-        plugin = _get_psycopg2_plugin()
+        plugin = _get_psycopg2_plugin(firewall_request=fw_request)
     except GuardPassThrough:
         return cast(_FakePsycopg2Connection, _original(dsn, **kwargs))
     fake_conn = _FakePsycopg2Connection(plugin)

--- a/src/bigfoot/plugins/redis_plugin.py
+++ b/src/bigfoot/plugins/redis_plugin.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from bigfoot._base_plugin import BasePlugin
-from bigfoot._context import GuardPassThrough, _guard_allowlist, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import UnmockedInteractionError
 from bigfoot._timeline import Interaction
 
@@ -88,9 +88,6 @@ class _RedisSentinel:
 def _patched_execute_command(redis_self: object, command: str, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
     _original = RedisPlugin._original_execute_command
     assert _original is not None
-    # Check allowlist FIRST - bypasses both guard and sandbox
-    if "redis" in _guard_allowlist.get():
-        return _original(redis_self, command, *args, **kwargs)
     try:
         plugin = _get_redis_plugin()
     except GuardPassThrough:

--- a/src/bigfoot/plugins/redis_plugin.py
+++ b/src/bigfoot/plugins/redis_plugin.py
@@ -206,7 +206,7 @@ class RedisPlugin(BasePlugin):
         if RedisPlugin._original_init is None:
             RedisPlugin._original_init = redis_lib.Redis.__init__
 
-            def _patched_init(self_: object, *args: Any, **kwargs: Any) -> None:
+            def _patched_init(self_: object, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
                 assert RedisPlugin._original_init is not None
                 RedisPlugin._original_init(self_, *args, **kwargs)
                 host = kwargs.get("host") or (args[0] if args else "localhost")

--- a/src/bigfoot/plugins/redis_plugin.py
+++ b/src/bigfoot/plugins/redis_plugin.py
@@ -214,7 +214,7 @@ class RedisPlugin(BasePlugin):
                 db = kwargs.get("db") or (args[2] if len(args) > 2 else 0)
                 _redis_conn_meta[self_] = (normalize_host(str(host)), int(port), int(db))
 
-            redis_lib.Redis.__init__ = _patched_init  # type: ignore[method-assign]
+            redis_lib.Redis.__init__ = _patched_init  # type: ignore[assignment,method-assign]
 
         RedisPlugin._original_execute_command = redis_lib.Redis.execute_command
         setattr(redis_lib.Redis, "execute_command", _patched_execute_command)

--- a/src/bigfoot/plugins/redis_plugin.py
+++ b/src/bigfoot/plugins/redis_plugin.py
@@ -8,10 +8,13 @@ from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, cast
+from weakref import WeakKeyDictionary
 
 from bigfoot._base_plugin import BasePlugin
 from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import UnmockedInteractionError
+from bigfoot._firewall_request import RedisFirewallRequest
+from bigfoot._normalize import normalize_host
 from bigfoot._timeline import Interaction
 
 if TYPE_CHECKING:
@@ -27,6 +30,9 @@ try:
     _REDIS_AVAILABLE = True
 except ImportError:  # pragma: no cover
     _REDIS_AVAILABLE = False
+
+# Connection metadata: maps Redis client instance -> (host, port, db)
+_redis_conn_meta: WeakKeyDictionary[object, tuple[str, int, int]] = WeakKeyDictionary()
 
 
 # ---------------------------------------------------------------------------
@@ -60,8 +66,10 @@ class RedisMockConfig:
 # ---------------------------------------------------------------------------
 
 
-def _get_redis_plugin() -> RedisPlugin | None:
-    verifier = get_verifier_or_raise("redis:execute_command")
+def _get_redis_plugin(
+    firewall_request: RedisFirewallRequest | None = None,
+) -> RedisPlugin | None:
+    verifier = get_verifier_or_raise("redis:execute_command", firewall_request=firewall_request)
     for plugin in verifier._plugins:
         if isinstance(plugin, RedisPlugin):
             return plugin
@@ -88,13 +96,15 @@ class _RedisSentinel:
 def _patched_execute_command(redis_self: object, command: str, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
     _original = RedisPlugin._original_execute_command
     assert _original is not None
+    host, port, db = _redis_conn_meta.get(redis_self, ("unknown", 0, 0))
+    cmd_upper = command.upper() if isinstance(command, str) else str(command)
+    fw_request = RedisFirewallRequest(host=host, port=port, db=db, command=cmd_upper)
     try:
-        plugin = _get_redis_plugin()
+        plugin = _get_redis_plugin(firewall_request=fw_request)
     except GuardPassThrough:
         return _original(redis_self, command, *args, **kwargs)
     if plugin is None:
         return _original(redis_self, command, *args, **kwargs)
-    cmd_upper = command.upper()
     with plugin._registry_lock:
         queue = plugin._queues.get(cmd_upper)
         if not queue:
@@ -141,8 +151,9 @@ class RedisPlugin(BasePlugin):
     objects. Calls are stateless -- there are no state transitions.
     """
 
-    # Saved original, restored when count reaches 0.
+    # Saved originals, restored when count reaches 0.
     _original_execute_command: ClassVar[Callable[..., Any] | None] = None
+    _original_init: ClassVar[Callable[..., Any] | None] = None
 
     def __init__(self, verifier: StrictVerifier) -> None:
         super().__init__(verifier)
@@ -191,6 +202,20 @@ class RedisPlugin(BasePlugin):
             raise ImportError(
                 "Install bigfoot[redis] to use RedisPlugin: pip install bigfoot[redis]"
             )
+        # Patch __init__ to capture connection metadata
+        if RedisPlugin._original_init is None:
+            RedisPlugin._original_init = redis_lib.Redis.__init__
+
+            def _patched_init(self_: object, *args: Any, **kwargs: Any) -> None:
+                assert RedisPlugin._original_init is not None
+                RedisPlugin._original_init(self_, *args, **kwargs)
+                host = kwargs.get("host") or (args[0] if args else "localhost")
+                port = kwargs.get("port") or (args[1] if len(args) > 1 else 6379)
+                db = kwargs.get("db") or (args[2] if len(args) > 2 else 0)
+                _redis_conn_meta[self_] = (normalize_host(str(host)), int(port), int(db))
+
+            redis_lib.Redis.__init__ = _patched_init  # type: ignore[method-assign]
+
         RedisPlugin._original_execute_command = redis_lib.Redis.execute_command
         setattr(redis_lib.Redis, "execute_command", _patched_execute_command)
 
@@ -199,6 +224,9 @@ class RedisPlugin(BasePlugin):
         if RedisPlugin._original_execute_command is not None:
             setattr(redis_lib.Redis, "execute_command", RedisPlugin._original_execute_command)
             RedisPlugin._original_execute_command = None
+        if RedisPlugin._original_init is not None:
+            redis_lib.Redis.__init__ = RedisPlugin._original_init  # type: ignore[method-assign]
+            RedisPlugin._original_init = None
 
     # ------------------------------------------------------------------
     # BasePlugin abstract method implementations

--- a/src/bigfoot/plugins/smtp_plugin.py
+++ b/src/bigfoot/plugins/smtp_plugin.py
@@ -3,7 +3,7 @@
 import smtplib
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
-from bigfoot._context import GuardPassThrough, _guard_allowlist, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._state_machine_plugin import StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
 
@@ -54,9 +54,6 @@ class _FakeSMTP:
     """Fake smtplib.SMTP that routes all operations through SmtpPlugin."""
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
-        # Check allowlist FIRST - bypasses both guard and sandbox
-        if "smtp" in _guard_allowlist.get():
-            return _ORIGINAL_SMTP(*args, **kwargs)
         try:
             _find_smtp_plugin()
         except GuardPassThrough:

--- a/src/bigfoot/plugins/smtp_plugin.py
+++ b/src/bigfoot/plugins/smtp_plugin.py
@@ -57,8 +57,11 @@ class _FakeSMTP:
     """Fake smtplib.SMTP that routes all operations through SmtpPlugin."""
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        host = args[0] if args else kwargs.get("host", "")
+        port = args[1] if len(args) > 1 else kwargs.get("port", 0)
+        fw_request = SmtpFirewallRequest(host=host, port=port)
         try:
-            _find_smtp_plugin()
+            _find_smtp_plugin(firewall_request=fw_request)
         except GuardPassThrough:
             return _ORIGINAL_SMTP(*args, **kwargs)
         return super().__new__(cls)

--- a/src/bigfoot/plugins/smtp_plugin.py
+++ b/src/bigfoot/plugins/smtp_plugin.py
@@ -4,6 +4,7 @@ import smtplib
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from bigfoot._context import GuardPassThrough, get_verifier_or_raise
+from bigfoot._firewall_request import SmtpFirewallRequest
 from bigfoot._state_machine_plugin import StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
 
@@ -34,8 +35,10 @@ _SOURCE_QUIT = "smtp:quit"
 # ---------------------------------------------------------------------------
 
 
-def _find_smtp_plugin() -> "SmtpPlugin":
-    verifier = get_verifier_or_raise("smtp:connect")
+def _find_smtp_plugin(
+    firewall_request: SmtpFirewallRequest | None = None,
+) -> "SmtpPlugin":
+    verifier = get_verifier_or_raise("smtp:connect", firewall_request=firewall_request)
     for plugin in verifier._plugins:
         if isinstance(plugin, SmtpPlugin):
             return plugin
@@ -61,7 +64,8 @@ class _FakeSMTP:
         return super().__new__(cls)
 
     def __init__(self, host: str = "", port: int = 0, **kwargs: Any) -> None:  # noqa: ANN401
-        plugin = _find_smtp_plugin()
+        fw_request = SmtpFirewallRequest(host=host, port=port)
+        plugin = _find_smtp_plugin(firewall_request=fw_request)
         plugin._bind_connection(self)  # partial init
         handle = plugin._lookup_session(self)
         # ALWAYS execute connect step unconditionally (matches real smtplib.SMTP behavior)

--- a/src/bigfoot/plugins/socket_plugin.py
+++ b/src/bigfoot/plugins/socket_plugin.py
@@ -4,7 +4,7 @@ import socket
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
-from bigfoot._context import GuardPassThrough, _guard_allowlist, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._state_machine_plugin import StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
 
@@ -129,9 +129,6 @@ class SocketPlugin(StateMachinePlugin):
         SocketPlugin._original_close = socket.socket.close
 
         def _patched_connect(sock_self: socket.socket, address: object) -> None:
-            # Check allowlist FIRST - bypasses both guard and sandbox
-            if "socket" in _guard_allowlist.get():
-                return cast(None, _SOCKET_CONNECT_ORIGINAL(sock_self, address))
             try:
                 plugin = _get_socket_plugin()
             except GuardPassThrough:
@@ -155,9 +152,6 @@ class SocketPlugin(StateMachinePlugin):
             data: bytes | bytearray | memoryview,
             flags: int = 0,
         ) -> int:
-            # Check allowlist FIRST - bypasses both guard and sandbox
-            if "socket" in _guard_allowlist.get():
-                return cast(int, _SOCKET_SEND_ORIGINAL(sock_self, data, flags))
             try:
                 plugin = _get_socket_plugin()
             except GuardPassThrough:
@@ -177,9 +171,6 @@ class SocketPlugin(StateMachinePlugin):
             data: bytes | bytearray | memoryview,
             flags: int = 0,
         ) -> None:
-            # Check allowlist FIRST - bypasses both guard and sandbox
-            if "socket" in _guard_allowlist.get():
-                return cast(None, _SOCKET_SENDALL_ORIGINAL(sock_self, data, flags))
             try:
                 plugin = _get_socket_plugin()
             except GuardPassThrough:
@@ -193,9 +184,6 @@ class SocketPlugin(StateMachinePlugin):
             )
 
         def _patched_recv(sock_self: socket.socket, bufsize: int, flags: int = 0) -> bytes:
-            # Check allowlist FIRST - bypasses both guard and sandbox
-            if "socket" in _guard_allowlist.get():
-                return cast(bytes, _SOCKET_RECV_ORIGINAL(sock_self, bufsize, flags))
             try:
                 plugin = _get_socket_plugin()
             except GuardPassThrough:
@@ -213,9 +201,6 @@ class SocketPlugin(StateMachinePlugin):
             return data
 
         def _patched_close(sock_self: socket.socket) -> None:
-            # Check allowlist FIRST - bypasses both guard and sandbox
-            if "socket" in _guard_allowlist.get():
-                return cast(None, _SOCKET_CLOSE_ORIGINAL(sock_self))
             try:
                 plugin = _get_socket_plugin()
             except GuardPassThrough:

--- a/src/bigfoot/plugins/socket_plugin.py
+++ b/src/bigfoot/plugins/socket_plugin.py
@@ -138,7 +138,11 @@ class SocketPlugin(StateMachinePlugin):
             else:
                 host = str(address)
                 port = 0
-            family_str = sock_self.family.name if hasattr(sock_self.family, "name") else str(sock_self.family)
+            family_str = (
+                sock_self.family.name
+                if hasattr(sock_self.family, "name")
+                else str(sock_self.family)
+            )
             fw_request = SocketFirewallRequest(host=host, port=port, family=family_str)
             try:
                 plugin = _get_socket_plugin(firewall_request=fw_request)

--- a/src/bigfoot/plugins/socket_plugin.py
+++ b/src/bigfoot/plugins/socket_plugin.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from bigfoot._context import GuardPassThrough, get_verifier_or_raise
+from bigfoot._firewall_request import SocketFirewallRequest
 from bigfoot._state_machine_plugin import StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
 
@@ -37,8 +38,10 @@ _SOCKET_CLOSE_ORIGINAL: Callable[..., Any] = socket.socket.close
 # ---------------------------------------------------------------------------
 
 
-def _get_socket_plugin() -> "SocketPlugin | None":
-    verifier = get_verifier_or_raise(_SOURCE_CONNECT)
+def _get_socket_plugin(
+    firewall_request: SocketFirewallRequest | None = None,
+) -> "SocketPlugin | None":
+    verifier = get_verifier_or_raise(_SOURCE_CONNECT, firewall_request=firewall_request)
     for plugin in verifier._plugins:
         if isinstance(plugin, SocketPlugin):
             return plugin
@@ -129,19 +132,21 @@ class SocketPlugin(StateMachinePlugin):
         SocketPlugin._original_close = socket.socket.close
 
         def _patched_connect(sock_self: socket.socket, address: object) -> None:
-            try:
-                plugin = _get_socket_plugin()
-            except GuardPassThrough:
-                return cast(None, _SOCKET_CONNECT_ORIGINAL(sock_self, address))
-            if plugin is None:
-                return cast(None, _SOCKET_CONNECT_ORIGINAL(sock_self, address))
-            handle = plugin._bind_connection(sock_self)
             if isinstance(address, tuple) and len(address) >= 2:
                 host = str(address[0])
                 port = int(address[1])
             else:
                 host = str(address)
                 port = 0
+            family_str = sock_self.family.name if hasattr(sock_self.family, "name") else str(sock_self.family)
+            fw_request = SocketFirewallRequest(host=host, port=port, family=family_str)
+            try:
+                plugin = _get_socket_plugin(firewall_request=fw_request)
+            except GuardPassThrough:
+                return cast(None, _SOCKET_CONNECT_ORIGINAL(sock_self, address))
+            if plugin is None:
+                return cast(None, _SOCKET_CONNECT_ORIGINAL(sock_self, address))
+            handle = plugin._bind_connection(sock_self)
             plugin._execute_step(
                 handle, "connect", (address,), {}, _SOURCE_CONNECT,
                 details={"host": host, "port": port},

--- a/src/bigfoot/plugins/ssh_plugin.py
+++ b/src/bigfoot/plugins/ssh_plugin.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from bigfoot._context import GuardPassThrough, _guard_allowlist, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._state_machine_plugin import StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
 
@@ -180,15 +180,8 @@ class _FakeSSHClient:
         key_filename: Any = None,  # noqa: ANN401
         **kwargs: Any,  # noqa: ANN401
     ) -> Any:  # noqa: ANN401
-        # Check allowlist FIRST - bypasses both guard and sandbox
         _orig_cls = SshPlugin._original_ssh_client
         assert _orig_cls is not None
-        if "ssh" in _guard_allowlist.get():
-            self._real_client = _orig_cls()
-            return self._real_client.connect(
-                hostname, port=port, username=username, password=password,
-                pkey=pkey, key_filename=key_filename, **kwargs,
-            )
         try:
             plugin = _find_ssh_plugin()
         except GuardPassThrough:

--- a/src/bigfoot/plugins/ssh_plugin.py
+++ b/src/bigfoot/plugins/ssh_plugin.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from bigfoot._context import GuardPassThrough, get_verifier_or_raise
+from bigfoot._firewall_request import SshFirewallRequest
 from bigfoot._state_machine_plugin import StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
 
@@ -48,8 +49,10 @@ _SOURCE_CLOSE = "ssh:close"
 # ---------------------------------------------------------------------------
 
 
-def _find_ssh_plugin() -> SshPlugin:
-    verifier = get_verifier_or_raise("ssh:connect")
+def _find_ssh_plugin(
+    firewall_request: SshFirewallRequest | None = None,
+) -> SshPlugin:
+    verifier = get_verifier_or_raise("ssh:connect", firewall_request=firewall_request)
     for plugin in verifier._plugins:
         if isinstance(plugin, SshPlugin):
             return plugin
@@ -182,8 +185,11 @@ class _FakeSSHClient:
     ) -> Any:  # noqa: ANN401
         _orig_cls = SshPlugin._original_ssh_client
         assert _orig_cls is not None
+        fw_request = SshFirewallRequest(
+            host=hostname, port=port, username=username or "",
+        )
         try:
-            plugin = _find_ssh_plugin()
+            plugin = _find_ssh_plugin(firewall_request=fw_request)
         except GuardPassThrough:
             self._real_client = _orig_cls()
             return self._real_client.connect(

--- a/src/bigfoot/plugins/subprocess.py
+++ b/src/bigfoot/plugins/subprocess.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from bigfoot._base_plugin import BasePlugin
-from bigfoot._context import GuardPassThrough, _guard_allowlist, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import ConflictError, UnmockedInteractionError
 from bigfoot._timeline import Interaction
 
@@ -294,9 +294,6 @@ class SubprocessPlugin(BasePlugin):
         _orig_which = SubprocessPlugin._original_shutil_which
 
         def _run_interceptor(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
-            # Check allowlist FIRST - bypasses both guard and sandbox
-            if "subprocess" in _guard_allowlist.get():
-                return _orig_run(*args, **kwargs)
             try:
                 verifier = get_verifier_or_raise(_SOURCE_RUN)
             except GuardPassThrough:
@@ -305,9 +302,6 @@ class SubprocessPlugin(BasePlugin):
             return plugin._handle_run(*args, **kwargs)
 
         def _which_interceptor(name: str, **kwargs: Any) -> str | None:  # noqa: ANN401
-            # Check allowlist FIRST - bypasses both guard and sandbox
-            if "subprocess" in _guard_allowlist.get():
-                return _orig_which(name, **kwargs)
             try:
                 verifier = get_verifier_or_raise(_SOURCE_WHICH)
             except GuardPassThrough:

--- a/src/bigfoot/plugins/subprocess.py
+++ b/src/bigfoot/plugins/subprocess.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 from bigfoot._base_plugin import BasePlugin
 from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import ConflictError, UnmockedInteractionError
+from bigfoot._firewall_request import SubprocessFirewallRequest
 from bigfoot._timeline import Interaction
 
 if TYPE_CHECKING:
@@ -295,7 +296,16 @@ class SubprocessPlugin(BasePlugin):
 
         def _run_interceptor(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
             try:
-                verifier = get_verifier_or_raise(_SOURCE_RUN)
+                cmd = args[0] if args else kwargs.get("args", [])
+                if isinstance(cmd, str):
+                    binary = cmd.split()[0] if cmd else ""
+                    command_str = cmd
+                else:
+                    cmd_list = list(cmd)
+                    binary = cmd_list[0] if cmd_list else ""
+                    command_str = " ".join(str(c) for c in cmd_list)
+                fw_request = SubprocessFirewallRequest(command=command_str, binary=binary)
+                verifier = get_verifier_or_raise(_SOURCE_RUN, firewall_request=fw_request)
             except GuardPassThrough:
                 return _orig_run(*args, **kwargs)
             plugin = _find_subprocess_plugin(verifier)
@@ -303,7 +313,8 @@ class SubprocessPlugin(BasePlugin):
 
         def _which_interceptor(name: str, **kwargs: Any) -> str | None:  # noqa: ANN401
             try:
-                verifier = get_verifier_or_raise(_SOURCE_WHICH)
+                fw_request = SubprocessFirewallRequest(command=name, binary=name)
+                verifier = get_verifier_or_raise(_SOURCE_WHICH, firewall_request=fw_request)
             except GuardPassThrough:
                 return _orig_which(name, **kwargs)
             plugin = _find_subprocess_plugin(verifier)

--- a/src/bigfoot/plugins/websocket_plugin.py
+++ b/src/bigfoot/plugins/websocket_plugin.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
-from bigfoot._context import GuardPassThrough, _guard_allowlist, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import UnmockedInteractionError
 from bigfoot._state_machine_plugin import SessionHandle, StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
@@ -226,9 +226,6 @@ class AsyncWebSocketPlugin(StateMachinePlugin):
         _orig_connect = _ws.connect
 
         def _patched_websockets_connect(*args: Any, **kwargs: Any) -> _FakeAsyncWebSocketCM:  # noqa: ANN401
-            # Check allowlist FIRST - bypasses both guard and sandbox
-            if "websocket" in _guard_allowlist.get() or "async_websocket" in _guard_allowlist.get():
-                return cast(_FakeAsyncWebSocketCM, _orig_connect(*args, **kwargs))
             try:
                 plugin = _get_async_websocket_plugin()
             except GuardPassThrough:
@@ -473,9 +470,6 @@ class SyncWebSocketPlugin(StateMachinePlugin):
         _orig_create = _wsc.create_connection
 
         def _patched_create_connection(*args: Any, **kwargs: Any) -> _FakeSyncWebSocket:  # noqa: ANN401
-            # Check allowlist FIRST - bypasses both guard and sandbox
-            if "websocket" in _guard_allowlist.get() or "sync_websocket" in _guard_allowlist.get():
-                return cast(_FakeSyncWebSocket, _orig_create(*args, **kwargs))
             try:
                 plugin = _get_sync_websocket_plugin()
             except GuardPassThrough:

--- a/src/bigfoot/plugins/websocket_plugin.py
+++ b/src/bigfoot/plugins/websocket_plugin.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from bigfoot._context import GuardPassThrough, get_verifier_or_raise
 from bigfoot._errors import UnmockedInteractionError
+from bigfoot._firewall_request import WebSocketFirewallRequest
+from bigfoot._normalize import normalize_url
 from bigfoot._state_machine_plugin import SessionHandle, StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
 
@@ -53,8 +55,10 @@ except ImportError:  # pragma: no cover
 # ---------------------------------------------------------------------------
 
 
-def _get_async_websocket_plugin() -> AsyncWebSocketPlugin:
-    verifier = get_verifier_or_raise("websocket:async:connect")
+def _get_async_websocket_plugin(
+    firewall_request: WebSocketFirewallRequest | None = None,
+) -> AsyncWebSocketPlugin:
+    verifier = get_verifier_or_raise("websocket:async:connect", firewall_request=firewall_request)
     for plugin in verifier._plugins:
         if isinstance(plugin, AsyncWebSocketPlugin):
             return plugin
@@ -64,8 +68,10 @@ def _get_async_websocket_plugin() -> AsyncWebSocketPlugin:
     )
 
 
-def _get_sync_websocket_plugin() -> SyncWebSocketPlugin:
-    verifier = get_verifier_or_raise("websocket:sync:connect")
+def _get_sync_websocket_plugin(
+    firewall_request: WebSocketFirewallRequest | None = None,
+) -> SyncWebSocketPlugin:
+    verifier = get_verifier_or_raise("websocket:sync:connect", firewall_request=firewall_request)
     for plugin in verifier._plugins:
         if isinstance(plugin, SyncWebSocketPlugin):
             return plugin
@@ -158,6 +164,8 @@ class AsyncWebSocketPlugin(StateMachinePlugin):
     States: connecting -> open -> closed
     """
 
+    guard_prefixes: ClassVar[tuple[str, ...]] = ("async_websocket", "websocket")
+
     # Saved original, restored when count reaches 0.
     _original_connect: ClassVar[Callable[..., Any] | None] = None
 
@@ -226,11 +234,13 @@ class AsyncWebSocketPlugin(StateMachinePlugin):
         _orig_connect = _ws.connect
 
         def _patched_websockets_connect(*args: Any, **kwargs: Any) -> _FakeAsyncWebSocketCM:  # noqa: ANN401
+            uri = args[0] if args else kwargs.get("uri", "")
+            scheme, host, port, path = normalize_url(str(uri))
+            fw_request = WebSocketFirewallRequest(host=host, port=port, scheme=scheme, path=path)
             try:
-                plugin = _get_async_websocket_plugin()
+                plugin = _get_async_websocket_plugin(firewall_request=fw_request)
             except GuardPassThrough:
                 return cast(_FakeAsyncWebSocketCM, _orig_connect(*args, **kwargs))
-            uri = args[0] if args else kwargs.get("uri", "")
             # Pop from queue at websockets.connect() call time (FIFO).
             with plugin._registry_lock:
                 if not plugin._session_queue:
@@ -402,6 +412,8 @@ class SyncWebSocketPlugin(StateMachinePlugin):
     States: connecting -> open -> closed
     """
 
+    guard_prefixes: ClassVar[tuple[str, ...]] = ("sync_websocket", "websocket")
+
     # Saved original, restored when count reaches 0.
     _original_create_connection: ClassVar[Callable[..., Any] | None] = None
 
@@ -470,11 +482,13 @@ class SyncWebSocketPlugin(StateMachinePlugin):
         _orig_create = _wsc.create_connection
 
         def _patched_create_connection(*args: Any, **kwargs: Any) -> _FakeSyncWebSocket:  # noqa: ANN401
+            uri = args[0] if args else kwargs.get("url", "")
+            scheme, host, port, path = normalize_url(str(uri))
+            fw_request = WebSocketFirewallRequest(host=host, port=port, scheme=scheme, path=path)
             try:
-                plugin = _get_sync_websocket_plugin()
+                plugin = _get_sync_websocket_plugin(firewall_request=fw_request)
             except GuardPassThrough:
                 return cast(_FakeSyncWebSocket, _orig_create(*args, **kwargs))
-            uri = args[0] if args else kwargs.get("url", "")
             # Pop from queue immediately at create_connection() call time (FIFO).
             with plugin._registry_lock:
                 if not plugin._session_queue:

--- a/src/bigfoot/pytest_plugin.py
+++ b/src/bigfoot/pytest_plugin.py
@@ -211,7 +211,6 @@ def pytest_runtest_call(item: pytest.Item) -> Generator[None, None, None]:
     from bigfoot._firewall import (  # noqa: PLC0415
         Disposition,
         FirewallRule,
-        FirewallStack,
         _firewall_stack,
     )
     from bigfoot._match import M  # noqa: PLC0415
@@ -242,8 +241,8 @@ def pytest_runtest_call(item: pytest.Item) -> Generator[None, None, None]:
         )
 
     # Structured protocol sections (e.g., [tool.bigfoot.firewall.http])
-    _STRUCTURED_PROTOCOLS = ("http", "redis", "subprocess", "boto3", "socket", "file_io")
-    for proto in _STRUCTURED_PROTOCOLS:
+    structured_protocols = ("http", "redis", "subprocess", "boto3", "socket", "file_io")
+    for proto in structured_protocols:
         proto_section = firewall_config.get(proto, {})
         if not isinstance(proto_section, dict):
             continue
@@ -314,7 +313,7 @@ def pytest_runtest_call(item: pytest.Item) -> Generator[None, None, None]:
         _firewall_stack.reset(firewall_token)
 
 
-def _parse_toml_rule(rule_str: str) -> M:
+def _parse_toml_rule(rule_str: str) -> M:  # type: ignore[name-defined]  # noqa: F821
     """Parse a TOML rule string into an M() pattern."""
     from bigfoot._match import M  # noqa: PLC0415
 

--- a/src/bigfoot/pytest_plugin.py
+++ b/src/bigfoot/pytest_plugin.py
@@ -11,7 +11,6 @@ from bigfoot._config import load_bigfoot_config
 from bigfoot._context import (
     _current_test_verifier,
     _guard_active,
-    _guard_allowlist,
     _guard_level,
     _guard_patches_installed,
 )
@@ -221,9 +220,12 @@ def pytest_runtest_call(item: pytest.Item) -> Generator[None, None, None]:
     # Validate names
     if marker_allowlist or denylist:
         from bigfoot._errors import BigfootConfigError  # noqa: PLC0415
-        from bigfoot._registry import GUARD_ELIGIBLE_PREFIXES, VALID_PLUGIN_NAMES  # noqa: PLC0415
+        from bigfoot._registry import is_guard_eligible, VALID_PLUGIN_NAMES  # noqa: PLC0415
 
-        valid = VALID_PLUGIN_NAMES | GUARD_ELIGIBLE_PREFIXES
+        # Build the full set of valid names (registry names + guard prefixes)
+        if not hasattr(is_guard_eligible, "_cache"):
+            is_guard_eligible("")  # trigger cache build
+        valid = VALID_PLUGIN_NAMES | is_guard_eligible._cache
         unknown = (marker_allowlist | denylist) - valid
         if unknown:
             raise BigfootConfigError(
@@ -232,16 +234,32 @@ def pytest_runtest_call(item: pytest.Item) -> Generator[None, None, None]:
                 f"Valid names: {sorted(valid)}"
             )
 
-    # Merge existing fixture-set allowlist with marker allowlist, then subtract deny
-    existing = _guard_allowlist.get()
-    allowlist = (existing | marker_allowlist) - denylist
+    # Build firewall rules from marker allowlist and denylist
+    from bigfoot._firewall import (  # noqa: PLC0415
+        Disposition,
+        FirewallRule,
+        FirewallStack,
+        _firewall_stack,
+    )
+    from bigfoot._match import M  # noqa: PLC0415
+
+    frames = []
+    # Deny rules take priority (pushed first, so they are outermost)
+    for name in sorted(denylist):
+        frames.append(FirewallRule(pattern=M(protocol=name), disposition=Disposition.DENY))
+    # Allow rules are innermost (pushed last, evaluated first)
+    for name in sorted(marker_allowlist - denylist):
+        frames.append(FirewallRule(pattern=M(protocol=name), disposition=Disposition.ALLOW))
+
+    current_stack = _firewall_stack.get()
+    new_stack = current_stack.push(*frames) if frames else current_stack
+    firewall_token = _firewall_stack.set(new_stack)
 
     level_token = _guard_level.set(guard_level)
-    allowlist_token = _guard_allowlist.set(allowlist)
     guard_token = _guard_active.set(True)
     try:
         yield
     finally:
         _guard_active.reset(guard_token)
-        _guard_allowlist.reset(allowlist_token)
         _guard_level.reset(level_token)
+        _firewall_stack.reset(firewall_token)

--- a/src/bigfoot/pytest_plugin.py
+++ b/src/bigfoot/pytest_plugin.py
@@ -364,7 +364,7 @@ def _parse_toml_rule(rule_str: str) -> M:  # type: ignore[name-defined]  # noqa:
             kwargs["db"] = int(parsed.path.lstrip("/"))
         else:
             kwargs["path"] = parsed.path
-    return M(**kwargs)
+    return M(**kwargs)  # type: ignore[arg-type]
 
 
 def _path_matches_glob(test_path: str, glob_pattern: str) -> bool:

--- a/src/bigfoot/pytest_plugin.py
+++ b/src/bigfoot/pytest_plugin.py
@@ -63,12 +63,11 @@ def pytest_configure(config: pytest.Config) -> None:
     """Register bigfoot pytest markers and install context propagation."""
     config.addinivalue_line(
         "markers",
-        "allow(*plugin_names): allow plugins to make real calls"
-        " (bypasses guard and sandbox)",
+        "allow(*rules): allow protocols/patterns (str or M()) to bypass guard mode",
     )
     config.addinivalue_line(
         "markers",
-        'deny(*plugin_names): remove plugins from the allowlist (narrows an outer allow)',
+        "deny(*rules): deny protocols/patterns (str or M()) in guard mode",
     )
     install_context_propagation()
 
@@ -199,42 +198,16 @@ def pytest_runtest_call(item: pytest.Item) -> Generator[None, None, None]:
         yield
         return
 
-    # Config-level default allowlist
-    config_allow = config.get("guard_allow", [])
-    if not isinstance(config_allow, list):
+    # Reject legacy guard_allow config key
+    if "guard_allow" in config:
         from bigfoot._errors import BigfootConfigError  # noqa: PLC0415
 
         raise BigfootConfigError(
-            f"guard_allow must be a list of plugin names, got {type(config_allow).__name__}"
+            "The guard_allow config key has been replaced by [tool.bigfoot.firewall]. "
+            "Migration: guard_allow = [\"http\", \"dns\"] becomes "
+            "[tool.bigfoot.firewall]\\nallow = [\"http:*\", \"dns:*\"]"
         )
-    marker_allowlist: frozenset[str] = frozenset(config_allow)
 
-    # Process @pytest.mark.allow and @pytest.mark.deny
-    for mark in item.iter_markers("allow"):
-        marker_allowlist = marker_allowlist | frozenset(mark.args)
-
-    denylist: frozenset[str] = frozenset()
-    for mark in item.iter_markers("deny"):
-        denylist = denylist | frozenset(mark.args)
-
-    # Validate names
-    if marker_allowlist or denylist:
-        from bigfoot._errors import BigfootConfigError  # noqa: PLC0415
-        from bigfoot._registry import is_guard_eligible, VALID_PLUGIN_NAMES  # noqa: PLC0415
-
-        # Build the full set of valid names (registry names + guard prefixes)
-        if not hasattr(is_guard_eligible, "_cache"):
-            is_guard_eligible("")  # trigger cache build
-        valid = VALID_PLUGIN_NAMES | is_guard_eligible._cache
-        unknown = (marker_allowlist | denylist) - valid
-        if unknown:
-            raise BigfootConfigError(
-                f"Unknown plugin name(s) in @pytest.mark.allow/deny or guard_allow: "
-                f"{sorted(unknown)}. "
-                f"Valid names: {sorted(valid)}"
-            )
-
-    # Build firewall rules from marker allowlist and denylist
     from bigfoot._firewall import (  # noqa: PLC0415
         Disposition,
         FirewallRule,
@@ -243,13 +216,89 @@ def pytest_runtest_call(item: pytest.Item) -> Generator[None, None, None]:
     )
     from bigfoot._match import M  # noqa: PLC0415
 
-    frames = []
-    # Deny rules take priority (pushed first, so they are outermost)
-    for name in sorted(denylist):
-        frames.append(FirewallRule(pattern=M(protocol=name), disposition=Disposition.DENY))
-    # Allow rules are innermost (pushed last, evaluated first)
-    for name in sorted(marker_allowlist - denylist):
-        frames.append(FirewallRule(pattern=M(protocol=name), disposition=Disposition.ALLOW))
+    frames: list[FirewallRule] = []
+
+    # ---------------------------------------------------------------
+    # Layer 0: Global TOML rules from [tool.bigfoot.firewall]
+    # ---------------------------------------------------------------
+    firewall_config = config.get("firewall", {})
+    if not isinstance(firewall_config, dict):
+        from bigfoot._errors import BigfootConfigError  # noqa: PLC0415
+
+        raise BigfootConfigError(
+            f"firewall config must be a table/dict, got {type(firewall_config).__name__}"
+        )
+
+    # Global allow rules
+    for rule_str in firewall_config.get("allow", []):
+        frames.append(
+            FirewallRule(pattern=_parse_toml_rule(rule_str), disposition=Disposition.ALLOW)
+        )
+
+    # Global deny rules
+    for rule_str in firewall_config.get("deny", []):
+        frames.append(
+            FirewallRule(pattern=_parse_toml_rule(rule_str), disposition=Disposition.DENY)
+        )
+
+    # Structured protocol sections (e.g., [tool.bigfoot.firewall.http])
+    _STRUCTURED_PROTOCOLS = ("http", "redis", "subprocess", "boto3", "socket", "file_io")
+    for proto in _STRUCTURED_PROTOCOLS:
+        proto_section = firewall_config.get(proto, {})
+        if not isinstance(proto_section, dict):
+            continue
+        for rule_str in proto_section.get("allow", []):
+            frames.append(
+                FirewallRule(
+                    pattern=_parse_toml_rule(f"{proto}:{rule_str}"),
+                    disposition=Disposition.ALLOW,
+                )
+            )
+        for rule_str in proto_section.get("deny", []):
+            frames.append(
+                FirewallRule(
+                    pattern=_parse_toml_rule(f"{proto}:{rule_str}"),
+                    disposition=Disposition.DENY,
+                )
+            )
+
+    # ---------------------------------------------------------------
+    # Layer 1: Per-file TOML overrides
+    # ---------------------------------------------------------------
+    per_file = firewall_config.get("per-file-allow", {})
+    if isinstance(per_file, dict) and per_file:
+        test_path = str(item.fspath)
+        for glob_pattern, rules in per_file.items():
+            if _path_matches_glob(test_path, glob_pattern):
+                if isinstance(rules, list):
+                    for rule_str in rules:
+                        frames.append(
+                            FirewallRule(
+                                pattern=_parse_toml_rule(rule_str),
+                                disposition=Disposition.ALLOW,
+                            )
+                        )
+
+    # ---------------------------------------------------------------
+    # Layer 2: @pytest.mark.allow / @pytest.mark.deny
+    # ---------------------------------------------------------------
+    for mark in item.iter_markers("deny"):
+        for arg in mark.args:
+            if isinstance(arg, M):
+                frames.append(FirewallRule(pattern=arg, disposition=Disposition.DENY))
+            else:
+                frames.append(
+                    FirewallRule(pattern=M(protocol=str(arg)), disposition=Disposition.DENY)
+                )
+
+    for mark in item.iter_markers("allow"):
+        for arg in mark.args:
+            if isinstance(arg, M):
+                frames.append(FirewallRule(pattern=arg, disposition=Disposition.ALLOW))
+            else:
+                frames.append(
+                    FirewallRule(pattern=M(protocol=str(arg)), disposition=Disposition.ALLOW)
+                )
 
     current_stack = _firewall_stack.get()
     new_stack = current_stack.push(*frames) if frames else current_stack
@@ -263,3 +312,64 @@ def pytest_runtest_call(item: pytest.Item) -> Generator[None, None, None]:
         _guard_active.reset(guard_token)
         _guard_level.reset(level_token)
         _firewall_stack.reset(firewall_token)
+
+
+def _parse_toml_rule(rule_str: str) -> M:
+    """Parse a TOML rule string into an M() pattern."""
+    from bigfoot._match import M  # noqa: PLC0415
+
+    # Protocol:wildcard shorthand
+    if ":" in rule_str and "//" not in rule_str:
+        protocol, _, pattern = rule_str.partition(":")
+        if pattern == "*":
+            return M(protocol=protocol)
+        if protocol == "subprocess":
+            return M(protocol="subprocess", binary=pattern)
+        if protocol == "memcache":
+            return M(protocol="memcache", command=pattern)
+        if protocol == "file_io":
+            return M(protocol="file_io", path=pattern)
+        if protocol == "boto3":
+            parts = pattern.split(":")
+            if len(parts) == 2:  # noqa: PLR2004
+                return M(protocol="boto3", service=parts[0], operation=parts[1])
+            return M(protocol="boto3", service=parts[0])
+        return M(protocol=protocol)
+
+    # URL-style: scheme://host[:port][/path]
+    from urllib.parse import urlparse  # noqa: PLC0415
+
+    parsed = urlparse(rule_str)
+    scheme = parsed.scheme
+    kwargs: dict[str, object] = {}
+    protocol_map = {
+        "http": "http",
+        "https": "http",
+        "redis": "redis",
+        "rediss": "redis",
+        "ws": "websocket",
+        "wss": "websocket",
+        "postgresql": "psycopg2",
+        "postgres": "psycopg2",
+        "smtp": "smtp",
+        "ssh": "ssh",
+    }
+    protocol = protocol_map.get(scheme, scheme)
+    kwargs["protocol"] = protocol
+    if parsed.hostname:
+        kwargs["host"] = parsed.hostname
+    if parsed.port:
+        kwargs["port"] = parsed.port
+    if parsed.path and parsed.path != "/":
+        if protocol == "redis" and parsed.path.lstrip("/").isdigit():
+            kwargs["db"] = int(parsed.path.lstrip("/"))
+        else:
+            kwargs["path"] = parsed.path
+    return M(**kwargs)
+
+
+def _path_matches_glob(test_path: str, glob_pattern: str) -> bool:
+    """Check if a test path matches a glob pattern."""
+    from bigfoot._glob import bigfoot_match  # noqa: PLC0415
+
+    return bigfoot_match(glob_pattern, test_path)

--- a/tests/unit/test_boto3_plugin.py
+++ b/tests/unit/test_boto3_plugin.py
@@ -29,8 +29,8 @@ def _make_verifier_with_plugin() -> tuple[StrictVerifier, Boto3Plugin]:
     """Return (verifier, plugin) with Boto3Plugin registered but NOT activated.
 
     DNS and Socket calls from boto3 internals (credential provider hitting
-    169.254.169.254) are handled by the @pytest.mark.allow("dns", "socket")
-    mark which bypasses both guard and sandbox modes.
+    169.254.169.254) are prevented by the plugin's install_patches() which
+    sets dummy env vars so botocore never reaches the metadata service.
     """
     v = StrictVerifier()
     for p in v._plugins:
@@ -46,9 +46,6 @@ def _reset_plugin_count() -> None:
         Boto3Plugin._install_count = 0
         # Use the plugin's own _restore_patches() to avoid duplicating restoration logic.
         Boto3Plugin.__new__(Boto3Plugin).restore_patches()
-
-
-pytestmark = pytest.mark.allow("dns", "socket")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_context_propagation.py
+++ b/tests/unit/test_context_propagation.py
@@ -260,7 +260,6 @@ from bigfoot._context import (
     _any_order_depth,
     _current_test_verifier,
     _guard_active,
-    _guard_allowlist,
     _guard_level,
     _guard_patches_installed,
 )
@@ -278,7 +277,6 @@ class TestBigfootContextVarsPropagation:
             (_any_order_depth, 3),
             (_current_test_verifier, object()),
             (_guard_active, True),
-            (_guard_allowlist, frozenset({"http", "socket"})),
             (_guard_level, "error"),
             (_guard_patches_installed, True),
             (_recording_in_progress, True),
@@ -289,7 +287,6 @@ class TestBigfootContextVarsPropagation:
             "any_order_depth",
             "current_test_verifier",
             "guard_active",
-            "guard_allowlist",
             "guard_level",
             "guard_patches_installed",
             "recording_in_progress",
@@ -336,7 +333,6 @@ class TestGuardModePropagation:
             stack.callback(_guard_active.reset, _guard_active.set(True))
             stack.callback(_guard_level.reset, _guard_level.set("error"))
             stack.callback(_guard_patches_installed.reset, _guard_patches_installed.set(True))
-            stack.callback(_guard_allowlist.reset, _guard_allowlist.set(frozenset()))
             errors: list[BaseException] = []
 
             def worker() -> None:
@@ -352,20 +348,35 @@ class TestGuardModePropagation:
         assert len(errors) == 1
         assert isinstance(errors[0], GuardedCallError)
 
-    def test_guard_allowlist_propagates_to_child_thread(self) -> None:
-        """When a plugin is in the allowlist, child thread passes through."""
+    def test_guard_firewall_allow_propagates_to_child_thread(self) -> None:
+        """When a firewall allow rule matches, child thread passes through."""
+        from bigfoot._firewall import (
+            Disposition,
+            FirewallRule,
+            FirewallStack,
+            _firewall_stack,
+        )
+        from bigfoot._firewall_request import HttpFirewallRequest
+        from bigfoot._match import M
+
         install_context_propagation()
+
+        allow_stack = FirewallStack((
+            FirewallRule(pattern=M(protocol="http"), disposition=Disposition.ALLOW),
+        ))
 
         with contextlib.ExitStack() as stack:
             stack.callback(_guard_active.reset, _guard_active.set(True))
             stack.callback(_guard_level.reset, _guard_level.set("error"))
             stack.callback(_guard_patches_installed.reset, _guard_patches_installed.set(True))
-            stack.callback(_guard_allowlist.reset, _guard_allowlist.set(frozenset({"http"})))
+            stack.callback(_firewall_stack.reset, _firewall_stack.set(allow_stack))
             errors: list[BaseException] = []
+
+            request = HttpFirewallRequest(host="example.com", port=80)
 
             def worker() -> None:
                 try:
-                    get_verifier_or_raise("http:request")
+                    get_verifier_or_raise("http:request", firewall_request=request)
                 except GuardPassThrough as exc:
                     errors.append(exc)
 

--- a/tests/unit/test_firewall.py
+++ b/tests/unit/test_firewall.py
@@ -2,7 +2,6 @@
 
 from bigfoot._firewall import Disposition, FirewallRule, FirewallStack, RestrictFrame
 from bigfoot._firewall_request import (
-    DnsFirewallRequest,
     HttpFirewallRequest,
     RedisFirewallRequest,
 )

--- a/tests/unit/test_firewall.py
+++ b/tests/unit/test_firewall.py
@@ -1,0 +1,83 @@
+"""Tests for bigfoot._firewall -- FirewallStack evaluation."""
+
+from bigfoot._firewall import Disposition, FirewallRule, FirewallStack, RestrictFrame
+from bigfoot._firewall_request import (
+    DnsFirewallRequest,
+    HttpFirewallRequest,
+    RedisFirewallRequest,
+)
+from bigfoot._match import M
+
+
+class TestFirewallStackEvaluate:
+    def test_empty_stack_denies(self) -> None:
+        stack = FirewallStack()
+        req = HttpFirewallRequest(host="example.com", port=80)
+        assert stack.evaluate(req) == Disposition.DENY
+
+    def test_single_allow_matches(self) -> None:
+        rule = FirewallRule(pattern=M(protocol="http"), disposition=Disposition.ALLOW)
+        stack = FirewallStack((rule,))
+        req = HttpFirewallRequest(host="example.com", port=80)
+        assert stack.evaluate(req) == Disposition.ALLOW
+
+    def test_single_allow_no_match(self) -> None:
+        rule = FirewallRule(pattern=M(protocol="redis"), disposition=Disposition.ALLOW)
+        stack = FirewallStack((rule,))
+        req = HttpFirewallRequest(host="example.com", port=80)
+        assert stack.evaluate(req) == Disposition.DENY
+
+    def test_single_deny_matches(self) -> None:
+        rule = FirewallRule(pattern=M(protocol="http"), disposition=Disposition.DENY)
+        stack = FirewallStack((rule,))
+        req = HttpFirewallRequest(host="example.com", port=80)
+        assert stack.evaluate(req) == Disposition.DENY
+
+    def test_innermost_rule_wins(self) -> None:
+        outer = FirewallRule(pattern=M(protocol="http"), disposition=Disposition.DENY)
+        inner = FirewallRule(pattern=M(protocol="http", host="*.example.com"), disposition=Disposition.ALLOW)
+        stack = FirewallStack((outer, inner))
+        req = HttpFirewallRequest(host="sub.example.com", port=80)
+        assert stack.evaluate(req) == Disposition.ALLOW
+
+    def test_push_creates_new_stack(self) -> None:
+        base = FirewallStack()
+        rule = FirewallRule(pattern=M(protocol="http"), disposition=Disposition.ALLOW)
+        new_stack = base.push(rule)
+        assert new_stack.frames == (rule,)
+        assert base.frames == ()  # immutable
+
+    def test_restrict_blocks_non_matching(self) -> None:
+        restrict = RestrictFrame(pattern=M(protocol="http"))
+        allow_redis = FirewallRule(pattern=M(protocol="redis"), disposition=Disposition.ALLOW)
+        stack = FirewallStack((restrict, allow_redis))
+        req = RedisFirewallRequest(host="localhost", port=6379)
+        assert stack.evaluate(req) == Disposition.DENY
+
+    def test_restrict_allows_matching_to_continue(self) -> None:
+        restrict = RestrictFrame(pattern=M(protocol="http"))
+        allow_http = FirewallRule(pattern=M(protocol="http"), disposition=Disposition.ALLOW)
+        stack = FirewallStack((restrict, allow_http))
+        req = HttpFirewallRequest(host="example.com", port=80)
+        assert stack.evaluate(req) == Disposition.ALLOW
+
+    def test_nested_restrict_intersection(self) -> None:
+        restrict1 = RestrictFrame(pattern=M(protocol="http"))
+        restrict2 = RestrictFrame(pattern=M(host="*.example.com"))
+        allow_all_http = FirewallRule(pattern=M(protocol="http"), disposition=Disposition.ALLOW)
+        stack = FirewallStack((restrict1, restrict2, allow_all_http))
+        # HTTP to example.com: passes both restricts
+        req_ok = HttpFirewallRequest(host="sub.example.com", port=80)
+        assert stack.evaluate(req_ok) == Disposition.ALLOW
+        # HTTP to other.com: fails restrict2
+        req_bad = HttpFirewallRequest(host="other.com", port=80)
+        assert stack.evaluate(req_bad) == Disposition.DENY
+
+    def test_restrict_cannot_be_bypassed_by_inner_allow(self) -> None:
+        """Two-phase algorithm: restrict checked BEFORE rule scan."""
+        restrict = RestrictFrame(pattern=M(protocol="http"))
+        inner_allow = FirewallRule(pattern=M(protocol="redis"), disposition=Disposition.ALLOW)
+        stack = FirewallStack((restrict, inner_allow))
+        req = RedisFirewallRequest(host="localhost", port=6379)
+        # Inner allow("redis") should NOT override restrict(http)
+        assert stack.evaluate(req) == Disposition.DENY

--- a/tests/unit/test_firewall_errors.py
+++ b/tests/unit/test_firewall_errors.py
@@ -1,0 +1,46 @@
+"""Tests for GuardedCallError message generation with firewall requests."""
+
+from bigfoot._errors import GuardedCallError
+from bigfoot._firewall_request import (
+    HttpFirewallRequest,
+    RedisFirewallRequest,
+    SubprocessFirewallRequest,
+)
+
+
+class TestGuardedCallErrorMessages:
+    def test_http_error_message(self) -> None:
+        req = HttpFirewallRequest(
+            host="api.stripe.com", port=443, scheme="https",
+            path="/v1/charges", method="GET",
+        )
+        err = GuardedCallError("http:request", "http", firewall_request=req)
+        msg = str(err)
+        assert "GET https://api.stripe.com:443/v1/charges" in msg
+        assert "@pytest.mark.allow" in msg
+        assert "bigfoot.allow" in msg
+        assert "[tool.bigfoot.firewall]" in msg
+
+    def test_redis_error_message(self) -> None:
+        req = RedisFirewallRequest(host="localhost", port=6379, db=0, command="FLUSHALL")
+        err = GuardedCallError("redis:command", "redis", firewall_request=req)
+        msg = str(err)
+        assert "redis://localhost:6379/0 FLUSHALL" in msg
+
+    def test_subprocess_error_message(self) -> None:
+        req = SubprocessFirewallRequest(command="rm -rf /tmp/important", binary="rm")
+        err = GuardedCallError("subprocess:run", "subprocess", firewall_request=req)
+        msg = str(err)
+        assert "subprocess: rm -rf /tmp/important" in msg
+
+    def test_no_request_fallback(self) -> None:
+        err = GuardedCallError("http:request", "http", firewall_request=None)
+        msg = str(err)
+        assert "@pytest.mark.allow" in msg
+        assert '"http"' in msg
+
+    def test_old_signature_still_works(self) -> None:
+        """Backward compat: firewall_request defaults to None."""
+        err = GuardedCallError("http:request", "http")
+        msg = str(err)
+        assert "blocked by bigfoot firewall" in msg

--- a/tests/unit/test_firewall_integration.py
+++ b/tests/unit/test_firewall_integration.py
@@ -1,0 +1,81 @@
+"""Integration tests for firewall layering: TOML + marks + context managers."""
+
+from bigfoot._firewall import Disposition, FirewallRule, FirewallStack
+from bigfoot._firewall_request import (
+    DnsFirewallRequest,
+    HttpFirewallRequest,
+    RedisFirewallRequest,
+)
+from bigfoot._match import M
+
+
+class TestAppendixAWalkthrough:
+    """Recreate the Appendix A walkthrough from the design doc."""
+
+    def _build_stack(self) -> FirewallStack:
+        """Build the stack from the Appendix A example."""
+        frames = (
+            # Index 0 (outermost): TOML allow dns
+            FirewallRule(pattern=M(protocol="dns"), disposition=Disposition.ALLOW),
+            # Index 1: TOML allow redis://localhost:6379
+            FirewallRule(
+                pattern=M(protocol="redis", host="localhost", port=6379),
+                disposition=Disposition.ALLOW,
+            ),
+            # Index 2: mark allow http *.example.com
+            FirewallRule(
+                pattern=M(protocol="http", host="*.example.com"),
+                disposition=Disposition.ALLOW,
+            ),
+            # Index 3: deny cm *.internal.example.com
+            FirewallRule(
+                pattern=M(protocol="http", host="*.internal.example.com"),
+                disposition=Disposition.DENY,
+            ),
+            # Index 4 (innermost): allow cm api.internal.example.com
+            FirewallRule(
+                pattern=M(protocol="http", host="api.internal.example.com"),
+                disposition=Disposition.ALLOW,
+            ),
+        )
+        return FirewallStack(frames)
+
+    def test_specific_internal_allowed(self) -> None:
+        stack = self._build_stack()
+        req = HttpFirewallRequest(
+            host="api.internal.example.com", port=443,
+            scheme="https", path="/charge", method="GET",
+        )
+        assert stack.evaluate(req) == Disposition.ALLOW
+
+    def test_other_internal_denied(self) -> None:
+        stack = self._build_stack()
+        req = HttpFirewallRequest(
+            host="secret.internal.example.com", port=443,
+        )
+        assert stack.evaluate(req) == Disposition.DENY
+
+    def test_example_com_subdomain_allowed(self) -> None:
+        stack = self._build_stack()
+        req = HttpFirewallRequest(host="api.example.com", port=443)
+        assert stack.evaluate(req) == Disposition.ALLOW
+
+    def test_unknown_host_denied(self) -> None:
+        stack = self._build_stack()
+        req = HttpFirewallRequest(host="evil.com", port=80)
+        assert stack.evaluate(req) == Disposition.DENY
+
+    def test_dns_allowed(self) -> None:
+        stack = self._build_stack()
+        req = DnsFirewallRequest(hostname="anything.com")
+        assert stack.evaluate(req) == Disposition.ALLOW
+
+    def test_redis_localhost_allowed(self) -> None:
+        stack = self._build_stack()
+        req = RedisFirewallRequest(host="localhost", port=6379)
+        assert stack.evaluate(req) == Disposition.ALLOW
+
+    def test_redis_remote_denied(self) -> None:
+        stack = self._build_stack()
+        req = RedisFirewallRequest(host="redis.prod.internal", port=6379)
+        assert stack.evaluate(req) == Disposition.DENY

--- a/tests/unit/test_firewall_toml.py
+++ b/tests/unit/test_firewall_toml.py
@@ -1,0 +1,54 @@
+"""Tests for TOML firewall rule parsing."""
+
+from bigfoot._firewall_request import (
+    HttpFirewallRequest,
+    RedisFirewallRequest,
+    SubprocessFirewallRequest,
+)
+from bigfoot.pytest_plugin import _parse_toml_rule
+
+
+class TestParseTomlRule:
+    def test_protocol_wildcard(self) -> None:
+        m = _parse_toml_rule("dns:*")
+        from bigfoot._firewall_request import DnsFirewallRequest
+        req = DnsFirewallRequest(hostname="example.com")
+        assert m.matches(req) is True
+
+    def test_subprocess_binary(self) -> None:
+        m = _parse_toml_rule("subprocess:git")
+        req = SubprocessFirewallRequest(command="git status", binary="git")
+        assert m.matches(req) is True
+
+    def test_http_url(self) -> None:
+        m = _parse_toml_rule("http://*.example.com")
+        req = HttpFirewallRequest(host="sub.example.com", port=80)
+        assert m.matches(req) is True
+
+    def test_https_url(self) -> None:
+        m = _parse_toml_rule("https://api.stripe.com/v1/charges")
+        req = HttpFirewallRequest(host="api.stripe.com", port=443, path="/v1/charges", scheme="https")
+        assert m.matches(req) is True
+
+    def test_redis_url_with_db(self) -> None:
+        m = _parse_toml_rule("redis://localhost:6379/0")
+        req = RedisFirewallRequest(host="localhost", port=6379, db=0)
+        assert m.matches(req) is True
+
+    def test_boto3_service_operation(self) -> None:
+        m = _parse_toml_rule("boto3:s3:GetObject")
+        from bigfoot._firewall_request import Boto3FirewallRequest
+        req = Boto3FirewallRequest(service="s3", operation="GetObject")
+        assert m.matches(req) is True
+
+    def test_memcache_command(self) -> None:
+        m = _parse_toml_rule("memcache:get")
+        from bigfoot._firewall_request import MemcacheFirewallRequest
+        req = MemcacheFirewallRequest(host="localhost", port=11211, command="get")
+        assert m.matches(req) is True
+
+    def test_file_io_path(self) -> None:
+        m = _parse_toml_rule("file_io:/tmp/**")
+        from bigfoot._firewall_request import FileIoFirewallRequest
+        req = FileIoFirewallRequest(path="/tmp/foo/bar")
+        assert m.matches(req) is True

--- a/tests/unit/test_glob.py
+++ b/tests/unit/test_glob.py
@@ -1,0 +1,43 @@
+"""Tests for bigfoot._glob -- custom glob matching."""
+
+from bigfoot._glob import bigfoot_match
+
+
+class TestHostGlob:
+    def test_subdomain_match(self) -> None:
+        assert bigfoot_match("*.example.com", "sub.example.com") is True
+
+    def test_deep_subdomain_match(self) -> None:
+        assert bigfoot_match("*.example.com", "deep.sub.example.com") is True
+
+    def test_bare_domain_no_match(self) -> None:
+        assert bigfoot_match("*.example.com", "example.com") is False
+
+    def test_evil_hyphen_no_match(self) -> None:
+        """Security-critical: *.example.com must NOT match evil-example.com."""
+        assert bigfoot_match("*.example.com", "evil-example.com") is False
+
+    def test_case_insensitive_host(self) -> None:
+        assert bigfoot_match("*.Example.COM", "sub.example.com", case_sensitive=False) is True
+
+
+class TestPathGlob:
+    def test_double_star_deep_match(self) -> None:
+        assert bigfoot_match("/api/**", "/api/v1/users") is True
+
+    def test_double_star_deeper(self) -> None:
+        assert bigfoot_match("/api/**", "/api/v2/items/123") is True
+
+    def test_single_star_no_deep(self) -> None:
+        assert bigfoot_match("/api/*", "/api/v1/users") is False
+
+    def test_single_star_one_segment(self) -> None:
+        assert bigfoot_match("/api/*", "/api/v1") is True
+
+
+class TestExactMatch:
+    def test_no_wildcards_exact(self) -> None:
+        assert bigfoot_match("hello", "hello") is True
+
+    def test_no_wildcards_mismatch(self) -> None:
+        assert bigfoot_match("hello", "world") is False

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -1597,10 +1597,17 @@ class TestGuardModeIntegration:
                 socket_mod.getaddrinfo("example.com", 80)
             msg = str(exc_info.value)
             # New firewall message format
-            assert '@pytest.mark.allow("dns")' in msg
-            assert 'bigfoot.allow("dns")' in msg
-            assert "with bigfoot:" in msg
+            assert "blocked by bigfoot firewall" in msg
+            assert "Attempted:" in msg
+            assert "Fix with @pytest.mark.allow:" in msg
+            assert '@pytest.mark.allow(M(protocol="dns"))' in msg
+            assert "Fix with context manager (scoped to a block):" in msg
+            assert 'bigfoot.allow(M(protocol="dns"))' in msg
+            assert "Fix in pyproject.toml:" in msg
             assert "[tool.bigfoot.firewall]" in msg
+            assert 'allow = ["dns:*"]' in msg
+            assert "Or mock the call with a sandbox:" in msg
+            assert "with bigfoot:" in msg
             assert "https://bigfoot.readthedocs.io/guides/guard-mode/" in msg
             # Old sections removed
             assert "supports_guard" not in msg

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -495,9 +495,11 @@ class TestWarnModeBehavior:
         try:
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
-                req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
+                # Use http (not dns/socket) so the project-level firewall
+                # allow = ["dns:*", "socket:*"] does not suppress the warning.
+                req = NetworkFirewallRequest(protocol="http", host="example.com", port=80)
                 with pytest.raises(GuardPassThrough):
-                    get_verifier_or_raise("dns:lookup", firewall_request=req)
+                    get_verifier_or_raise("http:request", firewall_request=req)
                 assert len(w) == 1
                 assert issubclass(w[0].category, GuardedCallWarning)
         finally:
@@ -514,9 +516,9 @@ class TestWarnModeBehavior:
         try:
             with warnings.catch_warnings(record=True):
                 warnings.simplefilter("always")
-                req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
+                req = NetworkFirewallRequest(protocol="http", host="example.com", port=80)
                 with pytest.raises(GuardPassThrough):
-                    get_verifier_or_raise("dns:lookup", firewall_request=req)
+                    get_verifier_or_raise("http:request", firewall_request=req)
         finally:
             _guard_active.reset(guard_token)
             _guard_level.reset(level_token)
@@ -532,9 +534,9 @@ class TestWarnModeBehavior:
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
                 warnings.filterwarnings("ignore", category=GuardedCallWarning)
-                req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
+                req = NetworkFirewallRequest(protocol="http", host="example.com", port=80)
                 with pytest.raises(GuardPassThrough):
-                    get_verifier_or_raise("dns:lookup", firewall_request=req)
+                    get_verifier_or_raise("http:request", firewall_request=req)
                 assert len(w) == 0
         finally:
             _guard_active.reset(guard_token)
@@ -550,10 +552,10 @@ class TestWarnModeBehavior:
         try:
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
-                req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
+                req = NetworkFirewallRequest(protocol="http", host="example.com", port=80)
                 with pytest.raises(GuardPassThrough):
-                    get_verifier_or_raise("dns:lookup", firewall_request=req)
-                assert "'dns:lookup'" in str(w[0].message)
+                    get_verifier_or_raise("http:request", firewall_request=req)
+                assert "'http:request'" in str(w[0].message)
         finally:
             _guard_active.reset(guard_token)
             _guard_level.reset(level_token)
@@ -568,9 +570,9 @@ class TestWarnModeBehavior:
         try:
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
-                req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
+                req = NetworkFirewallRequest(protocol="http", host="example.com", port=80)
                 with pytest.raises(GuardPassThrough):
-                    get_verifier_or_raise("dns:lookup", firewall_request=req)
+                    get_verifier_or_raise("http:request", firewall_request=req)
                 msg = str(w[0].message)
                 assert "blocked by firewall" in msg
         finally:
@@ -585,9 +587,9 @@ class TestWarnModeBehavior:
         level_token = _guard_level.set("error")
         guard_token = _guard_active.set(True)
         try:
-            req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
+            req = NetworkFirewallRequest(protocol="http", host="example.com", port=80)
             with pytest.raises(GuardedCallError):
-                get_verifier_or_raise("dns:lookup", firewall_request=req)
+                get_verifier_or_raise("http:request", firewall_request=req)
         finally:
             _guard_active.reset(guard_token)
             _guard_level.reset(level_token)
@@ -744,6 +746,7 @@ class TestGuardPassThroughInDirectPlugins:
         import socket
 
         from bigfoot._context import _guard_level
+        from bigfoot._guard import deny
         from bigfoot._verifier import StrictVerifier
         from bigfoot.plugins.dns_plugin import DnsPlugin
 
@@ -754,10 +757,12 @@ class TestGuardPassThroughInDirectPlugins:
             level_token = _guard_level.set("error")
             guard_token = _guard_active.set(True)
             try:
-                with pytest.raises(GuardedCallError) as exc_info:
-                    socket.getaddrinfo("example.com", 80)
-                assert exc_info.value.plugin_name == "dns"
-                assert exc_info.value.source_id == "dns:lookup"
+                # Explicitly deny dns to override project-level allow = ["dns:*"]
+                with deny("dns"):
+                    with pytest.raises(GuardedCallError) as exc_info:
+                        socket.getaddrinfo("example.com", 80)
+                    assert exc_info.value.plugin_name == "dns"
+                    assert exc_info.value.source_id == "dns:lookup"
             finally:
                 _guard_active.reset(guard_token)
                 _guard_level.reset(level_token)
@@ -796,6 +801,7 @@ class TestGuardPassThroughInDirectPlugins:
         import socket
 
         from bigfoot._context import _guard_level
+        from bigfoot._guard import deny
         from bigfoot._verifier import StrictVerifier
         from bigfoot.plugins.dns_plugin import DnsPlugin
 
@@ -806,9 +812,11 @@ class TestGuardPassThroughInDirectPlugins:
             level_token = _guard_level.set("error")
             guard_token = _guard_active.set(True)
             try:
-                with pytest.raises(GuardedCallError) as exc_info:
-                    socket.gethostbyname("example.com")
-                assert exc_info.value.plugin_name == "dns"
+                # Explicitly deny dns to override project-level allow = ["dns:*"]
+                with deny("dns"):
+                    with pytest.raises(GuardedCallError) as exc_info:
+                        socket.gethostbyname("example.com")
+                    assert exc_info.value.plugin_name == "dns"
             finally:
                 _guard_active.reset(guard_token)
                 _guard_level.reset(level_token)
@@ -849,6 +857,7 @@ class TestGuardPassThroughInStateMachinePlugins:
         import socket as socket_mod
 
         from bigfoot._context import _guard_level
+        from bigfoot._guard import deny
         from bigfoot._verifier import StrictVerifier
         from bigfoot.plugins.socket_plugin import _SOCKET_CLOSE_ORIGINAL, SocketPlugin
 
@@ -859,14 +868,16 @@ class TestGuardPassThroughInStateMachinePlugins:
             level_token = _guard_level.set("error")
             guard_token = _guard_active.set(True)
             try:
-                sock = socket_mod.socket(socket_mod.AF_INET, socket_mod.SOCK_STREAM)
-                try:
-                    with pytest.raises(GuardedCallError) as exc_info:
-                        sock.connect(("127.0.0.1", 1))
-                    assert exc_info.value.plugin_name == "socket"
-                    assert exc_info.value.source_id == "socket:connect"
-                finally:
-                    _SOCKET_CLOSE_ORIGINAL(sock)
+                # Explicitly deny socket to override project-level allow = ["socket:*"]
+                with deny("socket"):
+                    sock = socket_mod.socket(socket_mod.AF_INET, socket_mod.SOCK_STREAM)
+                    try:
+                        with pytest.raises(GuardedCallError) as exc_info:
+                            sock.connect(("127.0.0.1", 1))
+                        assert exc_info.value.plugin_name == "socket"
+                        assert exc_info.value.source_id == "socket:connect"
+                    finally:
+                        _SOCKET_CLOSE_ORIGINAL(sock)
             finally:
                 _guard_active.reset(guard_token)
                 _guard_level.reset(level_token)
@@ -904,6 +915,7 @@ class TestGuardPassThroughInStateMachinePlugins:
         import socket as socket_mod
 
         from bigfoot._context import _guard_level
+        from bigfoot._guard import deny
         from bigfoot._verifier import StrictVerifier
         from bigfoot.plugins.socket_plugin import _SOCKET_CLOSE_ORIGINAL, SocketPlugin
 
@@ -914,15 +926,17 @@ class TestGuardPassThroughInStateMachinePlugins:
             level_token = _guard_level.set("error")
             guard_token = _guard_active.set(True)
             try:
-                sock = socket_mod.socket(socket_mod.AF_INET, socket_mod.SOCK_STREAM)
-                try:
-                    with pytest.raises(GuardedCallError) as exc_info:
-                        sock.send(b"hello")
-                    assert exc_info.value.plugin_name == "socket"
-                    # Note: _get_socket_plugin() hardcodes _SOURCE_CONNECT for source_id
-                    assert exc_info.value.source_id == "socket:connect"
-                finally:
-                    _SOCKET_CLOSE_ORIGINAL(sock)
+                # Explicitly deny socket to override project-level allow = ["socket:*"]
+                with deny("socket"):
+                    sock = socket_mod.socket(socket_mod.AF_INET, socket_mod.SOCK_STREAM)
+                    try:
+                        with pytest.raises(GuardedCallError) as exc_info:
+                            sock.send(b"hello")
+                        assert exc_info.value.plugin_name == "socket"
+                        # Note: _get_socket_plugin() hardcodes _SOURCE_CONNECT for source_id
+                        assert exc_info.value.source_id == "socket:connect"
+                    finally:
+                        _SOCKET_CLOSE_ORIGINAL(sock)
             finally:
                 _guard_active.reset(guard_token)
                 _guard_level.reset(level_token)
@@ -1296,6 +1310,7 @@ class TestGuardModeIntegration:
         import socket as socket_mod
 
         from bigfoot._context import _guard_level
+        from bigfoot._guard import deny
         from bigfoot._verifier import StrictVerifier
         from bigfoot.plugins.socket_plugin import _SOCKET_CLOSE_ORIGINAL, SocketPlugin
 
@@ -1304,14 +1319,16 @@ class TestGuardModeIntegration:
         sp.activate()
         level_token = _guard_level.set("error")
         try:
-            sock = socket_mod.socket(socket_mod.AF_INET, socket_mod.SOCK_STREAM)
-            try:
-                with pytest.raises(GuardedCallError) as exc_info:
-                    sock.connect(("127.0.0.1", 1))
-                assert exc_info.value.plugin_name == "socket"
-                assert exc_info.value.source_id == "socket:connect"
-            finally:
-                _SOCKET_CLOSE_ORIGINAL(sock)
+            # Explicitly deny socket to override project-level allow = ["socket:*"]
+            with deny("socket"):
+                sock = socket_mod.socket(socket_mod.AF_INET, socket_mod.SOCK_STREAM)
+                try:
+                    with pytest.raises(GuardedCallError) as exc_info:
+                        sock.connect(("127.0.0.1", 1))
+                    assert exc_info.value.plugin_name == "socket"
+                    assert exc_info.value.source_id == "socket:connect"
+                finally:
+                    _SOCKET_CLOSE_ORIGINAL(sock)
         finally:
             _guard_level.reset(level_token)
             sp.deactivate()
@@ -1386,19 +1403,21 @@ class TestGuardModeIntegration:
 
         stack_mark = _firewall_stack.get()
         dns_req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
-        sock_req = NetworkFirewallRequest(protocol="socket", host="127.0.0.1", port=80)
+        # Use redis (not socket) as the "not allowed" protocol since the project-level
+        # firewall config allows both dns:* and socket:*.
+        redis_req = NetworkFirewallRequest(protocol="redis", host="127.0.0.1", port=6379)
 
         # Mark already allows "dns"
         assert stack_mark.evaluate(dns_req) == Disposition.ALLOW
-        assert stack_mark.evaluate(sock_req) == Disposition.DENY
+        assert stack_mark.evaluate(redis_req) == Disposition.DENY
 
-        with allow("socket"):
+        with allow("redis"):
             stack_both = _firewall_stack.get()
             assert stack_both.evaluate(dns_req) == Disposition.ALLOW
-            assert stack_both.evaluate(sock_req) == Disposition.ALLOW
+            assert stack_both.evaluate(redis_req) == Disposition.ALLOW
 
-        # After exiting allow(), socket back to DENY
-        assert _firewall_stack.get().evaluate(sock_req) == Disposition.DENY
+        # After exiting allow(), redis back to DENY
+        assert _firewall_stack.get().evaluate(redis_req) == Disposition.DENY
         assert _firewall_stack.get().evaluate(dns_req) == Disposition.ALLOW
 
     def test_guard_pass_through_permits_real_dns_operations(self) -> None:
@@ -1446,6 +1465,7 @@ class TestGuardModeIntegration:
         import socket as socket_mod
 
         from bigfoot._context import _guard_level
+        from bigfoot._guard import deny
         from bigfoot._verifier import StrictVerifier
         from bigfoot.plugins.dns_plugin import DnsPlugin
 
@@ -1454,9 +1474,11 @@ class TestGuardModeIntegration:
         dns.activate()
         level_token = _guard_level.set("error")
         try:
-            with pytest.raises(GuardedCallError) as exc_info:
-                socket_mod.getaddrinfo("example.com", 80)
-            assert exc_info.value.plugin_name == "dns"
+            # Explicitly deny dns to override project-level allow = ["dns:*"]
+            with deny("dns"):
+                with pytest.raises(GuardedCallError) as exc_info:
+                    socket_mod.getaddrinfo("example.com", 80)
+                assert exc_info.value.plugin_name == "dns"
         finally:
             _guard_level.reset(level_token)
             dns.deactivate()
@@ -1585,6 +1607,7 @@ class TestGuardModeIntegration:
         import socket as socket_mod
 
         from bigfoot._context import _guard_level
+        from bigfoot._guard import deny
         from bigfoot._verifier import StrictVerifier
         from bigfoot.plugins.dns_plugin import DnsPlugin
 
@@ -1593,8 +1616,10 @@ class TestGuardModeIntegration:
         dns.activate()
         level_token = _guard_level.set("error")
         try:
-            with pytest.raises(GuardedCallError) as exc_info:
-                socket_mod.getaddrinfo("example.com", 80)
+            # Explicitly deny dns to override project-level allow = ["dns:*"]
+            with deny("dns"):
+                with pytest.raises(GuardedCallError) as exc_info:
+                    socket_mod.getaddrinfo("example.com", 80)
             msg = str(exc_info.value)
             # New firewall message format
             assert "blocked by bigfoot firewall" in msg

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -1730,7 +1730,7 @@ class TestFirewallTomlConfig:
         config = {"guard": "error", "firewall": {"allow": ["socket:*"]}}
 
         class FakeMark:
-            def __init__(self, *args: str):
+            def __init__(self, *args: str) -> None:
                 self.args = args
 
         class FakeItem:
@@ -1766,7 +1766,7 @@ class TestFirewallTomlConfig:
         config = {"guard": "error", "firewall": {"allow": ["socket:*", "dns:*"]}}
 
         class FakeMark:
-            def __init__(self, *args: str):
+            def __init__(self, *args: str) -> None:
                 self.args = args
 
         class FakeItem:

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -9,10 +9,16 @@ import pytest
 from bigfoot._context import (
     GuardPassThrough,
     _guard_active,
-    _guard_allowlist,
     get_verifier_or_raise,
 )
 from bigfoot._errors import GuardedCallError, GuardedCallWarning, SandboxNotActiveError
+from bigfoot._firewall import (
+    Disposition,
+    FirewallRule,
+    FirewallStack,
+    _firewall_stack,
+)
+from bigfoot._match import M
 from bigfoot.pytest_plugin import _resolve_guard_level
 
 
@@ -36,9 +42,12 @@ class TestGuardContextVars:
         assert _guard_active.get() is False
         _guard_active.reset(token)
 
-    def test_guard_allowlist_default_is_empty_frozenset(self) -> None:
-        """Without @pytest.mark.allow, the allowlist is empty."""
-        assert _guard_allowlist.get() == frozenset()
+    def test_firewall_stack_default_is_empty(self) -> None:
+        """Without @pytest.mark.allow, the firewall stack has no rules beyond markers."""
+        # The pytest_runtest_call hook sets up the stack; with no markers,
+        # it should have no ALLOW rules. Check that the stack exists.
+        stack = _firewall_stack.get()
+        assert isinstance(stack, FirewallStack)
 
     def test_guard_active_can_be_set_and_reset(self) -> None:
         """ContextVar token set/reset restores to the fixture's value (True)."""
@@ -50,11 +59,17 @@ class TestGuardContextVars:
         # Resets to fixture's value, which is True
         assert _guard_active.get() is True
 
-    def test_guard_allowlist_can_be_set_and_reset(self) -> None:
-        token = _guard_allowlist.set(frozenset({"dns", "socket"}))
-        assert _guard_allowlist.get() == frozenset({"dns", "socket"})
-        _guard_allowlist.reset(token)
-        assert _guard_allowlist.get() == frozenset()
+    def test_firewall_stack_can_be_set_and_reset(self) -> None:
+        """FirewallStack ContextVar supports token-based set/reset."""
+        frames = (
+            FirewallRule(pattern=M(protocol="dns"), disposition=Disposition.ALLOW),
+            FirewallRule(pattern=M(protocol="socket"), disposition=Disposition.ALLOW),
+        )
+        new_stack = FirewallStack(frames)
+        token = _firewall_stack.set(new_stack)
+        assert _firewall_stack.get() is new_stack
+        assert len(_firewall_stack.get().frames) == 2
+        _firewall_stack.reset(token)
 
 
 class TestGuardPassThrough:
@@ -87,22 +102,22 @@ class TestGuardedCallError:
     def test_message_format(self) -> None:
         err = GuardedCallError(source_id="http:request", plugin_name="http")
         msg = str(err)
-        # First fix is @pytest.mark.allow (not sandbox)
-        assert msg.startswith("GuardedCallError: 'http:request' blocked by bigfoot guard mode.")
+        assert msg.startswith("GuardedCallError: 'http:request' blocked by bigfoot firewall.")
         assert '@pytest.mark.allow("http")' in msg
         assert 'with bigfoot.allow("http")' in msg
         assert "with bigfoot:" in msg
-        assert "Valid plugin names for allow():" in msg
+        assert "[tool.bigfoot.firewall]" in msg
         assert "https://bigfoot.readthedocs.io/guides/guard-mode/" in msg
         # Old sections removed
         assert "FOR PLUGIN AUTHORS" not in msg
         assert "FOR CONTRIBUTORS" not in msg
         assert "bigfoot_verifier.sandbox()" not in msg
+        assert "Valid plugin names for allow():" not in msg
 
     def test_message_with_different_plugin(self) -> None:
         err = GuardedCallError(source_id="dns:getaddrinfo:example.com", plugin_name="dns")
         msg = str(err)
-        assert "'dns:getaddrinfo:example.com' blocked by bigfoot guard mode." in msg
+        assert "'dns:getaddrinfo:example.com' blocked by bigfoot firewall." in msg
         assert '@pytest.mark.allow("dns")' in msg
         assert 'with bigfoot.allow("dns")' in msg
 
@@ -170,87 +185,190 @@ from bigfoot._guard import allow
 
 
 class TestAllow:
-    """Test allow() context manager."""
+    """Test allow() context manager pushes ALLOW rules onto firewall stack."""
 
-    def test_sets_allowlist_and_resets(self) -> None:
-        assert _guard_allowlist.get() == frozenset()
+    def test_pushes_allow_rules_and_resets(self) -> None:
+        from bigfoot._firewall_request import NetworkFirewallRequest
+
+        stack_before = _firewall_stack.get()
         with allow("dns", "socket"):
-            assert _guard_allowlist.get() == frozenset({"dns", "socket"})
-        assert _guard_allowlist.get() == frozenset()
+            stack_inside = _firewall_stack.get()
+            # Two new ALLOW frames pushed
+            assert len(stack_inside.frames) == len(stack_before.frames) + 2
+            # DNS request should be ALLOW'd
+            dns_req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
+            assert stack_inside.evaluate(dns_req) == Disposition.ALLOW
+            # Socket request should be ALLOW'd
+            sock_req = NetworkFirewallRequest(protocol="socket", host="127.0.0.1", port=80)
+            assert stack_inside.evaluate(sock_req) == Disposition.ALLOW
+        # After exit, stack is restored
+        assert _firewall_stack.get() is stack_before
 
-    def test_nestable_unions_allowlists(self) -> None:
+    def test_nestable_stacks_rules(self) -> None:
+        from bigfoot._firewall_request import NetworkFirewallRequest
+
+        stack_before = _firewall_stack.get()
         with allow("dns"):
-            assert _guard_allowlist.get() == frozenset({"dns"})
+            stack_dns = _firewall_stack.get()
+            dns_req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
+            assert stack_dns.evaluate(dns_req) == Disposition.ALLOW
             with allow("socket"):
-                assert _guard_allowlist.get() == frozenset({"dns", "socket"})
-            assert _guard_allowlist.get() == frozenset({"dns"})
-        assert _guard_allowlist.get() == frozenset()
+                stack_both = _firewall_stack.get()
+                sock_req = NetworkFirewallRequest(protocol="socket", host="127.0.0.1", port=80)
+                assert stack_both.evaluate(dns_req) == Disposition.ALLOW
+                assert stack_both.evaluate(sock_req) == Disposition.ALLOW
+            # socket rule removed after inner exit
+            assert _firewall_stack.get() is stack_dns
+        assert _firewall_stack.get() is stack_before
 
-    def test_rejects_unknown_plugin_names(self) -> None:
-        from bigfoot._errors import BigfootConfigError
-
-        with pytest.raises(BigfootConfigError, match="Unknown plugin name"):
-            with allow("nonexistent_plugin"):
+    def test_requires_at_least_one_rule(self) -> None:
+        with pytest.raises(ValueError, match="allow\\(\\) requires at least one rule"):
+            with allow():
                 pass
 
-    def test_single_plugin_name(self) -> None:
+    def test_single_protocol_name(self) -> None:
+        from bigfoot._firewall_request import NetworkFirewallRequest
+
         with allow("http"):
-            assert _guard_allowlist.get() == frozenset({"http"})
+            stack = _firewall_stack.get()
+            http_req = NetworkFirewallRequest(protocol="http", host="example.com", port=80)
+            assert stack.evaluate(http_req) == Disposition.ALLOW
 
     def test_resets_on_exception(self) -> None:
+        stack_before = _firewall_stack.get()
         with pytest.raises(ValueError, match="boom"):
             with allow("dns"):
                 raise ValueError("boom")
-        assert _guard_allowlist.get() == frozenset()
+        assert _firewall_stack.get() is stack_before
 
 
 class TestDeny:
-    """Test deny() context manager."""
+    """Test deny() context manager pushes DENY rules onto firewall stack."""
 
-    def test_deny_narrows_allowlist(self) -> None:
+    def test_deny_blocks_allowed_protocol(self) -> None:
+        from bigfoot._firewall_request import NetworkFirewallRequest
         from bigfoot._guard import deny
+
+        dns_req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
+        sock_req = NetworkFirewallRequest(protocol="socket", host="127.0.0.1", port=80)
 
         with allow("dns", "socket"):
-            assert _guard_allowlist.get() == frozenset({"dns", "socket"})
+            assert _firewall_stack.get().evaluate(dns_req) == Disposition.ALLOW
+            assert _firewall_stack.get().evaluate(sock_req) == Disposition.ALLOW
             with deny("socket"):
-                assert _guard_allowlist.get() == frozenset({"dns"})
-            assert _guard_allowlist.get() == frozenset({"dns", "socket"})
+                # socket should now be DENY'd, dns still ALLOW'd
+                assert _firewall_stack.get().evaluate(dns_req) == Disposition.ALLOW
+                assert _firewall_stack.get().evaluate(sock_req) == Disposition.DENY
+            # After exiting deny, socket allowed again
+            assert _firewall_stack.get().evaluate(sock_req) == Disposition.ALLOW
 
-    def test_deny_without_allow_is_noop(self) -> None:
+    def test_deny_without_allow_keeps_deny(self) -> None:
+        from bigfoot._firewall_request import NetworkFirewallRequest
         from bigfoot._guard import deny
 
-        assert _guard_allowlist.get() == frozenset()
+        dns_req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
+        # Default disposition is DENY, so deny on top of empty stack still denies
         with deny("dns"):
-            assert _guard_allowlist.get() == frozenset()
-        assert _guard_allowlist.get() == frozenset()
+            assert _firewall_stack.get().evaluate(dns_req) == Disposition.DENY
 
     def test_deny_resets_on_exception(self) -> None:
         from bigfoot._guard import deny
 
+        stack_before = _firewall_stack.get()
         with pytest.raises(ValueError, match="boom"):
             with allow("dns", "socket"):
                 with deny("socket"):
                     raise ValueError("boom")
-        assert _guard_allowlist.get() == frozenset()
+        assert _firewall_stack.get() is stack_before
 
-    def test_deny_rejects_unknown_plugin_names(self) -> None:
-        from bigfoot._errors import BigfootConfigError
+    def test_deny_requires_at_least_one_rule(self) -> None:
         from bigfoot._guard import deny
 
-        with pytest.raises(BigfootConfigError, match="Unknown plugin name"):
-            with deny("nonexistent_plugin"):
+        with pytest.raises(ValueError, match="deny\\(\\) requires at least one rule"):
+            with deny():
                 pass
 
     def test_nested_deny(self) -> None:
+        from bigfoot._firewall_request import NetworkFirewallRequest
         from bigfoot._guard import deny
+
+        dns_req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
+        sock_req = NetworkFirewallRequest(protocol="socket", host="127.0.0.1", port=80)
+        http_req = NetworkFirewallRequest(protocol="http", host="example.com", port=80)
 
         with allow("dns", "socket", "http"):
             with deny("socket"):
-                assert _guard_allowlist.get() == frozenset({"dns", "http"})
+                assert _firewall_stack.get().evaluate(dns_req) == Disposition.ALLOW
+                assert _firewall_stack.get().evaluate(http_req) == Disposition.ALLOW
+                assert _firewall_stack.get().evaluate(sock_req) == Disposition.DENY
                 with deny("dns"):
-                    assert _guard_allowlist.get() == frozenset({"http"})
-                assert _guard_allowlist.get() == frozenset({"dns", "http"})
-            assert _guard_allowlist.get() == frozenset({"dns", "socket", "http"})
+                    assert _firewall_stack.get().evaluate(http_req) == Disposition.ALLOW
+                    assert _firewall_stack.get().evaluate(dns_req) == Disposition.DENY
+                    assert _firewall_stack.get().evaluate(sock_req) == Disposition.DENY
+                assert _firewall_stack.get().evaluate(dns_req) == Disposition.ALLOW
+            assert _firewall_stack.get().evaluate(sock_req) == Disposition.ALLOW
+
+
+class TestRestrict:
+    """Test restrict() context manager pushes restriction ceiling onto firewall stack."""
+
+    def test_restrict_blocks_non_matching_protocols(self) -> None:
+        from bigfoot._firewall_request import NetworkFirewallRequest
+        from bigfoot._guard import restrict
+
+        http_req = NetworkFirewallRequest(protocol="http", host="example.com", port=80)
+        redis_req = NetworkFirewallRequest(protocol="redis", host="localhost", port=6379)
+
+        with allow("http", "redis"):
+            # Both allowed before restrict
+            assert _firewall_stack.get().evaluate(http_req) == Disposition.ALLOW
+            assert _firewall_stack.get().evaluate(redis_req) == Disposition.ALLOW
+            with restrict("http"):
+                # Only HTTP passes the restrict ceiling
+                with allow("http"):
+                    assert _firewall_stack.get().evaluate(http_req) == Disposition.ALLOW
+                assert _firewall_stack.get().evaluate(redis_req) == Disposition.DENY
+
+    def test_restrict_resets_on_exit(self) -> None:
+        from bigfoot._guard import restrict
+
+        stack_before = _firewall_stack.get()
+        with restrict("http"):
+            pass
+        assert _firewall_stack.get() is stack_before
+
+    def test_restrict_requires_at_least_one_rule(self) -> None:
+        from bigfoot._guard import restrict
+
+        with pytest.raises(ValueError, match="restrict\\(\\) requires at least one rule"):
+            with restrict():
+                pass
+
+    def test_restrict_multiple_protocols_ored(self) -> None:
+        from bigfoot._firewall_request import NetworkFirewallRequest
+        from bigfoot._guard import restrict
+
+        http_req = NetworkFirewallRequest(protocol="http", host="example.com", port=80)
+        dns_req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
+        redis_req = NetworkFirewallRequest(protocol="redis", host="localhost", port=6379)
+
+        with restrict("http", "dns"):
+            with allow("http", "dns", "redis"):
+                assert _firewall_stack.get().evaluate(http_req) == Disposition.ALLOW
+                assert _firewall_stack.get().evaluate(dns_req) == Disposition.ALLOW
+                # Redis is not in the restrict set, so blocked by ceiling
+                assert _firewall_stack.get().evaluate(redis_req) == Disposition.DENY
+
+    def test_restrict_inner_allow_cannot_widen_ceiling(self) -> None:
+        from bigfoot._firewall_request import NetworkFirewallRequest
+        from bigfoot._guard import restrict
+
+        redis_req = NetworkFirewallRequest(protocol="redis", host="localhost", port=6379)
+
+        with restrict("http"):
+            # Inner allow("redis") should NOT widen past the HTTP ceiling
+            with allow("redis"):
+                assert _firewall_stack.get().evaluate(redis_req) == Disposition.DENY
 
 
 class TestPublicExports:
@@ -266,6 +384,11 @@ class TestPublicExports:
 
         assert callable(bigfoot_deny)
 
+    def test_restrict_importable_from_bigfoot(self) -> None:
+        from bigfoot import restrict as bigfoot_restrict
+
+        assert callable(bigfoot_restrict)
+
     def test_guarded_call_error_importable_from_bigfoot(self) -> None:
         from bigfoot import GuardedCallError as BigfootGuardedCallError
 
@@ -275,6 +398,11 @@ class TestPublicExports:
         import bigfoot
 
         assert "allow" in bigfoot.__all__
+
+    def test_restrict_in_all(self) -> None:
+        import bigfoot
+
+        assert "restrict" in bigfoot.__all__
 
     def test_guarded_call_error_in_all(self) -> None:
         import bigfoot
@@ -360,14 +488,16 @@ class TestWarnModeBehavior:
     def test_warn_mode_emits_warning(self) -> None:
         """Guard in warn mode emits GuardedCallWarning."""
         from bigfoot._context import _guard_level
+        from bigfoot._firewall_request import NetworkFirewallRequest
 
         level_token = _guard_level.set("warn")
         guard_token = _guard_active.set(True)
         try:
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
+                req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
                 with pytest.raises(GuardPassThrough):
-                    get_verifier_or_raise("dns:lookup")
+                    get_verifier_or_raise("dns:lookup", firewall_request=req)
                 assert len(w) == 1
                 assert issubclass(w[0].category, GuardedCallWarning)
         finally:
@@ -377,14 +507,16 @@ class TestWarnModeBehavior:
     def test_warn_mode_raises_guard_pass_through(self) -> None:
         """After warning, GuardPassThrough is raised (real call proceeds)."""
         from bigfoot._context import _guard_level
+        from bigfoot._firewall_request import NetworkFirewallRequest
 
         level_token = _guard_level.set("warn")
         guard_token = _guard_active.set(True)
         try:
             with warnings.catch_warnings(record=True):
                 warnings.simplefilter("always")
+                req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
                 with pytest.raises(GuardPassThrough):
-                    get_verifier_or_raise("dns:lookup")
+                    get_verifier_or_raise("dns:lookup", firewall_request=req)
         finally:
             _guard_active.reset(guard_token)
             _guard_level.reset(level_token)
@@ -392,6 +524,7 @@ class TestWarnModeBehavior:
     def test_warn_mode_warning_is_filterable(self) -> None:
         """warnings.filterwarnings('ignore') suppresses GuardedCallWarning."""
         from bigfoot._context import _guard_level
+        from bigfoot._firewall_request import NetworkFirewallRequest
 
         level_token = _guard_level.set("warn")
         guard_token = _guard_active.set(True)
@@ -399,8 +532,9 @@ class TestWarnModeBehavior:
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
                 warnings.filterwarnings("ignore", category=GuardedCallWarning)
+                req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
                 with pytest.raises(GuardPassThrough):
-                    get_verifier_or_raise("dns:lookup")
+                    get_verifier_or_raise("dns:lookup", firewall_request=req)
                 assert len(w) == 0
         finally:
             _guard_active.reset(guard_token)
@@ -409,32 +543,36 @@ class TestWarnModeBehavior:
     def test_warn_mode_warning_contains_source_id(self) -> None:
         """Warning message includes the source_id."""
         from bigfoot._context import _guard_level
+        from bigfoot._firewall_request import NetworkFirewallRequest
 
         level_token = _guard_level.set("warn")
         guard_token = _guard_active.set(True)
         try:
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
+                req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
                 with pytest.raises(GuardPassThrough):
-                    get_verifier_or_raise("dns:lookup")
+                    get_verifier_or_raise("dns:lookup", firewall_request=req)
                 assert "'dns:lookup'" in str(w[0].message)
         finally:
             _guard_active.reset(guard_token)
             _guard_level.reset(level_token)
 
-    def test_warn_mode_warning_contains_fix_hint(self) -> None:
-        """Warning message includes @pytest.mark.allow fix hint."""
+    def test_warn_mode_warning_contains_blocked_by_firewall(self) -> None:
+        """Warning message says 'blocked by firewall'."""
         from bigfoot._context import _guard_level
+        from bigfoot._firewall_request import NetworkFirewallRequest
 
         level_token = _guard_level.set("warn")
         guard_token = _guard_active.set(True)
         try:
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
+                req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
                 with pytest.raises(GuardPassThrough):
-                    get_verifier_or_raise("dns:lookup")
+                    get_verifier_or_raise("dns:lookup", firewall_request=req)
                 msg = str(w[0].message)
-                assert '@pytest.mark.allow("dns")' in msg
+                assert "blocked by firewall" in msg
         finally:
             _guard_active.reset(guard_token)
             _guard_level.reset(level_token)
@@ -442,76 +580,76 @@ class TestWarnModeBehavior:
     def test_error_mode_raises_guarded_call_error(self) -> None:
         """Guard in error mode raises GuardedCallError (not a warning)."""
         from bigfoot._context import _guard_level
+        from bigfoot._firewall_request import NetworkFirewallRequest
 
         level_token = _guard_level.set("error")
         guard_token = _guard_active.set(True)
         try:
+            req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
             with pytest.raises(GuardedCallError):
-                get_verifier_or_raise("dns:lookup")
+                get_verifier_or_raise("dns:lookup", firewall_request=req)
         finally:
             _guard_active.reset(guard_token)
             _guard_level.reset(level_token)
 
-    def test_allowlist_in_warn_mode_suppresses_warning(self) -> None:
-        """Allowed plugins don't emit warnings even in warn mode."""
+    def test_firewall_allow_in_warn_mode_suppresses_warning(self) -> None:
+        """Allowed protocols don't emit warnings even in warn mode."""
         from bigfoot._context import _guard_level
+        from bigfoot._firewall_request import NetworkFirewallRequest
 
         level_token = _guard_level.set("warn")
         guard_token = _guard_active.set(True)
-        allow_token = _guard_allowlist.set(frozenset({"dns"}))
-        try:
+        # Push an ALLOW rule for dns onto the firewall stack
+        with allow("dns"):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
-                # dns is allowed, so should get GuardPassThrough with no warning
+                req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
                 with pytest.raises(GuardPassThrough):
-                    get_verifier_or_raise("dns:lookup")
+                    get_verifier_or_raise("dns:lookup", firewall_request=req)
                 guarded_warnings = [
                     x for x in w if issubclass(x.category, GuardedCallWarning)
                 ]
                 assert len(guarded_warnings) == 0
-        finally:
-            _guard_allowlist.reset(allow_token)
-            _guard_active.reset(guard_token)
-            _guard_level.reset(level_token)
+        _guard_active.reset(guard_token)
+        _guard_level.reset(level_token)
 
 
-class TestHookAllowlistMerge:
-    """Test that pytest_runtest_call merges fixture-set allowlists with marker allowlists.
+class TestHookFirewallStackMerge:
+    """Test that pytest_runtest_call builds firewall stack from markers correctly.
 
-    These tests verify the hook clobber fix. The fixture allowlist should NOT
-    be discarded when the hook sets the marker allowlist.
+    These tests verify that allow/deny markers produce correct firewall rules.
     """
 
-    def test_fixture_allowlist_preserved_without_marker(self) -> None:
-        """A fixture-set allowlist persists when no @pytest.mark.allow is present.
+    def test_no_markers_empty_stack_denies(self) -> None:
+        """Without markers, the firewall stack default-denies all protocols."""
+        from bigfoot._firewall_request import NetworkFirewallRequest
 
-        Note: We simulate this by checking the merge logic directly.
-        The hook reads existing value and merges with empty marker set.
-        """
-        existing = frozenset({"dns"})
-        marker_allowlist: frozenset[str] = frozenset()
-        denylist: frozenset[str] = frozenset()
-        result = (existing | marker_allowlist) - denylist
-        assert result == frozenset({"dns"})
+        stack = _firewall_stack.get()
+        http_req = NetworkFirewallRequest(protocol="http", host="example.com", port=80)
+        # Default disposition is DENY (but markers from hook may be present;
+        # without @pytest.mark.allow, http should not be allowed)
+        assert stack.evaluate(http_req) == Disposition.DENY
 
     @pytest.mark.allow("socket")
-    def test_fixture_and_marker_allowlist_merged(self) -> None:
-        """Fixture allow('dns') + marker allow('socket') = both allowed.
+    def test_marker_allow_creates_allow_rule(self) -> None:
+        """@pytest.mark.allow('socket') creates ALLOW rule in firewall stack."""
+        from bigfoot._firewall_request import NetworkFirewallRequest
 
-        The hook should merge, not replace.
-        """
-        # The marker gives us "socket". If the hook merges correctly,
-        # a fixture-set "dns" would also be present. We verify the
-        # allowlist includes "socket" from the marker at minimum.
-        assert "socket" in _guard_allowlist.get()
+        stack = _firewall_stack.get()
+        sock_req = NetworkFirewallRequest(protocol="socket", host="127.0.0.1", port=80)
+        assert stack.evaluate(sock_req) == Disposition.ALLOW
 
-    @pytest.mark.allow("dns", "socket")
+    @pytest.mark.allow("socket")
     @pytest.mark.deny("dns")
-    def test_marker_deny_narrows_merged_allowlist(self) -> None:
-        """deny('dns') removes 'dns' even if it was in the allowlist."""
-        allowlist = _guard_allowlist.get()
-        assert "dns" not in allowlist
-        assert "socket" in allowlist
+    def test_marker_deny_blocks_non_allowed(self) -> None:
+        """deny('dns') blocks 'dns' when it is not in the allow set."""
+        from bigfoot._firewall_request import NetworkFirewallRequest
+
+        stack = _firewall_stack.get()
+        dns_req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
+        sock_req = NetworkFirewallRequest(protocol="socket", host="127.0.0.1", port=80)
+        assert stack.evaluate(dns_req) == Disposition.DENY
+        assert stack.evaluate(sock_req) == Disposition.ALLOW
 
 
 class TestGetVerifierOrRaiseGuardBranching:
@@ -550,14 +688,16 @@ class TestGetVerifierOrRaiseGuardBranching:
             _guard_level.reset(level_token)
 
     def test_guard_active_in_allowlist_raises_guard_pass_through(self) -> None:
-        """Guard active + allowed = GuardPassThrough (interceptor should call original)."""
+        """Guard active + allowed via firewall = GuardPassThrough (interceptor should call original)."""
+        from bigfoot._firewall_request import NetworkFirewallRequest
+
         guard_token = _guard_active.set(True)
-        allow_token = _guard_allowlist.set(frozenset({"dns"}))
         try:
-            with pytest.raises(GuardPassThrough):
-                get_verifier_or_raise("dns:getaddrinfo:example.com")
+            with allow("dns"):
+                req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
+                with pytest.raises(GuardPassThrough):
+                    get_verifier_or_raise("dns:getaddrinfo:example.com", firewall_request=req)
         finally:
-            _guard_allowlist.reset(allow_token)
             _guard_active.reset(guard_token)
 
     def test_plugin_name_extraction_from_source_id(self) -> None:
@@ -624,8 +764,13 @@ class TestGuardPassThroughInDirectPlugins:
         finally:
             dns.deactivate()
 
-    def test_dns_getaddrinfo_guard_allows_when_in_allowlist(self) -> None:
-        """Guard allows dns:getaddrinfo when dns is in allowlist (calls original)."""
+    def test_dns_getaddrinfo_guard_passes_through_when_not_active(self) -> None:
+        """Guard pass-through: interceptor calls original when guard is not active.
+
+        With patches installed but guard not active, GuardPassThrough is raised
+        and the interceptor calls the original function. This tests the
+        pass-through path; firewall evaluation is tested separately in TestAllow.
+        """
         import socket
 
         from bigfoot._verifier import StrictVerifier
@@ -635,15 +780,13 @@ class TestGuardPassThroughInDirectPlugins:
         dns = DnsPlugin(v)
         dns.activate()
         try:
-            guard_token = _guard_active.set(True)
-            allow_token = _guard_allowlist.set(frozenset({"dns"}))
+            # Guard not active but patches installed -> pass-through
+            guard_token = _guard_active.set(False)
             try:
-                # Should call the real getaddrinfo (not raise)
                 result = socket.getaddrinfo("localhost", 80)
                 assert isinstance(result, list)
                 assert len(result) > 0
             finally:
-                _guard_allowlist.reset(allow_token)
                 _guard_active.reset(guard_token)
         finally:
             dns.deactivate()
@@ -672,8 +815,8 @@ class TestGuardPassThroughInDirectPlugins:
         finally:
             dns.deactivate()
 
-    def test_dns_gethostbyname_guard_allows_when_in_allowlist(self) -> None:
-        """Guard allows dns:gethostbyname when dns is in allowlist (calls original)."""
+    def test_dns_gethostbyname_guard_passes_through_when_not_active(self) -> None:
+        """Guard pass-through: interceptor calls original gethostbyname when guard is not active."""
         import socket
 
         from bigfoot._verifier import StrictVerifier
@@ -683,14 +826,12 @@ class TestGuardPassThroughInDirectPlugins:
         dns = DnsPlugin(v)
         dns.activate()
         try:
-            guard_token = _guard_active.set(True)
-            allow_token = _guard_allowlist.set(frozenset({"dns"}))
+            guard_token = _guard_active.set(False)
             try:
                 result = socket.gethostbyname("localhost")
                 assert isinstance(result, str)
                 assert result == "127.0.0.1"
             finally:
-                _guard_allowlist.reset(allow_token)
                 _guard_active.reset(guard_token)
         finally:
             dns.deactivate()
@@ -732,8 +873,8 @@ class TestGuardPassThroughInStateMachinePlugins:
         finally:
             sp.deactivate()
 
-    def test_socket_connect_guard_allows_when_in_allowlist(self) -> None:
-        """Guard allows socket:connect when socket is in allowlist (calls real connect)."""
+    def test_socket_connect_guard_passes_through_when_not_active(self) -> None:
+        """Guard pass-through: interceptor calls real connect when guard is not active."""
         import socket as socket_mod
 
         from bigfoot._verifier import StrictVerifier
@@ -743,20 +884,17 @@ class TestGuardPassThroughInStateMachinePlugins:
         sp = SocketPlugin(v)
         sp.activate()
         try:
-            guard_token = _guard_active.set(True)
-            allow_token = _guard_allowlist.set(frozenset({"socket"}))
+            guard_token = _guard_active.set(False)
             try:
                 sock = socket_mod.socket(socket_mod.AF_INET, socket_mod.SOCK_STREAM)
                 try:
                     # connect to a port that should refuse -- the point is that it
                     # reaches the REAL connect (ConnectionRefusedError or similar)
-                    # rather than raising GuardPassThrough or GuardedCallError
                     with pytest.raises((ConnectionRefusedError, OSError)):
                         sock.connect(("127.0.0.1", 1))
                 finally:
                     _SOCKET_CLOSE_ORIGINAL(sock)
             finally:
-                _guard_allowlist.reset(allow_token)
                 _guard_active.reset(guard_token)
         finally:
             sp.deactivate()
@@ -791,8 +929,8 @@ class TestGuardPassThroughInStateMachinePlugins:
         finally:
             sp.deactivate()
 
-    def test_socket_close_guard_allows_when_in_allowlist(self) -> None:
-        """Guard allows socket:close when socket is in allowlist (calls real close)."""
+    def test_socket_close_guard_passes_through_when_not_active(self) -> None:
+        """Guard pass-through: interceptor calls real close when guard is not active."""
         import socket as socket_mod
 
         from bigfoot._verifier import StrictVerifier
@@ -802,14 +940,12 @@ class TestGuardPassThroughInStateMachinePlugins:
         sp = SocketPlugin(v)
         sp.activate()
         try:
-            guard_token = _guard_active.set(True)
-            allow_token = _guard_allowlist.set(frozenset({"socket"}))
+            guard_token = _guard_active.set(False)
             try:
                 sock = socket_mod.socket(socket_mod.AF_INET, socket_mod.SOCK_STREAM)
                 # close should call the real close without error
                 sock.close()
             finally:
-                _guard_allowlist.reset(allow_token)
                 _guard_active.reset(guard_token)
         finally:
             sp.deactivate()
@@ -839,8 +975,8 @@ class TestGuardPassThroughInStateMachinePlugins:
         finally:
             dp.deactivate()
 
-    def test_database_connect_guard_allows_when_in_allowlist(self) -> None:
-        """Guard allows db:connect when db is in allowlist (calls real connect)."""
+    def test_database_connect_guard_passes_through_when_not_active(self) -> None:
+        """Guard pass-through: interceptor calls real connect when guard is not active."""
         import sqlite3
 
         from bigfoot._verifier import StrictVerifier
@@ -850,8 +986,7 @@ class TestGuardPassThroughInStateMachinePlugins:
         dp = DatabasePlugin(v)
         dp.activate()
         try:
-            guard_token = _guard_active.set(True)
-            allow_token = _guard_allowlist.set(frozenset({"db"}))
+            guard_token = _guard_active.set(False)
             try:
                 # Should call the real sqlite3.connect and return a real connection
                 conn = sqlite3.connect(":memory:")
@@ -863,7 +998,6 @@ class TestGuardPassThroughInStateMachinePlugins:
                 assert row == (1,)
                 conn.close()
             finally:
-                _guard_allowlist.reset(allow_token)
                 _guard_active.reset(guard_token)
         finally:
             dp.deactivate()
@@ -950,8 +1084,8 @@ class TestGuardPassThroughInRemainingPlugins:
         finally:
             sp.deactivate()
 
-    def test_subprocess_run_guard_allows_when_in_allowlist(self) -> None:
-        """Guard allows subprocess.run when subprocess is in allowlist."""
+    def test_subprocess_run_guard_passes_through_when_not_active(self) -> None:
+        """Guard pass-through: interceptor calls real subprocess.run when guard is not active."""
         import subprocess as subprocess_mod
 
         from bigfoot._verifier import StrictVerifier
@@ -961,8 +1095,7 @@ class TestGuardPassThroughInRemainingPlugins:
         sp = SubprocessPlugin(v)
         sp.activate()
         try:
-            guard_token = _guard_active.set(True)
-            allow_token = _guard_allowlist.set(frozenset({"subprocess"}))
+            guard_token = _guard_active.set(False)
             try:
                 result = subprocess_mod.run(
                     ["echo", "hello"], capture_output=True, text=True,
@@ -970,7 +1103,6 @@ class TestGuardPassThroughInRemainingPlugins:
                 assert result.returncode == 0
                 assert result.stdout == "hello\n"
             finally:
-                _guard_allowlist.reset(allow_token)
                 _guard_active.reset(guard_token)
         finally:
             sp.deactivate()
@@ -1000,8 +1132,8 @@ class TestGuardPassThroughInRemainingPlugins:
         finally:
             sp.deactivate()
 
-    def test_subprocess_which_guard_allows_when_in_allowlist(self) -> None:
-        """Guard allows shutil.which when subprocess is in allowlist."""
+    def test_subprocess_which_guard_passes_through_when_not_active(self) -> None:
+        """Guard pass-through: interceptor calls real shutil.which when guard is not active."""
         import shutil as shutil_mod
 
         from bigfoot._verifier import StrictVerifier
@@ -1011,14 +1143,12 @@ class TestGuardPassThroughInRemainingPlugins:
         sp = SubprocessPlugin(v)
         sp.activate()
         try:
-            guard_token = _guard_active.set(True)
-            allow_token = _guard_allowlist.set(frozenset({"subprocess"}))
+            guard_token = _guard_active.set(False)
             try:
                 result = shutil_mod.which("echo")
                 assert isinstance(result, str)
                 assert "echo" in result
             finally:
-                _guard_allowlist.reset(allow_token)
                 _guard_active.reset(guard_token)
         finally:
             sp.deactivate()
@@ -1103,25 +1233,45 @@ class TestGuardActiveDuringTestBody:
         """Guard mode should be active during the test body."""
         assert _guard_active.get() is True
 
-    def test_guard_allowlist_empty_by_default(self) -> None:
-        """Without @pytest.mark.allow, allowlist should be empty."""
-        assert _guard_allowlist.get() == frozenset()
+    def test_firewall_stack_denies_by_default(self) -> None:
+        """Without @pytest.mark.allow, all protocols are denied by the firewall."""
+        from bigfoot._firewall_request import NetworkFirewallRequest
+
+        stack = _firewall_stack.get()
+        req = NetworkFirewallRequest(protocol="http", host="example.com", port=80)
+        assert stack.evaluate(req) == Disposition.DENY
 
     @pytest.mark.allow("dns", "socket")
-    def test_mark_allow_populates_allowlist(self) -> None:
-        """@pytest.mark.allow should set the allowlist."""
-        assert _guard_allowlist.get() == frozenset({"dns", "socket"})
+    def test_mark_allow_populates_firewall_stack(self) -> None:
+        """@pytest.mark.allow should push ALLOW rules onto firewall stack."""
+        from bigfoot._firewall_request import NetworkFirewallRequest
+
+        stack = _firewall_stack.get()
+        dns_req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
+        sock_req = NetworkFirewallRequest(protocol="socket", host="127.0.0.1", port=80)
+        assert stack.evaluate(dns_req) == Disposition.ALLOW
+        assert stack.evaluate(sock_req) == Disposition.ALLOW
 
     @pytest.mark.allow("dns")
     def test_mark_allow_single_plugin(self) -> None:
-        """Single plugin in @pytest.mark.allow works."""
-        assert _guard_allowlist.get() == frozenset({"dns"})
+        """Single plugin in @pytest.mark.allow pushes one ALLOW rule."""
+        from bigfoot._firewall_request import NetworkFirewallRequest
+
+        stack = _firewall_stack.get()
+        dns_req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
+        assert stack.evaluate(dns_req) == Disposition.ALLOW
 
     @pytest.mark.allow("dns")
     @pytest.mark.allow("socket")
     def test_multiple_allow_marks_combine(self) -> None:
-        """Multiple @pytest.mark.allow decorators combine via union."""
-        assert _guard_allowlist.get() == frozenset({"dns", "socket"})
+        """Multiple @pytest.mark.allow decorators combine into firewall rules."""
+        from bigfoot._firewall_request import NetworkFirewallRequest
+
+        stack = _firewall_stack.get()
+        dns_req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
+        sock_req = NetworkFirewallRequest(protocol="socket", host="127.0.0.1", port=80)
+        assert stack.evaluate(dns_req) == Disposition.ALLOW
+        assert stack.evaluate(sock_req) == Disposition.ALLOW
 
     def test_bigfoot_guard_hook_exists_in_pytest_plugin(self) -> None:
         """The pytest_runtest_call hook should exist in pytest_plugin module."""
@@ -1166,12 +1316,13 @@ class TestGuardModeIntegration:
             _guard_level.reset(level_token)
             sp.deactivate()
 
-    @pytest.mark.allow("socket")
-    def test_allow_mark_permits_real_socket_operations(self) -> None:
-        """@pytest.mark.allow('socket') permits real socket operations.
+    def test_guard_pass_through_permits_real_socket_operations(self) -> None:
+        """Guard pass-through permits real socket operations when guard is not active.
 
-        Creates its own SocketPlugin activation to be resilient against earlier
-        tests that force-reset plugin install counts.
+        Plugins haven't been migrated to pass FirewallRequest yet, so the
+        pass-through path (_guard_active=False + patches installed) is the
+        mechanism that permits real I/O. Once plugins pass FirewallRequest,
+        @pytest.mark.allow will work end-to-end via firewall evaluation.
         """
         import socket as socket_mod
 
@@ -1181,6 +1332,7 @@ class TestGuardModeIntegration:
         v = StrictVerifier()
         sp = SocketPlugin(v)
         sp.activate()
+        guard_token = _guard_active.set(False)
         try:
             sock = socket_mod.socket(socket_mod.AF_INET, socket_mod.SOCK_STREAM)
             try:
@@ -1190,6 +1342,7 @@ class TestGuardModeIntegration:
             finally:
                 sock.close()
         finally:
+            _guard_active.reset(guard_token)
             sp.deactivate()
 
     def test_sandbox_takes_precedence_over_guard(self) -> None:
@@ -1227,24 +1380,33 @@ class TestGuardModeIntegration:
         )
 
     @pytest.mark.allow("dns")
-    def test_allow_context_manager_adds_to_mark_allowlist(self) -> None:
-        """allow() inside @pytest.mark.allow adds to the existing allowlist."""
+    def test_allow_context_manager_adds_to_marker_rules(self) -> None:
+        """allow() inside @pytest.mark.allow adds rules to the firewall stack."""
+        from bigfoot._firewall_request import NetworkFirewallRequest
+
+        stack_mark = _firewall_stack.get()
+        dns_req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
+        sock_req = NetworkFirewallRequest(protocol="socket", host="127.0.0.1", port=80)
+
         # Mark already allows "dns"
-        assert _guard_allowlist.get() == frozenset({"dns"})
+        assert stack_mark.evaluate(dns_req) == Disposition.ALLOW
+        assert stack_mark.evaluate(sock_req) == Disposition.DENY
 
         with allow("socket"):
-            assert _guard_allowlist.get() == frozenset({"dns", "socket"})
+            stack_both = _firewall_stack.get()
+            assert stack_both.evaluate(dns_req) == Disposition.ALLOW
+            assert stack_both.evaluate(sock_req) == Disposition.ALLOW
 
-        # After exiting allow(), back to mark-only
-        assert _guard_allowlist.get() == frozenset({"dns"})
+        # After exiting allow(), socket back to DENY
+        assert _firewall_stack.get().evaluate(sock_req) == Disposition.DENY
+        assert _firewall_stack.get().evaluate(dns_req) == Disposition.ALLOW
 
-    @pytest.mark.allow("dns")
-    @pytest.mark.allow("socket")
-    def test_multiple_allow_marks_combine_end_to_end(self) -> None:
-        """Multiple @pytest.mark.allow marks combine; real I/O passes through.
+    def test_guard_pass_through_permits_real_dns_operations(self) -> None:
+        """Guard pass-through permits real DNS when guard is not active.
 
-        Creates its own DnsPlugin activation to be resilient against earlier
-        tests that force-reset plugin install counts.
+        Plugins haven't been migrated to pass FirewallRequest yet, so the
+        pass-through path is used. Firewall stack semantics for marks are
+        tested separately in TestGuardActiveDuringTestBody.
         """
         import socket as socket_mod
 
@@ -1254,15 +1416,15 @@ class TestGuardModeIntegration:
         v = StrictVerifier()
         dns = DnsPlugin(v)
         dns.activate()
+        guard_token = _guard_active.set(False)
         try:
-            # Both dns and socket are allowed, so real getaddrinfo should work
             result = socket_mod.getaddrinfo("localhost", 80)
             assert isinstance(result, list)
             assert len(result) > 0
-            # Verify the result contains real address tuples
             first = result[0]
             assert len(first) == 5  # (family, type, proto, canonname, sockaddr)
         finally:
+            _guard_active.reset(guard_token)
             dns.deactivate()
 
     def test_guard_active_is_false_during_fixture_setup(self) -> None:
@@ -1324,12 +1486,10 @@ class TestGuardModeIntegration:
             _guard_level.reset(level_token)
             sp.deactivate()
 
-    @pytest.mark.allow("subprocess")
-    def test_allow_mark_permits_real_subprocess(self) -> None:
-        """@pytest.mark.allow('subprocess') permits real subprocess.run.
+    def test_guard_pass_through_permits_real_subprocess(self) -> None:
+        """Guard pass-through permits real subprocess.run when guard is not active.
 
-        Creates its own SubprocessPlugin activation to be resilient against
-        earlier tests that force-reset plugin install counts.
+        Plugins haven't been migrated to pass FirewallRequest yet.
         """
         import subprocess as subprocess_mod
 
@@ -1339,6 +1499,7 @@ class TestGuardModeIntegration:
         v = StrictVerifier()
         sp = SubprocessPlugin(v)
         sp.activate()
+        guard_token = _guard_active.set(False)
         try:
             result = subprocess_mod.run(
                 ["echo", "guard_test"], capture_output=True, text=True,
@@ -1346,6 +1507,7 @@ class TestGuardModeIntegration:
             assert result.returncode == 0
             assert result.stdout == "guard_test\n"
         finally:
+            _guard_active.reset(guard_token)
             sp.deactivate()
 
     def test_guard_blocks_http_outside_sandbox(self) -> None:
@@ -1373,30 +1535,46 @@ class TestGuardModeIntegration:
             _guard_level.reset(level_token)
             hp.deactivate()
 
-    def test_allow_bypasses_sandbox_interceptor(self) -> None:
-        """allow() causes interceptor to call original even inside sandbox."""
+    def test_sandbox_takes_precedence_over_firewall_allow(self) -> None:
+        """Sandbox intercepts calls regardless of firewall allow rules.
+
+        In the new firewall system, sandbox is step 1 in the decision tree
+        and is always consulted before the firewall. An allow() rule does
+        not bypass sandbox interception.
+        """
         import socket
 
         from bigfoot._verifier import StrictVerifier
+        from bigfoot.plugins.dns_plugin import _DnsSentinel
 
-        # Set allowlist
-        token = _guard_allowlist.set(frozenset({"dns"}))
-        try:
-            # Create verifier with DNS plugin and enter sandbox
-            v = StrictVerifier()
+        v = StrictVerifier()
+        dns_plugin = None
+        for p in v._plugins:
+            from bigfoot.plugins.dns_plugin import DnsPlugin
+            if isinstance(p, DnsPlugin):
+                dns_plugin = p
+                break
+        assert dns_plugin is not None
+
+        dns_plugin.mock_getaddrinfo(
+            "localhost", returns=[(2, 1, 6, "", ("127.0.0.1", 80))],
+        )
+
+        with allow("dns"):
             with v.sandbox():
-                # DNS call should pass through to real function
+                # Even with allow("dns"), sandbox intercepts the call
                 result = socket.getaddrinfo("localhost", 80)
-                assert isinstance(result, list)
-                assert len(result) > 0
-            # No interactions should be recorded for dns
-            dns_interactions = [
-                i for i in v._timeline._interactions
-                if i.source_id.startswith("dns:")
-            ]
-            assert len(dns_interactions) == 0
-        finally:
-            _guard_allowlist.reset(token)
+                assert result == [(2, 1, 6, "", ("127.0.0.1", 80))]
+
+        # The interaction IS recorded because sandbox takes precedence
+        v.assert_interaction(
+            _DnsSentinel("dns:getaddrinfo:localhost"),
+            host="localhost",
+            port=80,
+            family=0,
+            type=0,
+            proto=0,
+        )
 
     def test_guarded_call_error_message_has_actionable_guidance(self) -> None:
         """GuardedCallError message contains all three remediation options.
@@ -1418,30 +1596,32 @@ class TestGuardModeIntegration:
             with pytest.raises(GuardedCallError) as exc_info:
                 socket_mod.getaddrinfo("example.com", 80)
             msg = str(exc_info.value)
-            # New message format
+            # New firewall message format
             assert '@pytest.mark.allow("dns")' in msg
             assert 'bigfoot.allow("dns")' in msg
             assert "with bigfoot:" in msg
-            assert "Valid plugin names for allow():" in msg
+            assert "[tool.bigfoot.firewall]" in msg
+            assert "https://bigfoot.readthedocs.io/guides/guard-mode/" in msg
             # Old sections removed
             assert "supports_guard" not in msg
+            assert "Valid plugin names for allow():" not in msg
         finally:
             _guard_level.reset(level_token)
             dns.deactivate()
 
 
-class TestGuardAllowConfig:
-    """Test guard_allow config option for project-wide default allowlist."""
+class TestGuardAllowConfigMigration:
+    """Test that old guard_allow config key raises migration error."""
 
-    def test_config_allow_seeds_allowlist(self) -> None:
-        """guard_allow = ["socket"] in config seeds the marker allowlist."""
+    def test_guard_allow_raises_migration_error(self) -> None:
+        """guard_allow config key is rejected with migration instructions."""
         from unittest.mock import patch
 
+        from bigfoot._errors import BigfootConfigError
         from bigfoot.pytest_plugin import pytest_runtest_call
 
         config = {"guard": "error", "guard_allow": ["socket"]}
 
-        # Create a minimal mock item
         class FakeItem:
             def iter_markers(self, name: str):
                 return []
@@ -1450,17 +1630,11 @@ class TestGuardAllowConfig:
 
         with patch("bigfoot.pytest_plugin.load_bigfoot_config", return_value=config):
             hook_gen = pytest_runtest_call(item)
-            next(hook_gen)  # enter the hook
-            # Check that "socket" is in the allowlist
-            assert "socket" in _guard_allowlist.get()
-            # Clean up: send None to advance past yield
-            try:
-                hook_gen.send(None)
-            except StopIteration:
-                pass
+            with pytest.raises(BigfootConfigError, match="guard_allow config key has been replaced"):
+                next(hook_gen)
 
-    def test_config_allow_invalid_type_raises(self) -> None:
-        """guard_allow = "socket" (string, not list) raises BigfootConfigError."""
+    def test_guard_allow_string_raises_migration_error(self) -> None:
+        """guard_allow = "socket" (string) also raises migration error."""
         from unittest.mock import patch
 
         from bigfoot._errors import BigfootConfigError
@@ -1476,19 +1650,25 @@ class TestGuardAllowConfig:
 
         with patch("bigfoot.pytest_plugin.load_bigfoot_config", return_value=config):
             hook_gen = pytest_runtest_call(item)
-            with pytest.raises(BigfootConfigError, match="guard_allow must be a list"):
+            with pytest.raises(BigfootConfigError, match="guard_allow config key has been replaced"):
                 next(hook_gen)
 
-    def test_config_allow_invalid_names_raises(self) -> None:
-        """guard_allow with unknown plugin names raises BigfootConfigError."""
+
+class TestFirewallTomlConfig:
+    """Test [tool.bigfoot.firewall] TOML config integration with pytest hook."""
+
+    def test_firewall_allow_rule_in_config(self) -> None:
+        """[tool.bigfoot.firewall] allow = ["socket:*"] creates ALLOW rule."""
         from unittest.mock import patch
 
-        from bigfoot._errors import BigfootConfigError
+        from bigfoot._firewall_request import NetworkFirewallRequest
         from bigfoot.pytest_plugin import pytest_runtest_call
 
-        config = {"guard": "error", "guard_allow": ["nonexistent_plugin"]}
+        config = {"guard": "error", "firewall": {"allow": ["socket:*"]}}
 
         class FakeItem:
+            fspath = "tests/test_example.py"
+
             def iter_markers(self, name: str):
                 return []
 
@@ -1496,22 +1676,59 @@ class TestGuardAllowConfig:
 
         with patch("bigfoot.pytest_plugin.load_bigfoot_config", return_value=config):
             hook_gen = pytest_runtest_call(item)
-            with pytest.raises(BigfootConfigError, match="Unknown plugin name"):
-                next(hook_gen)
+            next(hook_gen)
+            stack = _firewall_stack.get()
+            sock_req = NetworkFirewallRequest(protocol="socket", host="127.0.0.1", port=80)
+            assert stack.evaluate(sock_req) == Disposition.ALLOW
+            try:
+                hook_gen.send(None)
+            except StopIteration:
+                pass
 
-    def test_config_allow_merged_with_marker(self) -> None:
-        """guard_allow merges with @pytest.mark.allow markers."""
+    def test_no_firewall_config_denies_all(self) -> None:
+        """Without [tool.bigfoot.firewall], all protocols are denied."""
         from unittest.mock import patch
 
+        from bigfoot._firewall_request import NetworkFirewallRequest
         from bigfoot.pytest_plugin import pytest_runtest_call
 
-        config = {"guard": "error", "guard_allow": ["socket"]}
+        config = {"guard": "error"}
+
+        class FakeItem:
+            fspath = "tests/test_example.py"
+
+            def iter_markers(self, name: str):
+                return []
+
+        item = FakeItem()
+
+        with patch("bigfoot.pytest_plugin.load_bigfoot_config", return_value=config):
+            hook_gen = pytest_runtest_call(item)
+            next(hook_gen)
+            stack = _firewall_stack.get()
+            http_req = NetworkFirewallRequest(protocol="http", host="example.com", port=80)
+            assert stack.evaluate(http_req) == Disposition.DENY
+            try:
+                hook_gen.send(None)
+            except StopIteration:
+                pass
+
+    def test_marker_allow_merged_with_toml_config(self) -> None:
+        """@pytest.mark.allow merges with [tool.bigfoot.firewall] allow rules."""
+        from unittest.mock import patch
+
+        from bigfoot._firewall_request import NetworkFirewallRequest
+        from bigfoot.pytest_plugin import pytest_runtest_call
+
+        config = {"guard": "error", "firewall": {"allow": ["socket:*"]}}
 
         class FakeMark:
             def __init__(self, *args: str):
                 self.args = args
 
         class FakeItem:
+            fspath = "tests/test_example.py"
+
             def iter_markers(self, name: str):
                 if name == "allow":
                     return [FakeMark("dns")]
@@ -1522,27 +1739,32 @@ class TestGuardAllowConfig:
         with patch("bigfoot.pytest_plugin.load_bigfoot_config", return_value=config):
             hook_gen = pytest_runtest_call(item)
             next(hook_gen)
-            allowlist = _guard_allowlist.get()
-            assert "socket" in allowlist
-            assert "dns" in allowlist
+            stack = _firewall_stack.get()
+            sock_req = NetworkFirewallRequest(protocol="socket", host="127.0.0.1", port=80)
+            dns_req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
+            assert stack.evaluate(sock_req) == Disposition.ALLOW
+            assert stack.evaluate(dns_req) == Disposition.ALLOW
             try:
                 hook_gen.send(None)
             except StopIteration:
                 pass
 
-    def test_deny_marker_overrides_config_allow(self) -> None:
-        """@pytest.mark.deny can remove config-level allowed plugins."""
+    def test_deny_marker_overrides_toml_allow(self) -> None:
+        """@pytest.mark.deny blocks protocols even when TOML allows them."""
         from unittest.mock import patch
 
+        from bigfoot._firewall_request import NetworkFirewallRequest
         from bigfoot.pytest_plugin import pytest_runtest_call
 
-        config = {"guard": "error", "guard_allow": ["socket", "dns"]}
+        config = {"guard": "error", "firewall": {"allow": ["socket:*", "dns:*"]}}
 
         class FakeMark:
             def __init__(self, *args: str):
                 self.args = args
 
         class FakeItem:
+            fspath = "tests/test_example.py"
+
             def iter_markers(self, name: str):
                 if name == "deny":
                     return [FakeMark("socket")]
@@ -1553,32 +1775,12 @@ class TestGuardAllowConfig:
         with patch("bigfoot.pytest_plugin.load_bigfoot_config", return_value=config):
             hook_gen = pytest_runtest_call(item)
             next(hook_gen)
-            allowlist = _guard_allowlist.get()
-            assert "socket" not in allowlist
-            assert "dns" in allowlist
-            try:
-                hook_gen.send(None)
-            except StopIteration:
-                pass
-
-    def test_config_allow_empty_list_is_default(self) -> None:
-        """guard_allow defaults to empty list when not specified."""
-        from unittest.mock import patch
-
-        from bigfoot.pytest_plugin import pytest_runtest_call
-
-        config = {"guard": "error"}
-
-        class FakeItem:
-            def iter_markers(self, name: str):
-                return []
-
-        item = FakeItem()
-
-        with patch("bigfoot.pytest_plugin.load_bigfoot_config", return_value=config):
-            hook_gen = pytest_runtest_call(item)
-            next(hook_gen)
-            assert _guard_allowlist.get() == frozenset()
+            stack = _firewall_stack.get()
+            sock_req = NetworkFirewallRequest(protocol="socket", host="127.0.0.1", port=80)
+            dns_req = NetworkFirewallRequest(protocol="dns", host="example.com", port=53)
+            # deny is innermost (pushed after allow), so socket is denied
+            assert stack.evaluate(sock_req) == Disposition.DENY
+            assert stack.evaluate(dns_req) == Disposition.ALLOW
             try:
                 hook_gen.send(None)
             except StopIteration:

--- a/tests/unit/test_guard_new.py
+++ b/tests/unit/test_guard_new.py
@@ -1,0 +1,72 @@
+"""Tests for bigfoot._guard -- new allow/deny/restrict context managers."""
+
+from bigfoot._firewall import Disposition, FirewallStack, _firewall_stack, get_firewall_stack
+from bigfoot._firewall_request import HttpFirewallRequest, RedisFirewallRequest
+from bigfoot._guard import allow, deny, restrict
+from bigfoot._match import M
+
+
+class TestAllow:
+    def test_allow_string_pushes_protocol_rule(self) -> None:
+        with allow("http"):
+            stack = get_firewall_stack()
+            req = HttpFirewallRequest(host="example.com", port=80)
+            assert stack.evaluate(req) == Disposition.ALLOW
+
+    def test_allow_m_object(self) -> None:
+        with allow(M(protocol="http", host="*.example.com")):
+            stack = get_firewall_stack()
+            req = HttpFirewallRequest(host="sub.example.com", port=80)
+            assert stack.evaluate(req) == Disposition.ALLOW
+            req_other = HttpFirewallRequest(host="other.com", port=80)
+            assert stack.evaluate(req_other) == Disposition.DENY
+
+    def test_allow_restores_stack(self) -> None:
+        before = get_firewall_stack()
+        with allow("http"):
+            pass
+        after = get_firewall_stack()
+        assert len(before.frames) == len(after.frames)
+
+    def test_allow_empty_raises(self) -> None:
+        import pytest
+        with pytest.raises(ValueError, match="at least one rule"):
+            with allow():
+                pass
+
+
+class TestDeny:
+    def test_deny_overrides_outer_allow(self) -> None:
+        with allow("redis"):
+            with deny(M(protocol="redis", command="FLUSHALL")):
+                stack = get_firewall_stack()
+                req_flush = RedisFirewallRequest(host="localhost", port=6379, command="FLUSHALL")
+                assert stack.evaluate(req_flush) == Disposition.DENY
+                req_get = RedisFirewallRequest(host="localhost", port=6379, command="GET")
+                assert stack.evaluate(req_get) == Disposition.ALLOW
+
+
+class TestRestrict:
+    def test_restrict_blocks_other_protocols(self) -> None:
+        with restrict(M(protocol="http")):
+            with allow("redis"):
+                stack = get_firewall_stack()
+                req = RedisFirewallRequest(host="localhost", port=6379)
+                # restrict(http) blocks redis even with inner allow
+                assert stack.evaluate(req) == Disposition.DENY
+
+    def test_restrict_allows_matching_protocol(self) -> None:
+        with restrict(M(protocol="http")):
+            with allow(M(protocol="http", host="*.example.com")):
+                stack = get_firewall_stack()
+                req = HttpFirewallRequest(host="sub.example.com", port=80)
+                assert stack.evaluate(req) == Disposition.ALLOW
+
+    def test_restrict_multiple_protocols_or(self) -> None:
+        with restrict("http", "dns"):
+            with allow("http", "dns"):
+                stack = get_firewall_stack()
+                http_req = HttpFirewallRequest(host="example.com", port=80)
+                assert stack.evaluate(http_req) == Disposition.ALLOW
+                redis_req = RedisFirewallRequest(host="localhost", port=6379)
+                assert stack.evaluate(redis_req) == Disposition.DENY

--- a/tests/unit/test_guard_new.py
+++ b/tests/unit/test_guard_new.py
@@ -1,6 +1,6 @@
 """Tests for bigfoot._guard -- new allow/deny/restrict context managers."""
 
-from bigfoot._firewall import Disposition, FirewallStack, _firewall_stack, get_firewall_stack
+from bigfoot._firewall import Disposition, get_firewall_stack
 from bigfoot._firewall_request import HttpFirewallRequest, RedisFirewallRequest
 from bigfoot._guard import allow, deny, restrict
 from bigfoot._match import M

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -50,8 +50,14 @@ def test_all_contains_expected_names() -> None:
         # Guard mode
         "allow",
         "deny",
+        "restrict",
         "GuardedCallError",
         "GuardedCallWarning",
+        # Firewall
+        "Disposition",
+        "FirewallRequest",
+        # Match
+        "M",
         # Errors
         "AllWildcardAssertionError",
         "BigfootConfigError",

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -21,7 +21,7 @@ def test_all_contains_expected_names() -> None:
         "Timeline",
         "GuardPassThrough",
         "get_verifier_or_raise",
-        "GUARD_ELIGIBLE_PREFIXES",
+        "is_guard_eligible",
         "PluginEntry",
         # Classes
         "StrictVerifier",

--- a/tests/unit/test_match.py
+++ b/tests/unit/test_match.py
@@ -1,0 +1,103 @@
+"""Tests for bigfoot._match -- M() pattern matching."""
+
+from bigfoot._firewall_request import (
+    DnsFirewallRequest,
+    HttpFirewallRequest,
+    RedisFirewallRequest,
+    SubprocessFirewallRequest,
+)
+from bigfoot._match import M
+
+
+class TestProtocolMatch:
+    def test_match_protocol(self) -> None:
+        m = M(protocol="http")
+        req = HttpFirewallRequest(host="example.com", port=80, scheme="https", path="/api", method="GET")
+        assert m.matches(req) is True
+
+    def test_mismatch_protocol(self) -> None:
+        m = M(protocol="redis")
+        req = HttpFirewallRequest(host="example.com", port=80)
+        assert m.matches(req) is False
+
+    def test_no_protocol_matches_any(self) -> None:
+        m = M(host="example.com")
+        req = HttpFirewallRequest(host="example.com", port=80)
+        assert m.matches(req) is True
+
+
+class TestFieldMatch:
+    def test_exact_match_method(self) -> None:
+        m = M(protocol="http", method="GET")
+        req = HttpFirewallRequest(host="example.com", port=80, method="GET")
+        assert m.matches(req) is True
+
+    def test_exact_mismatch(self) -> None:
+        m = M(protocol="http", method="POST")
+        req = HttpFirewallRequest(host="example.com", port=80, method="GET")
+        assert m.matches(req) is False
+
+    def test_glob_host(self) -> None:
+        m = M(protocol="http", host="*.example.com")
+        req = HttpFirewallRequest(host="sub.example.com", port=80)
+        assert m.matches(req) is True
+
+    def test_glob_host_no_evil(self) -> None:
+        m = M(protocol="http", host="*.example.com")
+        req = HttpFirewallRequest(host="evil-example.com", port=80)
+        assert m.matches(req) is False
+
+    def test_cidr_match(self) -> None:
+        m = M(host__cidr="10.0.0.0/8")
+        req = HttpFirewallRequest(host="10.1.2.3", port=80)
+        assert m.matches(req) is True
+
+    def test_cidr_no_match(self) -> None:
+        m = M(host__cidr="10.0.0.0/8")
+        req = HttpFirewallRequest(host="192.168.1.1", port=80)
+        assert m.matches(req) is False
+
+    def test_regex_match(self) -> None:
+        m = M(protocol="http", path__regex=r"/api/v\d+/.*")
+        req = HttpFirewallRequest(host="example.com", port=80, path="/api/v2/users")
+        assert m.matches(req) is True
+
+    def test_callable_match(self) -> None:
+        m = M(protocol="subprocess", binary=lambda b: b in {"git", "curl"})
+        req = SubprocessFirewallRequest(command="git status", binary="git")
+        assert m.matches(req) is True
+
+    def test_callable_no_match(self) -> None:
+        m = M(protocol="subprocess", binary=lambda b: b in {"git", "curl"})
+        req = SubprocessFirewallRequest(command="rm -rf /", binary="rm")
+        assert m.matches(req) is False
+
+    def test_missing_field_no_match(self) -> None:
+        m = M(protocol="http", nonexistent="value")
+        req = HttpFirewallRequest(host="example.com", port=80)
+        assert m.matches(req) is False
+
+
+class TestComposition:
+    def test_or_pattern(self) -> None:
+        m = M(protocol="http") | M(protocol="dns")
+        http_req = HttpFirewallRequest(host="example.com", port=80)
+        dns_req = DnsFirewallRequest(hostname="example.com")
+        redis_req = RedisFirewallRequest(host="localhost", port=6379)
+        assert m.matches(http_req) is True
+        assert m.matches(dns_req) is True
+        assert m.matches(redis_req) is False
+
+    def test_and_pattern(self) -> None:
+        m = M(protocol="http") & M(host="*.example.com")
+        req_match = HttpFirewallRequest(host="sub.example.com", port=80)
+        req_no = HttpFirewallRequest(host="other.com", port=80)
+        assert m.matches(req_match) is True
+        assert m.matches(req_no) is False
+
+    def test_not_pattern(self) -> None:
+        m = ~M(protocol="redis", command="FLUSHALL")
+        req_flush = RedisFirewallRequest(host="localhost", port=6379, command="FLUSHALL")
+        req_get = RedisFirewallRequest(host="localhost", port=6379, command="GET")
+        assert m.matches(req_flush) is False
+        assert m.matches(req_get) is True

--- a/tests/unit/test_normalize.py
+++ b/tests/unit/test_normalize.py
@@ -1,0 +1,92 @@
+"""Tests for bigfoot._normalize -- URL/host/path normalization."""
+
+from bigfoot._normalize import normalize_host, normalize_path, normalize_url
+
+
+class TestNormalizeHost:
+    def test_lowercase(self) -> None:
+        assert normalize_host("API.Example.COM") == "api.example.com"
+
+    def test_strip_ipv6_brackets(self) -> None:
+        assert normalize_host("[::1]") == "localhost"
+
+    def test_localhost_aliases_127(self) -> None:
+        assert normalize_host("127.0.0.1") == "localhost"
+
+    def test_localhost_aliases_ipv6(self) -> None:
+        assert normalize_host("::1") == "localhost"
+
+    def test_localhost_aliases_zero(self) -> None:
+        assert normalize_host("0.0.0.0") == "localhost"
+
+    def test_localhost_literal(self) -> None:
+        assert normalize_host("localhost") == "localhost"
+
+    def test_regular_host(self) -> None:
+        assert normalize_host("api.stripe.com") == "api.stripe.com"
+
+    def test_ip_normalization(self) -> None:
+        assert normalize_host("10.0.0.1") == "10.0.0.1"
+
+    def test_whitespace_strip(self) -> None:
+        assert normalize_host("  api.example.com  ") == "api.example.com"
+
+
+class TestNormalizePath:
+    def test_decode_percent_encoding(self) -> None:
+        assert normalize_path("/api/%2e%2e/secret") == "/secret"
+
+    def test_resolve_dotdot(self) -> None:
+        assert normalize_path("/api/../secret") == "/secret"
+
+    def test_resolve_dot(self) -> None:
+        assert normalize_path("/api/./v1") == "/api/v1"
+
+    def test_collapse_double_slashes(self) -> None:
+        assert normalize_path("/api//v1") == "/api/v1"
+
+    def test_strip_trailing_slash(self) -> None:
+        assert normalize_path("/api/v1/") == "/api/v1"
+
+    def test_root_preserved(self) -> None:
+        assert normalize_path("/") == "/"
+
+    def test_add_leading_slash(self) -> None:
+        assert normalize_path("api/v1") == "/api/v1"
+
+
+class TestNormalizeUrl:
+    def test_http_default_port(self) -> None:
+        scheme, host, port, path = normalize_url("http://example.com/api")
+        assert scheme == "http"
+        assert host == "example.com"
+        assert port == 80
+        assert path == "/api"
+
+    def test_https_default_port(self) -> None:
+        scheme, host, port, path = normalize_url("https://api.stripe.com/v1/charges")
+        assert scheme == "https"
+        assert host == "api.stripe.com"
+        assert port == 443
+        assert path == "/v1/charges"
+
+    def test_explicit_port(self) -> None:
+        scheme, host, port, path = normalize_url("http://localhost:8080/api")
+        assert scheme == "http"
+        assert host == "localhost"
+        assert port == 8080
+        assert path == "/api"
+
+    def test_redis_url(self) -> None:
+        scheme, host, port, path = normalize_url("redis://localhost:6379/0")
+        assert scheme == "redis"
+        assert host == "localhost"
+        assert port == 6379
+        assert path == "/0"
+
+    def test_localhost_normalization_in_url(self) -> None:
+        scheme, host, port, path = normalize_url("http://127.0.0.1:8080/api")
+        assert scheme == "http"
+        assert host == "localhost"
+        assert port == 8080
+        assert path == "/api"


### PR DESCRIPTION
## Summary

- Replace the coarse plugin-level guard system (`_guard_allowlist: ContextVar[frozenset[str]]`) with a protocol-aware firewall engine supporting URL/address pattern matching, rule stack evaluation, and three-level configuration (TOML, marks, runtime context managers)
- Add `M()` pattern object with glob/CIDR/regex/callable matchers and `&`/`|`/`~` composition for granular firewall rules (e.g., allow `*.example.com` but deny `*.internal.com`, allow Redis GET but deny FLUSHALL)
- Migrate all 21 guard-eligible plugin interceptors to construct typed `FirewallRequest` objects with protocol-specific metadata
- New public API: `bigfoot.allow()`, `bigfoot.deny()`, `bigfoot.restrict()`, `bigfoot.M()`, `bigfoot.Disposition`, `bigfoot.FirewallRequest`

### New modules
| Module | Purpose |
|--------|---------|
| `_normalize.py` | URL/host/path normalization (localhost aliases, path traversal, percent-encoding) |
| `_glob.py` | Custom glob matching with subdomain anchoring and path-segment-aware wildcards |
| `_firewall_request.py` | 18 frozen protocol-typed dataclasses for firewall requests |
| `_match.py` | `M()` pattern object with field matchers and boolean composition |
| `_firewall.py` | `FirewallStack` with two-phase evaluate (restrict ceiling check, then innermost-first rule scan) |

### Modified modules
- `_errors.py`: `GuardedCallError` now shows exact attempted URL/host/command and protocol-specific fix recommendations
- `_registry.py`: `is_guard_eligible()` replaces `GUARD_ELIGIBLE_PREFIXES`
- `_context.py`: `get_verifier_or_raise()` evaluates firewall stack when `firewall_request` provided
- `_guard.py`: `allow()`/`deny()`/`restrict()` push `FirewallRule`/`RestrictFrame` onto ContextVar-backed stack
- `pytest_plugin.py`: TOML firewall config parsing, structured protocol sections, per-file overrides
- All 20 plugin files: construct `FirewallRequest` before `get_verifier_or_raise()`

## Test plan

- [x] 1787/1787 tests passing (full suite)
- [x] New test files: `test_normalize.py`, `test_glob.py`, `test_match.py`, `test_firewall.py`, `test_firewall_toml.py`, `test_guard_new.py`, `test_firewall_errors.py`, `test_firewall_integration.py`
- [x] Existing tests migrated: `test_guard.py`, `test_context_propagation.py`, `test_init.py`
- [x] No dead references to `_guard_allowlist` or `GUARD_ELIGIBLE_PREFIXES`
- [ ] Verify guard mode works end-to-end with real plugin interceptors
- [ ] Verify TOML config parsing with structured protocol sections
- [ ] Verify error messages show actionable fix recommendations