### PR TITLE
Improve error formatting, fix guard mode socket passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Guard mode no longer blocks non-connect socket operations:** `socket.send()`, `socket.sendall()`, `socket.recv()`, and `socket.close()` now pass through to the originals when no sandbox is active. Previously, these operations hit the "fail closed" guard path because they had no `FirewallRequest` to evaluate, causing `GuardedCallError` on asyncio internal socket cleanup (self-pipe sockets) and any other non-bigfoot-managed socket. The firewall decision is made at `socket.connect()` time; subsequent operations on the same socket are implicitly allowed.
 - **`_get_socket_plugin` now accepts `source_id` parameter:** Previously hardcoded `_SOURCE_CONNECT` regardless of which operation called it, producing misleading error messages in sandbox mode.
 
+### Changed
+
+- **`require_response` now defaults to `True`:** `HttpPlugin` now requires response assertions by default. Calling `assert_request()` returns an `HttpAssertionBuilder` that must be completed with `.assert_response(status, headers, body)`. To opt out, pass `require_response=False` per-call or set `require_response = false` in `[tool.bigfoot.http]` config. This aligns with bigfoot's "certainty is the contract" philosophy: if you mock a response, you should assert you got it.
+
 ### Improved
 
 - **Field-level diffs in `InteractionMismatchError`:** Mismatch errors now show per-field `expected:` / `actual:` comparisons for only the fields that differ, with `difflib.unified_diff` for long strings. Matching fields are collapsed to a single "N fields matched" line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.1] - 2026-03-27
+
+### Improved
+
+- **Field-level diffs in `InteractionMismatchError`:** Mismatch errors now show per-field `expected:` / `actual:` comparisons for only the fields that differ, with `difflib.unified_diff` for long strings. Matching fields are collapsed to a single "N fields matched" line.
+- **Compact remaining timeline:** The "Remaining timeline" section in mismatch errors is hidden when redundant (single interaction already shown above).
+- **Assertion-first `UnassertedInteractionsError`:** Copy-pasteable assertion code is shown first per interaction; the teaching preamble appears once at the end, not repeated per interaction.
+- **Slimmer `InteractionMismatchError` header:** Removed redundant `Expected={...}, actual={...}` repr dump from the one-liner; the formatted hint already contains all the detail.
+- **Cleaner `VerificationError` nesting:** When both unasserted and unused errors fire, section headers (`--- Unasserted Interactions ---`, `--- Unused Mocks ---`) replace the old cramped nesting.
+- **`MissingAssertionFieldsError` shows provided fields:** Error message now lists both the missing fields and the fields that were provided, so you see the gap at a glance.
+- **Richer `MockPlugin.format_interaction`:** One-liners now include a truncated preview of the first positional arg (e.g., `[MockPlugin] mod:attr.__call__(["osascript", "-e", ...])`), making timeline listings distinguishable when multiple interactions share the same source.
+
 ## [0.19.0] - 2026-03-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.19.2] - 2026-03-31
+## [0.19.1] - 2026-03-27
 
 ### Fixed
 
 - **Guard mode no longer blocks non-connect socket operations:** `socket.send()`, `socket.sendall()`, `socket.recv()`, and `socket.close()` now pass through to the originals when no sandbox is active. Previously, these operations hit the "fail closed" guard path because they had no `FirewallRequest` to evaluate, causing `GuardedCallError` on asyncio internal socket cleanup (self-pipe sockets) and any other non-bigfoot-managed socket. The firewall decision is made at `socket.connect()` time; subsequent operations on the same socket are implicitly allowed.
 - **`_get_socket_plugin` now accepts `source_id` parameter:** Previously hardcoded `_SOURCE_CONNECT` regardless of which operation called it, producing misleading error messages in sandbox mode.
-
-## [0.19.1] - 2026-03-27
 
 ### Improved
 
@@ -371,7 +369,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-OS CI matrix (Ubuntu, macOS, Windows) across Python 3.11, 3.12, and 3.13
 - OIDC trusted publishing to PyPI on `v*` tags
 
-[0.19.2]: https://github.com/axiomantic/bigfoot/releases/tag/v0.19.2
 [0.19.1]: https://github.com/axiomantic/bigfoot/releases/tag/v0.19.1
 [0.19.0]: https://github.com/axiomantic/bigfoot/releases/tag/v0.19.0
 [0.18.0]: https://github.com/axiomantic/bigfoot/releases/tag/v0.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.2] - 2026-03-31
+
+### Fixed
+
+- **Guard mode no longer blocks non-connect socket operations:** `socket.send()`, `socket.sendall()`, `socket.recv()`, and `socket.close()` now pass through to the originals when no sandbox is active. Previously, these operations hit the "fail closed" guard path because they had no `FirewallRequest` to evaluate, causing `GuardedCallError` on asyncio internal socket cleanup (self-pipe sockets) and any other non-bigfoot-managed socket. The firewall decision is made at `socket.connect()` time; subsequent operations on the same socket are implicitly allowed.
+- **`_get_socket_plugin` now accepts `source_id` parameter:** Previously hardcoded `_SOURCE_CONNECT` regardless of which operation called it, producing misleading error messages in sandbox mode.
+
 ## [0.19.1] - 2026-03-27
 
 ### Improved
@@ -364,6 +371,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-OS CI matrix (Ubuntu, macOS, Windows) across Python 3.11, 3.12, and 3.13
 - OIDC trusted publishing to PyPI on `v*` tags
 
+[0.19.2]: https://github.com/axiomantic/bigfoot/releases/tag/v0.19.2
+[0.19.1]: https://github.com/axiomantic/bigfoot/releases/tag/v0.19.1
 [0.19.0]: https://github.com/axiomantic/bigfoot/releases/tag/v0.19.0
 [0.18.0]: https://github.com/axiomantic/bigfoot/releases/tag/v0.18.0
 [0.17.0]: https://github.com/axiomantic/bigfoot/releases/tag/v0.17.0

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ def test_payment():
     bigfoot.http.assert_request(
         "POST", "https://api.stripe.com/v1/charges",
         headers=IsInstance(dict), body='{"amount": 5000}',
-    )
+    ).assert_response(200, IsInstance(dict), '{"id": "ch_123"}')
     assert result["id"] == "ch_123"
 ```
 
@@ -95,7 +95,7 @@ def test_payment_flow():
     bigfoot.http.assert_request(
         "POST", "https://api.stripe.com/v1/charges",
         headers=IsInstance(dict), body='{"amount": 5000}',
-    )
+    ).assert_response(200, IsInstance(dict), '{"id": "ch_123"}')
     assert result["id"] == "ch_123"
 ```
 
@@ -109,6 +109,11 @@ E           "POST",
 E           "https://api.stripe.com/v1/charges",
 E           headers={'host': 'api.stripe.com', ...},
 E           body='{"amount":5000}',
+E           require_response=True,
+E       ).assert_response(
+E           status=200,
+E           headers={'content-type': 'application/json'},
+E           body='{"id": "ch_123"}',
 E       )
 E       # ^ [sequence=0] [HttpPlugin] POST https://api.stripe.com/v1/charges (status=200)
 ```
@@ -174,7 +179,7 @@ def test_fetch_user():
     bigfoot.http.assert_request(
         "GET", "https://api.example.com/users/42",
         headers=IsInstance(dict), body=None,
-    )
+    ).assert_response(200, IsInstance(dict), '{"name": "Alice"}')
     assert user["name"] == "Alice"
 ```
 
