### PR TITLE
Rewrite README for human voice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.2] - 2026-04-08
+
+### Changed
+
+- Rewrite README for human voice: add Morpheus quote, rewrite intro, fix LLM-sounding prose, break out Firewall mode section, correct allow/restrict examples to use context manager syntax
+
 ## [0.19.1] - 2026-03-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ def test_payment():
 | Scenario | unittest.mock | bigfoot |
 |----------|---------------|---------|
 | Mocked function is never called | Passes silently | `UnusedMocksError` |
-| Wrong arguments | Only caught if you add `assert_called_with` | Recorded, must be asserted with exact args |
+| Wrong arguments | Only caught if you add `assert_called_with` | `InteractionMismatchError` |
 | Real HTTP/DB/Redis call leaks through | Goes to production | `UnmockedInteractionError` |
 | Forgot to assert a call | Passes silently | `UnassertedInteractionsError` |
 | `MagicMock` returns wrong type | Auto-generates attributes forever | You declare explicit return values |
@@ -69,23 +69,28 @@ def test_payment():
 
 Firewall mode is on by default. When your test session starts, bigfoot installs interceptors that catch any real I/O call happening outside a sandbox.
 
-In `"warn"` mode (the default), accidental calls emit a `GuardedCallWarning` and proceed normally, so your existing suite keeps working while showing you exactly which calls are unguarded. Set `guard = "error"` for strict enforcement.
+In `"warn"` mode (the default), accidental calls emit a `GuardedCallWarning` and proceed normally, so your existing suite keeps working while showing you exactly which calls are unguarded. Set `guard = "error"` under `[tool.bigfoot]` in your `pyproject.toml` for strict enforcement.
 
 ```python
-# Selectively permit real calls
-bigfoot.allow("dns", "socket")
+from bigfoot import M
 
-# Or via marker
+# Selectively permit real calls within a scope
+with bigfoot.allow("dns", "socket"):
+    ...
+
+# Or via marker for an entire test
 @pytest.mark.allow("dns", "socket")
 
 # Granular patterns
-bigfoot.allow(M(protocol="http", host="*.example.com"))
+with bigfoot.allow(M(protocol="http", host="*.example.com")):
+    ...
 
 # Set a ceiling that inner blocks cannot widen
-bigfoot.restrict("http", "subprocess")
+with bigfoot.restrict("http", "subprocess"):
+    ...
 ```
 
-Configure project-wide rules in `[tool.bigfoot.firewall]` in your `pyproject.toml`.
+Configure project-wide allow/deny rules in `[tool.bigfoot.firewall]` in your `pyproject.toml`.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -5,34 +5,28 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-<!-- CHANGED: New opening description repositioned as unittest.mock replacement -->
+> *"Let me tell you why you're here. You're here because you know something. What you know you can't explain, but you feel it. You've felt it your entire life, that there's something wrong with the world. You don't know what it is, but it's there, like a splinter in your mind, driving you mad."*
+> -- Morpheus, The Matrix (1999)
 
-**bigfoot replaces `unittest.mock` with full-certainty test mocking for Python.**
+You've had tests pass in CI and then watched the thing they were supposedly testing break in production. You go back and look at the test, and it turns out the mock was wrong, or incomplete, or your production code was making a call the test didn't even know about. The green checkmark was meaningless.
 
-Drop-in mocking that catches the bugs `unittest.mock` silently ignores. bigfoot intercepts every external call your code makes and forces your tests to account for all of them. It ships with plugins for HTTP, subprocess, database, socket, Redis, SMTP, WebSocket, logging, and more. It enforces three guarantees that `unittest.mock` and most mocking libraries leave silent:
+This is what testing with `unittest.mock` is like. It gives you the tools to mock things, but it's entirely on you to remember to assert every call, verify every argument, and notice when production code starts making calls your tests don't account for. Most of the time, you won't. Not because you're careless, but because `unittest.mock` is designed around silence -- if you forget to check something, it has no way of telling you.
 
-<!-- END CHANGED -->
+bigfoot replaces `unittest.mock` with mocking that actually enforces correctness.
+
+```bash
+pip install bigfoot[all]
+```
+
+## The three guarantees
+
+bigfoot intercepts every external call your code makes and enforces three rules that `unittest.mock` leaves entirely to you:
 
 1. **Every call must be pre-authorized.** Code makes a call with no registered mock? `UnmockedInteractionError`, immediately.
 2. **Every recorded interaction must be explicitly asserted.** Forget to assert an interaction? `UnassertedInteractionsError` at teardown.
 3. **Every registered mock must actually be triggered.** Register a mock that never fires? `UnusedMocksError` at teardown.
 
-<!-- NEW SECTION: Why Not unittest.mock? -->
-
-## Why Not unittest.mock?
-
-`unittest.mock` is designed for flexibility. bigfoot is designed for correctness. Here is what `unittest.mock` silently allows that bigfoot catches:
-
-| Scenario | unittest.mock | bigfoot |
-|----------|---------------|---------|
-| Mocked function is never called | Test passes silently | `UnusedMocksError` at teardown |
-| Mocked function called with wrong args | `assert_called_with` only if you remember to add it | Recorded and required to be asserted with exact args |
-| Real HTTP/DB/Redis call leaks through | Nothing happens (call goes to production) | `UnmockedInteractionError` immediately |
-| You forget to assert a call happened | Test passes silently | `UnassertedInteractionsError` at teardown |
-| Mock returns wrong type, caller doesn't notice | `MagicMock` auto-generates attributes forever | Not applicable; you declare explicit return values |
-| Production code adds a new external call | Existing tests still pass, new call is untested | `UnmockedInteractionError` forces you to handle it |
-
-**The core problem:** `unittest.mock` makes it your responsibility to remember what to assert. bigfoot makes it impossible to forget.
+## What this looks like in practice
 
 ```python
 # unittest.mock -- this test passes, but proves nothing
@@ -62,15 +56,36 @@ def test_payment():
     assert result["id"] == "ch_123"
 ```
 
-<!-- END NEW SECTION -->
+| Scenario | unittest.mock | bigfoot |
+|----------|---------------|---------|
+| Mocked function is never called | Passes silently | `UnusedMocksError` |
+| Wrong arguments | Only caught if you add `assert_called_with` | Recorded, must be asserted with exact args |
+| Real HTTP/DB/Redis call leaks through | Goes to production | `UnmockedInteractionError` |
+| Forgot to assert a call | Passes silently | `UnassertedInteractionsError` |
+| `MagicMock` returns wrong type | Auto-generates attributes forever | You declare explicit return values |
+| Production code adds a new external call | Existing tests still pass | `UnmockedInteractionError` forces you to handle it |
 
-**Firewall mode** (enabled by default) goes further: bigfoot installs interceptors at test session startup, catching any real I/O call that happens outside a sandbox. In the default `"warn"` level, accidental calls emit a `GuardedCallWarning` and proceed normally, so existing test suites keep working while you see exactly which calls are unguarded. Set `guard = "error"` in `[tool.bigfoot]` for strict enforcement that raises `GuardedCallError` on every unguarded call. Use `bigfoot.allow("dns", "socket")` or `@pytest.mark.allow(...)` to selectively permit real calls. Use `M()` pattern objects for granular matching (e.g., `M(protocol="http", host="*.example.com")`). Use `bigfoot.restrict(...)` to set a ceiling that inner blocks cannot widen. Configure project-wide rules in `[tool.bigfoot.firewall]` TOML sections.
+## Firewall mode
 
-A plugin system makes it straightforward to intercept any service and enforce all three guarantees.
+Firewall mode is on by default. When your test session starts, bigfoot installs interceptors that catch any real I/O call happening outside a sandbox.
 
-```bash
-pip install bigfoot[all]
+In `"warn"` mode (the default), accidental calls emit a `GuardedCallWarning` and proceed normally, so your existing suite keeps working while showing you exactly which calls are unguarded. Set `guard = "error"` for strict enforcement.
+
+```python
+# Selectively permit real calls
+bigfoot.allow("dns", "socket")
+
+# Or via marker
+@pytest.mark.allow("dns", "socket")
+
+# Granular patterns
+bigfoot.allow(M(protocol="http", host="*.example.com"))
+
+# Set a ceiling that inner blocks cannot widen
+bigfoot.restrict("http", "subprocess")
 ```
+
+Configure project-wide rules in `[tool.bigfoot.firewall]` in your `pyproject.toml`.
 
 ## Quick Start
 
@@ -118,9 +133,9 @@ E       )
 E       # ^ [sequence=0] [HttpPlugin] POST https://api.stripe.com/v1/charges (status=200)
 ```
 
-Every field is shown. Every value is real. Copy, paste, done.
+The error output includes every field with its actual value, so you can usually just copy it directly into your test as the assertion.
 
-## How It Works
+## How it works
 
 1. **Register mocks** before the sandbox (`mock_response`, `mock_run`, `returns`, etc.)
 2. **Open the sandbox** with `with bigfoot:` (or `async with bigfoot:`)
@@ -128,9 +143,7 @@ Every field is shown. Every value is real. Copy, paste, done.
 4. **Assert interactions** after the sandbox closes, in order
 5. **`verify_all()`** runs automatically at test teardown via the pytest plugin
 
-No fixture injection required. Install bigfoot, `import bigfoot`, and go.
-
-<!-- NEW SECTION: Coming from unittest.mock -->
+Since bigfoot uses a module-level API, there are no fixtures to set up or inject. You just import it.
 
 ## Coming from unittest.mock
 
@@ -241,8 +254,6 @@ You do not have to migrate your entire test suite at once. bigfoot and `unittest
 1. **Start with guard mode.** Install bigfoot and run your suite. Guard mode (default `"warn"`) will show you every real I/O call across all tests without breaking anything.
 2. **Migrate test by test.** Pick tests that touch HTTP, subprocess, or database calls first -- these benefit most from bigfoot's strict enforcement.
 3. **Escalate to strict guard mode.** Once coverage is high, set `guard = "error"` in `pyproject.toml` to catch any remaining leaks.
-
-<!-- END NEW SECTION -->
 
 ## Plugins
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bigfoot"
-version = "0.19.1"
+version = "0.19.2"
 description = "Full-certainty test mocking: every call recorded and verified"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Add Morpheus quote as opening hook
- Rewrite intro to describe the problem from the reader's experience rather than listing features
- Replace performative punchiness ("Every field is shown. Every value is real. Copy, paste, done.") with natural prose
- Remove mic-drop standalone sentences ("bigfoot does.")
- Break out Firewall mode into its own section with code examples instead of one dense paragraph
- Remove stale HTML comments (`<!-- CHANGED -->`, `<!-- NEW SECTION -->`)
- Restructure top sections: "The three guarantees" and "What this looks like in practice"

## Test plan

- [ ] Render README on GitHub and verify formatting
- [ ] Verify all links still work
- [ ] Read through for any remaining LLM-sounding prose