@@ -332,8 +337,10 @@ svc.charge.returns({"status": "ok"})
 
 ```python
 with bigfoot.in_any_order():
-    bigfoot.http.assert_request(method="GET", url=".../a", headers=IsInstance(dict), body=None)
-    bigfoot.http.assert_request(method="GET", url=".../b", headers=IsInstance(dict), body=None)
+    bigfoot.http.assert_request(method="GET", url=".../a", headers=IsInstance(dict), body=None,
+                                require_response=False)
+    bigfoot.http.assert_request(method="GET", url=".../b", headers=IsInstance(dict), body=None,
+                                require_response=False)
 ```
 
 **Mock / spy** -- composable mocks with import-site patching:
@@ -390,7 +397,7 @@ bigfoot.http.pass_through("GET", url)
 
 ```toml
 [tool.bigfoot.http]
-require_response = true  # Every assert_request() must be followed by .assert_response()
+require_response = true  # This is the default; set to false to opt out
 ```
 
 Per-call arguments override project-level settings. See the [configuration guide](https://axiomantic.github.io/bigfoot/guides/configuration/).

--- a/README.md
+++ b/README.md
@@ -102,16 +102,15 @@ def test_payment_flow():
 If you forget the `assert_request()` call, bigfoot fails the test at teardown:
 
 ```
-E   bigfoot._errors.UnassertedInteractionsError: 1 interaction(s) were not asserted
+E   bigfoot._errors.UnassertedInteractionsError: 1 interaction was not asserted.
 E
-E     [sequence=0] [HttpPlugin] POST https://api.stripe.com/v1/charges (status=200)
-E       To assert this interaction:
-E         http.assert_request(
-E       "POST",
-E       "https://api.stripe.com/v1/charges",
-E       headers={'host': 'api.stripe.com', ...},
-E       body='{"amount":5000}',
-E   )
+E       http.assert_request(
+E           "POST",
+E           "https://api.stripe.com/v1/charges",
+E           headers={'host': 'api.stripe.com', ...},
+E           body='{"amount":5000}',
+E       )
+E       # ^ [sequence=0] [HttpPlugin] POST https://api.stripe.com/v1/charges (status=200)
 ```
 
 Every field is shown. Every value is real. Copy, paste, done.

--- a/docs/guides/http-plugin.md
+++ b/docs/guides/http-plugin.md
@@ -27,7 +27,8 @@ def test_api():
         response = httpx.get("https://api.example.com/users")
 
     bigfoot.http.assert_request("GET", "https://api.example.com/users",
-                                headers=IsMapping(), body="")
+                                headers=IsMapping(), body="") \
+        .assert_response(200, {"content-type": "application/json"}, '{"users": []}')
 ```
 
 For manual use outside pytest, construct `HttpPlugin` explicitly:
@@ -95,7 +96,7 @@ bigfoot.http.mock_response("GET", "https://api.example.com/search", json={...}, 
 
 ## Asserting HTTP interactions
 
-Use `bigfoot.http.assert_request()` to assert interactions after the sandbox exits:
+Use `bigfoot.http.assert_request()` to assert interactions after the sandbox exits. By default, `assert_request()` returns an `HttpAssertionBuilder` that must be completed with `.assert_response()`:
 
 ```python
 import bigfoot, httpx
@@ -107,21 +108,18 @@ def test_users():
         response = httpx.get("https://api.example.com/users")
 
     bigfoot.http.assert_request("GET", "https://api.example.com/users",
-                                headers=IsMapping(), body="")
+                                headers=IsMapping(), body="") \
+        .assert_response(200, {"content-type": "application/json"}, '[]')
 ```
 
 `assert_request()` requires all assertable request fields. Omitting any of `method`, `url`, `headers`, or `body` raises `MissingAssertionFieldsError`. Use `IsMapping()` from `dirty-equals` for headers when you want to assert type without exact matching, or `ANY` from `unittest.mock`.
 
-`assert_request()` is a convenience wrapper around the lower-level `verifier.assert_interaction()` call:
+To assert only request fields without response assertions, pass `require_response=False`:
 
 ```python
-# Convenience (recommended):
 bigfoot.http.assert_request("GET", "https://api.example.com/users",
-                            headers=IsMapping(), body="")
-
-# Equivalent low-level call:
-bigfoot.assert_interaction(bigfoot.http.request, method="GET", url="https://api.example.com/users",
-                           request_headers=IsMapping(), request_body="")
+                            headers=IsMapping(), body="",
+                            require_response=False)
 ```
 
 Parameters for `assert_request()`:
@@ -147,7 +145,8 @@ def test_httpx_sync():
         assert response.json() == {"value": 42}
 
     bigfoot.http.assert_request("GET", "https://api.example.com/data",
-                                headers=IsMapping(), body="")
+                                headers=IsMapping(), body="") \
+        .assert_response(200, {"content-type": "application/json"}, '{"value": 42}')
 ```
 
 ## Using with httpx async
@@ -164,7 +163,8 @@ async def test_httpx_async():
         assert response.status_code == 201
 
     bigfoot.http.assert_request("POST", "https://api.example.com/items",
-                                headers=IsMapping(), body="")
+                                headers=IsMapping(), body="") \
+        .assert_response(201, {"content-type": "application/json"}, '{"id": 1}')
 ```
 
 ## Using with requests
@@ -180,7 +180,8 @@ def test_requests():
         assert response.status_code == 204
 
     bigfoot.http.assert_request("DELETE", "https://api.example.com/items/99",
-                                headers=IsMapping(), body="")
+                                headers=IsMapping(), body="") \
+        .assert_response(204, IsMapping(), "")
 ```
 
 ## Mocking errors
@@ -280,27 +281,29 @@ def test_mixed():
         real   = httpx.get("https://api.example.com/live")     # makes real HTTP call
 
     bigfoot.http.assert_request("GET", "https://api.example.com/cached",
-                                headers=IsMapping(), body="")
+                                headers=IsMapping(), body="") \
+        .assert_response(200, IsMapping(), '{"data": "cached"}')
     bigfoot.http.assert_request("GET", "https://api.example.com/live",
-                                headers=IsMapping(), body="")
+                                headers=IsMapping(), body="") \
+        .assert_response(IsInstance(int), IsMapping(), IsInstance(str))
 ```
 
 Mock responses are checked before pass-through rules. If a mock matches, the pass-through rule is not evaluated for that request. If no mock matches and a pass-through rule matches, the real call is made. If neither matches, `UnmockedInteractionError` is raised.
 
 ## Requiring response assertions
 
-By default, `assert_request()` asserts only the four request fields (`method`, `url`, `request_headers`, `request_body`) and returns `None`. The `require_response` feature changes this behavior so that `assert_request()` returns an `HttpAssertionBuilder` that must be completed with a chained `.assert_response()` call. This ensures all seven fields (four request + three response) are always asserted.
+By default, `assert_request()` returns an `HttpAssertionBuilder` that must be completed with a chained `.assert_response()` call. This ensures all seven fields (four request + three response) are always asserted. To opt out and assert only request fields, pass `require_response=False` on the call or set it in configuration.
 
-### Enabling via configuration
+### Configuration
 
-Add to your `pyproject.toml`:
+The default is `require_response = true`. To disable it project-wide, add to your `pyproject.toml`:
 
 ```toml
 [tool.bigfoot.http]
-require_response = true
+require_response = false
 ```
 
-With this setting, every `assert_request()` call returns an `HttpAssertionBuilder`:
+With the default setting (or explicit `require_response = true`), every `assert_request()` call returns an `HttpAssertionBuilder`:
 
 ```python
 import bigfoot, httpx
@@ -332,11 +335,11 @@ http = HttpPlugin(verifier, require_response=True)
 The `require_response` parameter on `assert_request()` overrides both the constructor default and the project-level config:
 
 ```python
-# Force response assertion for this call, regardless of project config:
+# Force response assertion for this call (this is the default):
 bigfoot.http.assert_request("GET", "https://api.example.com/data", require_response=True) \
     .assert_response(200, {}, '{"value": 42}')
 
-# Disable response assertion for this call, even if project config enables it:
+# Disable response assertion for this call (opt out of the default):
 bigfoot.http.assert_request("GET", "https://api.example.com/health", require_response=False)
 ```
 

--- a/examples/async_api/test_app.py
+++ b/examples/async_api/test_app.py
@@ -32,10 +32,14 @@ async def test_sync_user_data_fetches_and_stores():
 
     assert result == {"id": 1, "name": "Alice", "email": "alice@example.com"}
 
-    # Assert the HTTP request
+    # Assert the HTTP request and response
     bigfoot.http.assert_request(
         method="GET",
         url="https://api.example.com/users/1",
+    ).assert_response(
+        status=200,
+        headers={"content-type": "application/json"},
+        body='{"id": 1, "name": "Alice", "email": "alice@example.com"}',
     )
 
     # Assert the log message

--- a/examples/flask_api/test_app.py
+++ b/examples/flask_api/test_app.py
@@ -25,6 +25,10 @@ def test_create_charge_posts_to_stripe_and_logs():
         url="https://api.stripe.com/v1/charges",
         headers=IsInstance(dict),
         body=IsInstance(str),
+    ).assert_response(
+        status=200,
+        headers=IsInstance(dict),
+        body='{"id": "ch_test_123", "amount": 5000, "currency": "usd"}',
     )
     bigfoot.log_mock.assert_info(
         'HTTP Request: POST https://api.stripe.com/v1/charges "HTTP/1.1 200 OK"',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bigfoot"
-version = "0.19.0"
+version = "0.19.1"
 description = "Full-certainty test mocking: every call recorded and verified"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bigfoot"
-version = "0.19.1"
+version = "0.19.2"
 description = "Full-certainty test mocking: every call recorded and verified"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bigfoot"
-version = "0.19.2"
+version = "0.19.1"
 description = "Full-certainty test mocking: every call recorded and verified"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/bigfoot/_errors.py
+++ b/src/bigfoot/_errors.py
@@ -53,15 +53,8 @@ class UnassertedInteractionsError(BigfootError):
         self.interactions = interactions
         self.hint = hint
         count = len(interactions)
-        preamble = (
-            f"{count} interaction{'s were' if count > 1 else ' was'} not asserted. "
-            f"Every intercepted call must be verified with an assert_* call "
-            f"after the sandbox closes:\n\n"
-            f"    with bigfoot:\n"
-            f"        result = do_something()\n"
-            f"    plugin.assert_*(...)  # <-- required for each interaction\n\n"
-        )
-        super().__init__(f"{preamble}{hint}")
+        header = f"{count} interaction{'s were' if count > 1 else ' was'} not asserted."
+        super().__init__(f"{header}\n\n{hint}")
 
 
 class UnusedMocksError(BigfootError):
@@ -90,15 +83,14 @@ class VerificationError(BigfootError):
         self.unasserted = unasserted
         self.unused = unused
 
-        parts: list[str] = []
+        sections: list[str] = []
         if unasserted is not None:
-            parts.append(f"  [UnassertedInteractions] {unasserted}")
+            sections.append(f"--- Unasserted Interactions ---\n{unasserted}")
         if unused is not None:
-            parts.append(f"  [UnusedMocks] {unused}")
+            sections.append(f"--- Unused Mocks ---\n{unused}")
 
-        if parts:
-            body = "\n".join(parts)
-            message = f"VerificationError:\n{body}"
+        if sections:
+            message = "\n\n".join(sections)
         else:
             message = "VerificationError: (no details)"
 
@@ -121,9 +113,7 @@ class InteractionMismatchError(BigfootError):
         self.expected = expected
         self.actual = actual
         self.hint = hint
-        super().__init__(
-            f"Expected={expected!r}, actual={actual!r}\n\n{hint}"
-        )
+        super().__init__(hint)
 
 
 class SandboxNotActiveError(BigfootError):
@@ -190,15 +180,20 @@ class MissingAssertionFieldsError(BigfootError):
         missing_fields: frozenset of field names that were required but absent.
     """
 
-    def __init__(self, missing_fields: frozenset[str]) -> None:
+    def __init__(self, missing_fields: frozenset[str], provided_fields: frozenset[str] | None = None) -> None:
         self.missing_fields = missing_fields
-        fields_str = ", ".join(sorted(missing_fields))
-        super().__init__(
-            f"MissingAssertionFieldsError: the following assertable fields were not "
-            f"included in the assertion: {fields_str}. "
-            f"Include them in **expected or use a dirty-equals matcher (e.g., IsAnything()) "
-            f"if the value is not the focus of this assertion."
-        )
+        self.provided_fields = provided_fields
+        missing_str = ", ".join(sorted(missing_fields))
+        lines = [
+            f"Missing assertion fields: {missing_str}",
+        ]
+        if provided_fields is not None:
+            provided_str = ", ".join(sorted(provided_fields))
+            lines.append(f"  Provided: {provided_str}")
+        lines.append("")
+        lines.append("Include them in **expected or use a dirty-equals matcher (e.g., IsAnything())")
+        lines.append("if the value is not the focus of this assertion.")
+        super().__init__("\n".join(lines))
 
 
 class AutoAssertError(BigfootError):

--- a/src/bigfoot/_errors.py
+++ b/src/bigfoot/_errors.py
@@ -180,7 +180,11 @@ class MissingAssertionFieldsError(BigfootError):
         missing_fields: frozenset of field names that were required but absent.
     """
 
-    def __init__(self, missing_fields: frozenset[str], provided_fields: frozenset[str] | None = None) -> None:
+    def __init__(
+        self,
+        missing_fields: frozenset[str],
+        provided_fields: frozenset[str] | None = None,
+    ) -> None:
         self.missing_fields = missing_fields
         self.provided_fields = provided_fields
         missing_str = ", ".join(sorted(missing_fields))
@@ -191,8 +195,13 @@ class MissingAssertionFieldsError(BigfootError):
             provided_str = ", ".join(sorted(provided_fields))
             lines.append(f"  Provided: {provided_str}")
         lines.append("")
-        lines.append("Include them in **expected or use a dirty-equals matcher (e.g., IsAnything())")
-        lines.append("if the value is not the focus of this assertion.")
+        lines.append(
+            "Include them in **expected or use a dirty-equals"
+            " matcher (e.g., IsAnything())"
+        )
+        lines.append(
+            "if the value is not the focus of this assertion."
+        )
         super().__init__("\n".join(lines))
 
 

--- a/src/bigfoot/_mock_plugin.py
+++ b/src/bigfoot/_mock_plugin.py
@@ -596,10 +596,16 @@ class MockPlugin(BasePlugin):
             return False
 
     def format_interaction(self, interaction: Interaction) -> str:
-        """One-line description: '[MockPlugin] MockName.method_name'."""
+        """One-line description: '[MockPlugin] MockName.method_name(first_arg_preview)'."""
         # source_id is "mock:MockName.method_name"
         readable = interaction.source_id.replace("mock:", "[MockPlugin] ", 1)
-        return readable
+        args = interaction.details.get("args", ())
+        if args:
+            first_repr = repr(args[0])
+            if len(first_repr) > 60:
+                first_repr = first_repr[:60] + "..."
+            return f"{readable}({first_repr})"
+        return f"{readable}()"
 
     def format_mock_hint(self, interaction: Interaction) -> str:
         """Copy-pasteable code to configure a mock for this interaction."""
@@ -607,8 +613,8 @@ class MockPlugin(BasePlugin):
         method_name = interaction.details.get("method_name", "?")
         if "raised" in interaction.details:
             raised = interaction.details["raised"]
-            return f'verifier.mock("{mock_name}").{method_name}.raises({raised!r})'
-        return f'verifier.mock("{mock_name}").{method_name}.returns(<value>)'
+            return f'bigfoot.mock("{mock_name}").{method_name}.raises({raised!r})'
+        return f'bigfoot.mock("{mock_name}").{method_name}.returns(<value>)'
 
     def format_unmocked_hint(
         self,
@@ -626,9 +632,9 @@ class MockPlugin(BasePlugin):
             f"Unexpected call to {mock_name}.{method_name}\n\n"
             f"  Called with: args={args!r}, kwargs={kwargs!r}\n\n"
             f"  To mock this interaction, add before your sandbox:\n"
-            f'    verifier.mock("{mock_name}").{method_name}.returns(<value>)\n\n'
+            f'    bigfoot.mock("{mock_name}").{method_name}.returns(<value>)\n\n'
             f"  Or to mark it optional:\n"
-            f'    verifier.mock("{mock_name}").{method_name}.required(False).returns(<value>)'
+            f'    bigfoot.mock("{mock_name}").{method_name}.required(False).returns(<value>)'
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
@@ -638,7 +644,7 @@ class MockPlugin(BasePlugin):
         args = interaction.details.get("args", ())
         kwargs = interaction.details.get("kwargs", {})
         lines = [
-            f'verifier.mock("{mock_name}").{method_name}.assert_call(',
+            f'bigfoot.mock("{mock_name}").{method_name}.assert_call(',
             f"    args={args!r},",
             f"    kwargs={kwargs!r},",
         ]
@@ -693,6 +699,6 @@ class MockPlugin(BasePlugin):
             f"{mock_config.registration_traceback}\n"
             f"    Options:\n"
             f"      - Remove this mock if it's not needed\n"
-            f'      - Mark it optional: verifier.mock("{mock_config.mock_name}")'
+            f'      - Mark it optional: bigfoot.mock("{mock_config.mock_name}")'
             f".{mock_config.method_name}.required(False).returns(...)"
         )

--- a/src/bigfoot/_verifier.py
+++ b/src/bigfoot/_verifier.py
@@ -202,7 +202,10 @@ class StrictVerifier:
             required_fields = candidate.plugin.assertable_fields(candidate)
             missing = required_fields - set(expected.keys())
             if missing:
-                raise MissingAssertionFieldsError(missing_fields=frozenset(missing), provided_fields=frozenset(expected.keys()))
+                raise MissingAssertionFieldsError(
+                    missing_fields=frozenset(missing),
+                    provided_fields=frozenset(expected.keys()),
+                )
             # Detect all-wildcard assertions
             if expected and self._all_wildcards(expected):
                 hint = candidate.plugin.format_assert_hint(candidate)
@@ -237,7 +240,10 @@ class StrictVerifier:
             required_fields = interaction.plugin.assertable_fields(interaction)
             missing = required_fields - set(expected.keys())
             if missing:
-                raise MissingAssertionFieldsError(missing_fields=frozenset(missing), provided_fields=frozenset(expected.keys()))
+                raise MissingAssertionFieldsError(
+                    missing_fields=frozenset(missing),
+                    provided_fields=frozenset(expected.keys()),
+                )
             # Detect all-wildcard assertions
             if expected and self._all_wildcards(expected):
                 hint = interaction.plugin.format_assert_hint(interaction)
@@ -346,7 +352,7 @@ class StrictVerifier:
                     if act_val is _MISSING:
                         lines.append(f"  {key}:")
                         lines.append(f"    expected: {exp_val!r}")
-                        lines.append(f"    actual:   (missing)")
+                        lines.append("    actual:   (missing)")
                     elif exp_val != act_val:
                         exp_repr = repr(exp_val)
                         act_repr = repr(act_val)
@@ -377,7 +383,15 @@ class StrictVerifier:
                     lines.append(f"  ({matched} field{'s' if matched != 1 else ''} matched)")
 
         # Compact timeline: skip when there's exactly 1 remaining and it's the actual
-        if remaining and not (len(remaining) == 1 and actual is not None and remaining[0] is actual):
+        show_remaining = (
+            remaining
+            and not (
+                len(remaining) == 1
+                and actual is not None
+                and remaining[0] is actual
+            )
+        )
+        if show_remaining:
             lines.append("")
             lines.append(f"  Remaining timeline ({len(remaining)} interaction(s)):")
             for r in remaining:

--- a/src/bigfoot/_verifier.py
+++ b/src/bigfoot/_verifier.py
@@ -1,6 +1,7 @@
 # src/bigfoot/_verifier.py
 """StrictVerifier, SandboxContext, and InAnyOrderContext."""
 
+import difflib
 import warnings
 from importlib.metadata import entry_points
 from types import TracebackType
@@ -19,6 +20,8 @@ from bigfoot._errors import (
     VerificationError,
 )
 from bigfoot._timeline import Interaction, Timeline
+
+_MISSING = object()
 
 if TYPE_CHECKING:
     import contextvars
@@ -199,7 +202,7 @@ class StrictVerifier:
             required_fields = candidate.plugin.assertable_fields(candidate)
             missing = required_fields - set(expected.keys())
             if missing:
-                raise MissingAssertionFieldsError(missing_fields=frozenset(missing))
+                raise MissingAssertionFieldsError(missing_fields=frozenset(missing), provided_fields=frozenset(expected.keys()))
             # Detect all-wildcard assertions
             if expected and self._all_wildcards(expected):
                 hint = candidate.plugin.format_assert_hint(candidate)
@@ -234,7 +237,7 @@ class StrictVerifier:
             required_fields = interaction.plugin.assertable_fields(interaction)
             missing = required_fields - set(expected.keys())
             if missing:
-                raise MissingAssertionFieldsError(missing_fields=frozenset(missing))
+                raise MissingAssertionFieldsError(missing_fields=frozenset(missing), provided_fields=frozenset(expected.keys()))
             # Detect all-wildcard assertions
             if expected and self._all_wildcards(expected):
                 hint = interaction.plugin.format_assert_hint(interaction)
@@ -322,20 +325,64 @@ class StrictVerifier:
             "",
             f"  Expected source: {source_id}",
         ]
-        if expected:
-            fields_str = ", ".join(f"{k}={v!r}" for k, v in expected.items())
-            lines.append(f"  Expected fields: {fields_str}")
-        lines.append("")
+
         if actual is None:
-            lines.append("  Actual next interaction: (none — timeline is empty or all asserted)")
+            # No interaction to compare against; fall back to flat dump
+            if expected:
+                fields_str = ", ".join(f"{k}={v!r}" for k, v in expected.items())
+                lines.append(f"  Expected fields: {fields_str}")
+            lines.append("")
+            lines.append("  Actual next interaction: (none -- timeline is empty or all asserted)")
         else:
             lines.append(f"  Actual next interaction (sequence={actual.sequence}):")
             lines.append(f"    {actual.plugin.format_interaction(actual)}")
-        if remaining:
+            lines.append("")
+
+            # Field-by-field diff: only show mismatched fields
+            if expected:
+                matched = 0
+                for key, exp_val in expected.items():
+                    act_val = actual.details.get(key, _MISSING)
+                    if act_val is _MISSING:
+                        lines.append(f"  {key}:")
+                        lines.append(f"    expected: {exp_val!r}")
+                        lines.append(f"    actual:   (missing)")
+                    elif exp_val != act_val:
+                        exp_repr = repr(exp_val)
+                        act_repr = repr(act_val)
+                        if (
+                            isinstance(exp_val, str)
+                            and isinstance(act_val, str)
+                            and len(exp_repr) > 60
+                            and len(act_repr) > 60
+                        ):
+                            diff_lines = list(
+                                difflib.unified_diff(
+                                    exp_val.splitlines(keepends=True),
+                                    act_val.splitlines(keepends=True),
+                                    fromfile="expected",
+                                    tofile="actual",
+                                )
+                            )
+                            lines.append(f"  {key}:")
+                            for dl in diff_lines:
+                                lines.append(f"    {dl.rstrip()}")
+                        else:
+                            lines.append(f"  {key}:")
+                            lines.append(f"    expected: {exp_repr}")
+                            lines.append(f"    actual:   {act_repr}")
+                    else:
+                        matched += 1
+                if matched:
+                    lines.append(f"  ({matched} field{'s' if matched != 1 else ''} matched)")
+
+        # Compact timeline: skip when there's exactly 1 remaining and it's the actual
+        if remaining and not (len(remaining) == 1 and actual is not None and remaining[0] is actual):
             lines.append("")
             lines.append(f"  Remaining timeline ({len(remaining)} interaction(s)):")
             for r in remaining:
                 lines.append(f"    [{r.sequence}] {r.plugin.format_interaction(r)}")
+
         lines.append("")
         lines.append("  Hint: Did you forget an in_any_order() block?")
         return "\n".join(lines)
@@ -352,12 +399,18 @@ class StrictVerifier:
     def _format_unasserted_error(self, unasserted: list[Interaction]) -> str:
         lines = [f"{len(unasserted)} interaction(s) were not asserted", ""]
         for i in unasserted:
-            lines.append(f"  [sequence={i.sequence}] {i.plugin.format_interaction(i)}")
+            hint = i.plugin.format_assert_hint(i)
+            # Indent each line of the hint
+            indented_hint = "\n".join(f"    {ln}" for ln in hint.splitlines())
+            lines.append(indented_hint)
+            lines.append(f"    # ^ [sequence={i.sequence}] {i.plugin.format_interaction(i)}")
             lines.append("")
-            lines.append("    Copy this assertion into your test:")
-            lines.append("")
-            lines.append(f"      {i.plugin.format_assert_hint(i)}")
-            lines.append("")
+        lines.append("  Every intercepted call must be verified with an assert_* call")
+        lines.append("  after the sandbox closes:")
+        lines.append("")
+        lines.append("    with bigfoot:")
+        lines.append("        result = do_something()")
+        lines.append("    plugin.assert_*(...)  # <-- required for each interaction")
         return "\n".join(lines)
 
     def _format_unused_mocks_error(self, unused: list[tuple["BasePlugin", Any]]) -> str:

--- a/src/bigfoot/plugins/http.py
+++ b/src/bigfoot/plugins/http.py
@@ -298,7 +298,7 @@ class HttpPlugin(BasePlugin):
     _original_urllib_opener: Any = None
     _original_aiohttp_request: Callable[..., Any] | None = None
 
-    def __init__(self, verifier: "StrictVerifier", require_response: bool = False) -> None:
+    def __init__(self, verifier: "StrictVerifier", require_response: bool = True) -> None:
         super().__init__(verifier)
         self._mock_queue: list[HttpMockEntry] = []
         self._sentinel = HttpRequestSentinel(self)
@@ -320,7 +320,7 @@ class HttpPlugin(BasePlugin):
         Recognized keys:
             require_response (bool): When True, assert_request() returns an
                 HttpAssertionBuilder requiring .assert_response() to complete
-                the assertion. Default False.
+                the assertion. Default True.
 
         Unknown keys are silently ignored for forward-compatibility.
         Raises TypeError for require_response with a non-bool value.
@@ -353,7 +353,7 @@ class HttpPlugin(BasePlugin):
         When ``raised`` is provided, the assertion is always terminal (error
         interactions have no response to chain). Returns ``None``.
 
-        When ``require_response`` is False (the default), this method is terminal:
+        When ``require_response`` is False, this method is terminal:
         it asserts only the four request fields and returns ``None``.
 
         When ``require_response`` is True, this method returns an

--- a/src/bigfoot/plugins/socket_plugin.py
+++ b/src/bigfoot/plugins/socket_plugin.py
@@ -4,7 +4,7 @@ import socket
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
-from bigfoot._context import GuardPassThrough, get_verifier_or_raise
+from bigfoot._context import GuardPassThrough, get_active_verifier, get_verifier_or_raise
 from bigfoot._firewall_request import SocketFirewallRequest
 from bigfoot._state_machine_plugin import StateMachinePlugin, _StepSentinel
 from bigfoot._timeline import Interaction
@@ -40,8 +40,9 @@ _SOCKET_CLOSE_ORIGINAL: Callable[..., Any] = socket.socket.close
 
 def _get_socket_plugin(
     firewall_request: SocketFirewallRequest | None = None,
+    source_id: str = _SOURCE_CONNECT,
 ) -> "SocketPlugin | None":
-    verifier = get_verifier_or_raise(_SOURCE_CONNECT, firewall_request=firewall_request)
+    verifier = get_verifier_or_raise(source_id, firewall_request=firewall_request)
     for plugin in verifier._plugins:
         if isinstance(plugin, SocketPlugin):
             return plugin
@@ -161,8 +162,10 @@ class SocketPlugin(StateMachinePlugin):
             data: bytes | bytearray | memoryview,
             flags: int = 0,
         ) -> int:
+            if get_active_verifier() is None:
+                return cast(int, _SOCKET_SEND_ORIGINAL(sock_self, data, flags))
             try:
-                plugin = _get_socket_plugin()
+                plugin = _get_socket_plugin(source_id=_SOURCE_SEND)
             except GuardPassThrough:
                 return cast(int, _SOCKET_SEND_ORIGINAL(sock_self, data, flags))
             if plugin is None:
@@ -180,8 +183,10 @@ class SocketPlugin(StateMachinePlugin):
             data: bytes | bytearray | memoryview,
             flags: int = 0,
         ) -> None:
+            if get_active_verifier() is None:
+                return cast(None, _SOCKET_SENDALL_ORIGINAL(sock_self, data, flags))
             try:
-                plugin = _get_socket_plugin()
+                plugin = _get_socket_plugin(source_id=_SOURCE_SENDALL)
             except GuardPassThrough:
                 return cast(None, _SOCKET_SENDALL_ORIGINAL(sock_self, data, flags))
             if plugin is None:
@@ -193,8 +198,10 @@ class SocketPlugin(StateMachinePlugin):
             )
 
         def _patched_recv(sock_self: socket.socket, bufsize: int, flags: int = 0) -> bytes:
+            if get_active_verifier() is None:
+                return cast(bytes, _SOCKET_RECV_ORIGINAL(sock_self, bufsize, flags))
             try:
-                plugin = _get_socket_plugin()
+                plugin = _get_socket_plugin(source_id=_SOURCE_RECV)
             except GuardPassThrough:
                 return cast(bytes, _SOCKET_RECV_ORIGINAL(sock_self, bufsize, flags))
             if plugin is None:
@@ -210,8 +217,10 @@ class SocketPlugin(StateMachinePlugin):
             return data
 
         def _patched_close(sock_self: socket.socket) -> None:
+            if get_active_verifier() is None:
+                return cast(None, _SOCKET_CLOSE_ORIGINAL(sock_self))
             try:
-                plugin = _get_socket_plugin()
+                plugin = _get_socket_plugin(source_id=_SOURCE_CLOSE)
             except GuardPassThrough:
                 return cast(None, _SOCKET_CLOSE_ORIGINAL(sock_self))
             if plugin is None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -110,8 +110,8 @@ def test_load_config_require_response_true() -> None:
     """load_config with require_response=True sets _require_response to True."""
     stub = _StubVerifier(bigfoot_config={})
     plugin = HttpPlugin(stub)  # type: ignore[arg-type]
-    # Default is False
-    assert plugin._require_response is False
+    # Default is True
+    assert plugin._require_response is True
     plugin.load_config({"require_response": True})
     assert plugin._require_response is True
 
@@ -186,24 +186,24 @@ def test_http_plugin_reads_require_response_from_config(
 def test_config_absent_preserves_default(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """No [tool.bigfoot.http] in pyproject.toml → _require_response remains False."""
+    """No [tool.bigfoot.http] in pyproject.toml → _require_response remains True (the default)."""
     (tmp_path / "pyproject.toml").write_text("[tool.other]\nkey = 1\n")
     monkeypatch.chdir(tmp_path)
     verifier = StrictVerifier()
     # Retrieve the auto-created HttpPlugin
     plugin = next(p for p in verifier._plugins if isinstance(p, HttpPlugin))
-    assert plugin._require_response is False
+    assert plugin._require_response is True
 
 
 def test_no_pyproject_preserves_default(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """No pyproject.toml at all → _require_response remains False."""
+    """No pyproject.toml at all → _require_response remains True (the default)."""
     monkeypatch.chdir(tmp_path)
     verifier = StrictVerifier()
     # Retrieve the auto-created HttpPlugin
     plugin = next(p for p in verifier._plugins if isinstance(p, HttpPlugin))
-    assert plugin._require_response is False
+    assert plugin._require_response is True
 
 
 def test_require_response_wrong_type_raises_on_plugin_init(

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -157,12 +157,7 @@ def test_unasserted_interactions_error_str() -> None:
     )
     result = str(err)
     assert result == (
-        "2 interactions were not asserted. "
-        "Every intercepted call must be verified with an assert_* call "
-        "after the sandbox closes:\n\n"
-        "    with bigfoot:\n"
-        "        result = do_something()\n"
-        "    plugin.assert_*(...)  # <-- required for each interaction\n\n"
+        "2 interactions were not asserted.\n\n"
         "Assert all recorded interactions before teardown."
     )
 
@@ -269,18 +264,12 @@ def test_verification_error_str_both_set() -> None:
     )
     err = VerificationError(unasserted=unasserted, unused=unused)
     result = str(err)
-    unasserted_preamble = (
-        "1 interaction was not asserted. "
-        "Every intercepted call must be verified with an assert_* call "
-        "after the sandbox closes:\n\n"
-        "    with bigfoot:\n"
-        "        result = do_something()\n"
-        "    plugin.assert_*(...)  # <-- required for each interaction\n\n"
-    )
     assert result == (
-        "VerificationError:\n"
-        f"  [UnassertedInteractions] {unasserted_preamble}Assert each interaction.\n"
-        "  [UnusedMocks] Remove or set required=False."
+        "--- Unasserted Interactions ---\n"
+        "1 interaction was not asserted.\n\n"
+        "Assert each interaction.\n\n"
+        "--- Unused Mocks ---\n"
+        "Remove or set required=False."
     )
 
 
@@ -292,17 +281,10 @@ def test_verification_error_str_only_unasserted() -> None:
     )
     err = VerificationError(unasserted=unasserted, unused=None)
     result = str(err)
-    unasserted_preamble = (
-        "0 interaction was not asserted. "
-        "Every intercepted call must be verified with an assert_* call "
-        "after the sandbox closes:\n\n"
-        "    with bigfoot:\n"
-        "        result = do_something()\n"
-        "    plugin.assert_*(...)  # <-- required for each interaction\n\n"
-    )
     assert result == (
-        "VerificationError:\n"
-        f"  [UnassertedInteractions] {unasserted_preamble}Nothing to assert."
+        "--- Unasserted Interactions ---\n"
+        "0 interaction was not asserted.\n\n"
+        "Nothing to assert."
     )
 
 
@@ -315,7 +297,8 @@ def test_verification_error_str_only_unused() -> None:
     err = VerificationError(unasserted=None, unused=unused)
     result = str(err)
     assert result == (
-        "VerificationError:\n  [UnusedMocks] Fix unused."
+        "--- Unused Mocks ---\n"
+        "Fix unused."
     )
 
 
@@ -368,11 +351,7 @@ def test_interaction_mismatch_error_str() -> None:
         hint="Check order of assert_interaction() calls.",
     )
     result = str(err)
-    assert result == (
-        "Expected={'source_id': 'http.get'}, "
-        "actual={'source_id': 'db.read'}\n\n"
-        "Check order of assert_interaction() calls."
-    )
+    assert result == "Check order of assert_interaction() calls."
 
 
 # ---------------------------------------------------------------------------
@@ -531,9 +510,8 @@ def test_missing_assertion_fields_error_str_single_field() -> None:
     err = MissingAssertionFieldsError(frozenset({"args"}))
     result = str(err)
     assert result == (
-        "MissingAssertionFieldsError: the following assertable fields were not "
-        "included in the assertion: args. "
-        "Include them in **expected or use a dirty-equals matcher (e.g., IsAnything()) "
+        "Missing assertion fields: args\n\n"
+        "Include them in **expected or use a dirty-equals matcher (e.g., IsAnything())\n"
         "if the value is not the focus of this assertion."
     )
 
@@ -543,9 +521,8 @@ def test_missing_assertion_fields_error_str_multiple_fields_sorted() -> None:
     err = MissingAssertionFieldsError(frozenset({"kwargs", "args"}))
     result = str(err)
     assert result == (
-        "MissingAssertionFieldsError: the following assertable fields were not "
-        "included in the assertion: args, kwargs. "
-        "Include them in **expected or use a dirty-equals matcher (e.g., IsAnything()) "
+        "Missing assertion fields: args, kwargs\n\n"
+        "Include them in **expected or use a dirty-equals matcher (e.g., IsAnything())\n"
         "if the value is not the focus of this assertion."
     )
 

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -921,7 +921,6 @@ class TestGuardPassThroughInStateMachinePlugins:
         from bigfoot._verifier import StrictVerifier
         from bigfoot.plugins.socket_plugin import (
             _SOCKET_CLOSE_ORIGINAL,
-            _SOCKET_SEND_ORIGINAL,
             SocketPlugin,
         )
 

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -910,36 +910,37 @@ class TestGuardPassThroughInStateMachinePlugins:
         finally:
             sp.deactivate()
 
-    def test_socket_send_guard_blocks_when_not_allowed(self) -> None:
-        """Guard blocks socket:send when socket not in allowlist."""
+    def test_socket_send_guard_passes_through_in_guard_mode(self) -> None:
+        """In guard mode (no sandbox), send passes through to the original.
+
+        The firewall decision was already made at connect time; send/recv/
+        sendall/close skip bigfoot entirely when no sandbox is active.
+        """
         import socket as socket_mod
 
-        from bigfoot._context import _guard_level
-        from bigfoot._guard import deny
         from bigfoot._verifier import StrictVerifier
-        from bigfoot.plugins.socket_plugin import _SOCKET_CLOSE_ORIGINAL, SocketPlugin
+        from bigfoot.plugins.socket_plugin import (
+            _SOCKET_CLOSE_ORIGINAL,
+            _SOCKET_SEND_ORIGINAL,
+            SocketPlugin,
+        )
 
         v = StrictVerifier()
         sp = SocketPlugin(v)
         sp.activate()
         try:
-            level_token = _guard_level.set("error")
             guard_token = _guard_active.set(True)
             try:
-                # Explicitly deny socket to override project-level allow = ["socket:*"]
-                with deny("socket"):
-                    sock = socket_mod.socket(socket_mod.AF_INET, socket_mod.SOCK_STREAM)
-                    try:
-                        with pytest.raises(GuardedCallError) as exc_info:
-                            sock.send(b"hello")
-                        assert exc_info.value.plugin_name == "socket"
-                        # Note: _get_socket_plugin() hardcodes _SOURCE_CONNECT for source_id
-                        assert exc_info.value.source_id == "socket:connect"
-                    finally:
-                        _SOCKET_CLOSE_ORIGINAL(sock)
+                sock = socket_mod.socket(socket_mod.AF_INET, socket_mod.SOCK_STREAM)
+                try:
+                    # send should pass through without GuardedCallError
+                    # (will raise OSError because socket is not connected, but NOT GuardedCallError)
+                    with pytest.raises(OSError):
+                        sock.send(b"hello")
+                finally:
+                    _SOCKET_CLOSE_ORIGINAL(sock)
             finally:
                 _guard_active.reset(guard_token)
-                _guard_level.reset(level_token)
         finally:
             sp.deactivate()
 
@@ -1817,3 +1818,172 @@ class TestFirewallTomlConfig:
                 hook_gen.send(None)
             except StopIteration:
                 pass
+
+
+class TestSocketNonConnectGuardPassThrough:
+    """Test that send/recv/sendall/close pass through in guard mode (no sandbox).
+
+    The firewall decision is made at connect time. Non-connect operations
+    should not hit the firewall at all when no sandbox is active.
+    """
+
+    def test_send_passes_through_in_guard_mode(self) -> None:
+        """socket.send passes through to original in guard mode."""
+        import socket as socket_mod
+
+        from bigfoot._verifier import StrictVerifier
+        from bigfoot.plugins.socket_plugin import _SOCKET_CLOSE_ORIGINAL, SocketPlugin
+
+        v = StrictVerifier()
+        sp = SocketPlugin(v)
+        sp.activate()
+        try:
+            guard_token = _guard_active.set(True)
+            try:
+                sock = socket_mod.socket(socket_mod.AF_INET, socket_mod.SOCK_STREAM)
+                try:
+                    # Not connected, so real send raises OSError, not GuardedCallError
+                    with pytest.raises(OSError):
+                        sock.send(b"hello")
+                finally:
+                    _SOCKET_CLOSE_ORIGINAL(sock)
+            finally:
+                _guard_active.reset(guard_token)
+        finally:
+            sp.deactivate()
+
+    def test_sendall_passes_through_in_guard_mode(self) -> None:
+        """socket.sendall passes through to original in guard mode."""
+        import socket as socket_mod
+
+        from bigfoot._verifier import StrictVerifier
+        from bigfoot.plugins.socket_plugin import _SOCKET_CLOSE_ORIGINAL, SocketPlugin
+
+        v = StrictVerifier()
+        sp = SocketPlugin(v)
+        sp.activate()
+        try:
+            guard_token = _guard_active.set(True)
+            try:
+                sock = socket_mod.socket(socket_mod.AF_INET, socket_mod.SOCK_STREAM)
+                try:
+                    # Not connected, so real sendall raises OSError, not GuardedCallError
+                    with pytest.raises(OSError):
+                        sock.sendall(b"hello")
+                finally:
+                    _SOCKET_CLOSE_ORIGINAL(sock)
+            finally:
+                _guard_active.reset(guard_token)
+        finally:
+            sp.deactivate()
+
+    def test_recv_passes_through_in_guard_mode(self) -> None:
+        """socket.recv passes through to original in guard mode."""
+        import socket as socket_mod
+
+        from bigfoot._verifier import StrictVerifier
+        from bigfoot.plugins.socket_plugin import _SOCKET_CLOSE_ORIGINAL, SocketPlugin
+
+        v = StrictVerifier()
+        sp = SocketPlugin(v)
+        sp.activate()
+        try:
+            guard_token = _guard_active.set(True)
+            try:
+                sock = socket_mod.socket(socket_mod.AF_INET, socket_mod.SOCK_STREAM)
+                try:
+                    # Not connected, so real recv raises OSError, not GuardedCallError
+                    with pytest.raises(OSError):
+                        sock.recv(1024)
+                finally:
+                    _SOCKET_CLOSE_ORIGINAL(sock)
+            finally:
+                _guard_active.reset(guard_token)
+        finally:
+            sp.deactivate()
+
+    def test_close_passes_through_in_guard_mode(self) -> None:
+        """socket.close passes through to original in guard mode."""
+        import socket as socket_mod
+
+        from bigfoot._verifier import StrictVerifier
+        from bigfoot.plugins.socket_plugin import SocketPlugin
+
+        v = StrictVerifier()
+        sp = SocketPlugin(v)
+        sp.activate()
+        try:
+            guard_token = _guard_active.set(True)
+            try:
+                sock = socket_mod.socket(socket_mod.AF_INET, socket_mod.SOCK_STREAM)
+                # close should succeed without GuardedCallError
+                sock.close()
+            finally:
+                _guard_active.reset(guard_token)
+        finally:
+            sp.deactivate()
+
+    def test_close_no_guarded_call_error_even_with_deny(self) -> None:
+        """socket.close does not raise GuardedCallError even when socket is denied.
+
+        Non-connect operations bypass bigfoot entirely in guard mode,
+        regardless of firewall rules.
+        """
+        import socket as socket_mod
+
+        from bigfoot._context import _guard_level
+        from bigfoot._guard import deny
+        from bigfoot._verifier import StrictVerifier
+        from bigfoot.plugins.socket_plugin import SocketPlugin
+
+        v = StrictVerifier()
+        sp = SocketPlugin(v)
+        sp.activate()
+        try:
+            level_token = _guard_level.set("error")
+            guard_token = _guard_active.set(True)
+            try:
+                with deny("socket"):
+                    sock = socket_mod.socket(socket_mod.AF_INET, socket_mod.SOCK_STREAM)
+                    # close passes through even with deny("socket") active
+                    sock.close()
+            finally:
+                _guard_active.reset(guard_token)
+                _guard_level.reset(level_token)
+        finally:
+            sp.deactivate()
+
+    def test_send_no_guarded_call_error_even_with_deny(self) -> None:
+        """socket.send does not raise GuardedCallError even when socket is denied.
+
+        Non-connect operations bypass bigfoot entirely in guard mode,
+        regardless of firewall rules. The real send raises OSError because
+        the socket is not connected.
+        """
+        import socket as socket_mod
+
+        from bigfoot._context import _guard_level
+        from bigfoot._guard import deny
+        from bigfoot._verifier import StrictVerifier
+        from bigfoot.plugins.socket_plugin import _SOCKET_CLOSE_ORIGINAL, SocketPlugin
+
+        v = StrictVerifier()
+        sp = SocketPlugin(v)
+        sp.activate()
+        try:
+            level_token = _guard_level.set("error")
+            guard_token = _guard_active.set(True)
+            try:
+                with deny("socket"):
+                    sock = socket_mod.socket(socket_mod.AF_INET, socket_mod.SOCK_STREAM)
+                    try:
+                        # Real send raises OSError, not GuardedCallError
+                        with pytest.raises(OSError):
+                            sock.send(b"hello")
+                    finally:
+                        _SOCKET_CLOSE_ORIGINAL(sock)
+            finally:
+                _guard_active.reset(guard_token)
+                _guard_level.reset(level_token)
+        finally:
+            sp.deactivate()

--- a/tests/unit/test_http_plugin.py
+++ b/tests/unit/test_http_plugin.py
@@ -672,6 +672,11 @@ def test_format_assert_hint_returns_correct_snippet() -> None:
         '    "https://api.example.com/data",\n'
         "    headers={},\n"
         "    body='',\n"
+        "    require_response=True,\n"
+        ").assert_response(\n"
+        "    status=200,\n"
+        "    headers={},\n"
+        "    body='',\n"
         ")"
     )
 
@@ -1438,7 +1443,7 @@ def test_assert_request_lazy_does_not_touch_timeline() -> None:
 
 
 # ESCAPE: test_assert_request_terminal_when_require_response_false
-#   CLAIM: assert_request() with default require_response=False is terminal: returns
+#   CLAIM: assert_request() with explicit require_response=False is terminal: returns
 #          None and fully asserts the interaction (verify_all passes).
 #   PATH:  assert_request() -> effective=False -> assert_interaction(4 request fields)
 #          -> returns None.
@@ -1460,6 +1465,7 @@ def test_assert_request_terminal_when_require_response_false() -> None:
         "GET",
         "https://api.example.com/terminal",
         headers=recorded_headers,
+        require_response=False,
     )
 
     assert result is None
@@ -1563,6 +1569,7 @@ def test_assert_request_terminal_missing_field_raises() -> None:
             "POST",  # Wrong method -- recorded interaction is GET
             "https://api.example.com/mismatch",
             headers=recorded_headers,
+            require_response=False,
         )
 
 
@@ -2248,6 +2255,7 @@ def test_assert_request_missing_raised_triggers_missing_fields_error() -> None:
             "https://api.example.com/data",
             headers=recorded_headers,
             body="",
+            require_response=False,
             # raised= intentionally omitted
         )
     assert "raised" in exc_info.value.missing_fields

--- a/tests/unit/test_mock_plugin.py
+++ b/tests/unit/test_mock_plugin.py
@@ -898,7 +898,7 @@ def test_format_interaction_returns_string() -> None:
         plugin=p,
     )
     result = p.format_interaction(interaction)
-    assert result == "[MockPlugin] Svc.method"
+    assert result == "[MockPlugin] Svc.method()"
 
 
 def test_format_interaction_includes_source_id_components() -> None:
@@ -947,7 +947,7 @@ def test_format_mock_hint_returns_string() -> None:
         plugin=p,
     )
     result = p.format_mock_hint(interaction)
-    assert result == 'verifier.mock("Svc").method.returns(<value>)'
+    assert result == 'bigfoot.mock("Svc").method.returns(<value>)'
 
 
 # ---------------------------------------------------------------------------
@@ -991,9 +991,9 @@ def test_format_unmocked_hint_returns_string() -> None:
         "Unexpected call to Svc.method\n\n"
         "  Called with: args=(), kwargs={}\n\n"
         "  To mock this interaction, add before your sandbox:\n"
-        '    verifier.mock("Svc").method.returns(<value>)\n\n'
+        '    bigfoot.mock("Svc").method.returns(<value>)\n\n'
         "  Or to mark it optional:\n"
-        '    verifier.mock("Svc").method.required(False).returns(<value>)'
+        '    bigfoot.mock("Svc").method.required(False).returns(<value>)'
     )
     assert result == expected
 
@@ -1022,7 +1022,7 @@ def test_format_assert_hint_returns_string() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        'verifier.mock("Svc").method.assert_call(\n'
+        'bigfoot.mock("Svc").method.assert_call(\n'
         "    args=(),\n"
         "    kwargs={},\n"
         ")"
@@ -1502,7 +1502,7 @@ def test_mock_plugin_format_assert_hint_includes_args_and_kwargs() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        'verifier.mock("Logger").log.assert_call(\n'
+        'bigfoot.mock("Logger").log.assert_call(\n'
         "    args=('event',),\n"
         "    kwargs={'level': 'info'},\n"
         ")"
@@ -1838,7 +1838,7 @@ def test_format_assert_hint_includes_raised_when_present() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        'verifier.mock("Svc").method.assert_call(\n'
+        'bigfoot.mock("Svc").method.assert_call(\n'
         "    args=('a',),\n"
         "    kwargs={},\n"
         f"    raised={exc!r},\n"
@@ -1865,7 +1865,7 @@ def test_format_assert_hint_includes_returned_when_present() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        'verifier.mock("Svc").method.assert_call(\n'
+        'bigfoot.mock("Svc").method.assert_call(\n'
         "    args=(),\n"
         "    kwargs={},\n"
         "    returned={'data': 'value'},\n"
@@ -1891,7 +1891,7 @@ def test_format_assert_hint_plain_call_unchanged() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        'verifier.mock("Svc").method.assert_call(\n'
+        'bigfoot.mock("Svc").method.assert_call(\n'
         "    args=(),\n"
         "    kwargs={},\n"
         ")"
@@ -1917,4 +1917,4 @@ def test_format_mock_hint_includes_raises_when_raised_in_details() -> None:
         plugin=p,
     )
     result = p.format_mock_hint(interaction)
-    assert result == f'verifier.mock("Svc").method.raises({exc!r})'
+    assert result == f'bigfoot.mock("Svc").method.raises({exc!r})'

--- a/tests/unit/test_wildcard_detection.py
+++ b/tests/unit/test_wildcard_detection.py
@@ -58,6 +58,7 @@ def test_all_wildcard_assertion_raises():
             url=AnyThing(),
             headers=AnyThing(),
             body=AnyThing(),
+            require_response=False,
         )
 
 
@@ -73,6 +74,7 @@ def test_partial_wildcard_is_allowed():
         url=AnyThing(),
         headers=AnyThing(),
         body=AnyThing(),
+        require_response=False,
     )
 
 
@@ -88,6 +90,7 @@ def test_all_wildcard_error_shows_real_values():
             url=AnyThing(),
             headers=AnyThing(),
             body=AnyThing(),
+            require_response=False,
         )
 
     # The error message should contain the real values from format_assert_hint
@@ -109,4 +112,5 @@ def test_all_wildcard_detection_in_any_order():
                 url=AnyThing(),
                 headers=AnyThing(),
                 body=AnyThing(),
+                require_response=False,
             )


### PR DESCRIPTION
## Summary

### `require_response` defaults to `True`
- **Response assertions required by default:** `assert_request()` now returns an `HttpAssertionBuilder` that must be completed with `.assert_response(status, headers, body)`. This enforces bigfoot's "certainty is the contract" philosophy -- if you mock an HTTP response, you should assert you received it.
- **Opt-out available:** Pass `require_response=False` per-call or set `require_response = false` in `[tool.bigfoot.http]` config to preserve request-only behavior.
- **Docs and examples updated:** README, HTTP plugin guide, and all examples show the new default pattern.

### Error output formatting
- **Field-level diffs** in `InteractionMismatchError`: shows per-field `expected:` / `actual:` for only mismatched fields, with `difflib.unified_diff` for long strings
- **Assertion-first** `UnassertedInteractionsError`: copy-paste code shown first, teaching preamble once at end
- **Compact timeline**: hidden when redundant (single interaction already shown)
- **Slimmer mismatch header**: removed redundant `Expected={...}, actual={...}` repr dump
- **Cleaner `VerificationError`**: section headers replace cramped nesting
- **`MissingAssertionFieldsError`**: now shows both missing and provided fields
- **Richer `MockPlugin.format_interaction`**: truncated first-arg preview in one-liners

### Guard mode socket fix
- **Non-connect socket operations pass through in guard mode:** `socket.send()`, `sendall()`, `recv()`, and `close()` no longer hit the "fail closed" guard path when no sandbox is active. Previously they raised `GuardedCallError` because they had no `FirewallRequest` to evaluate (notably breaking asyncio internal self-pipe cleanup). The firewall decision is made at `socket.connect()` time; subsequent operations are implicitly allowed.
- **`_get_socket_plugin` accepts `source_id` parameter:** Previously hardcoded `_SOURCE_CONNECT` regardless of operation, producing misleading error messages in sandbox mode.

Patch bump to 0.19.1.

## Test plan

- [x] All 1793 unit/integration/dogfood tests pass
- [x] `require_response=True` default verified in config and assertion tests
- [x] Examples updated to show `.assert_response()` chaining
- [x] README and HTTP plugin guide updated
- [x] CHANGELOG entry added
- [x] Error string assertions updated in test_errors.py and test_mock_plugin.py
- [x] Guard passthrough tests added for send/sendall/recv/close in guard mode