### PR TITLE
refactor(api)!: drop `_mock` suffix from plugin proxy names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] - 2026-04-20
+
+### Changed
+
+- **Plugin proxy attributes renamed to drop the `_mock` suffix:** All 26 `_mock`-suffixed plugin proxy attributes on the `bigfoot` module have been renamed to their un-suffixed forms. The un-suffixed names are now canonical: `bigfoot.subprocess`, `bigfoot.popen`, `bigfoot.smtp`, `bigfoot.socket`, `bigfoot.db`, `bigfoot.async_websocket`, `bigfoot.sync_websocket`, `bigfoot.redis`, `bigfoot.mongo`, `bigfoot.dns`, `bigfoot.memcache`, `bigfoot.celery`, `bigfoot.log`, `bigfoot.async_subprocess`, `bigfoot.psycopg2`, `bigfoot.asyncpg`, `bigfoot.boto3`, `bigfoot.elasticsearch`, `bigfoot.jwt`, `bigfoot.crypto`, `bigfoot.file_io`, `bigfoot.pika`, `bigfoot.ssh`, `bigfoot.grpc`, `bigfoot.mcp`, and `bigfoot.native`. `bigfoot.http` was already un-suffixed and is unchanged.
+
+### Deprecated
+
+- **Old `_mock`-suffixed proxy names:** The previous attribute names (`bigfoot.subprocess_mock`, `bigfoot.db_mock`, `bigfoot.redis_mock`, and the rest of the 26) are retained as backward-compatibility aliases. Accessing any one of them emits a `DeprecationWarning` on first access per name, pointing at the new un-suffixed attribute. The aliases will be removed in a future release. Migration is mechanical: find-and-replace `_mock` where it appears immediately after a `bigfoot.` proxy access (e.g., `bigfoot.redis_mock.mock_command(...)` becomes `bigfoot.redis.mock_command(...)`). Local variables, plugin class names, and method names like `mock_response` / `mock_run` are not affected.
+
 ## [0.19.2] - 2026-04-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -216,14 +216,14 @@ def test_deploy(mock_run):
 
 # AFTER: bigfoot
 def test_deploy():
-    bigfoot.subprocess_mock.mock_run(
+    bigfoot.subprocess.mock_run(
         ["kubectl", "apply", "-f", "prod.yaml"],
         returncode=0, stdout="deployed",
     )
     with bigfoot:
         result = deploy("prod")
 
-    bigfoot.subprocess_mock.assert_run(
+    bigfoot.subprocess.assert_run(
         ["kubectl", "apply", "-f", "prod.yaml"],
         returncode=0, stdout="deployed",
     )
@@ -281,12 +281,12 @@ bigfoot ships with 27 plugins covering the most common external dependencies:
 
 **Subprocess**
 ```python
-bigfoot.subprocess_mock.mock_run(["git", "pull"], returncode=0, stdout="Up to date.\n")
+bigfoot.subprocess.mock_run(["git", "pull"], returncode=0, stdout="Up to date.\n")
 ```
 
 **Database (sqlite3)**
 ```python
-bigfoot.db_mock.new_session() \
+bigfoot.db.new_session() \
     .expect("connect", returns=None) \
     .expect("execute", returns=[]) \
     .expect("commit", returns=None) \
@@ -295,22 +295,22 @@ bigfoot.db_mock.new_session() \
 
 **Redis**
 ```python
-bigfoot.redis_mock.mock_command("GET", returns=b"cached_value")
+bigfoot.redis.mock_command("GET", returns=b"cached_value")
 ```
 
 **MongoDB**
 ```python
-bigfoot.mongo_mock.mock_operation("find_one", returns={"_id": "abc", "name": "Alice"})
+bigfoot.mongo.mock_operation("find_one", returns={"_id": "abc", "name": "Alice"})
 ```
 
 **AWS (boto3)**
 ```python
-bigfoot.boto3_mock.mock_api_call("s3", "GetObject", returns={"Body": b"file contents"})
+bigfoot.boto3.mock_api_call("s3", "GetObject", returns={"Body": b"file contents"})
 ```
 
 **RabbitMQ (pika)**
 ```python
-bigfoot.pika_mock.new_session() \
+bigfoot.pika.new_session() \
     .expect("connect", returns=None) \
     .expect("channel", returns=None) \
     .expect("publish", returns=None) \
@@ -319,7 +319,7 @@ bigfoot.pika_mock.new_session() \
 
 **SSH (paramiko)**
 ```python
-bigfoot.ssh_mock.new_session() \
+bigfoot.ssh.new_session() \
     .expect("connect", returns=None) \
     .expect("exec_command", returns=(b"", b"output\n", b"")) \
     .expect("close", returns=None)
@@ -327,7 +327,7 @@ bigfoot.ssh_mock.new_session() \
 
 **SMTP**
 ```python
-bigfoot.smtp_mock.new_session() \
+bigfoot.smtp.new_session() \
     .expect("connect", returns=(220, b"OK")) \
     .expect("ehlo", returns=(250, b"OK")) \
     .expect("sendmail", returns={}) \
@@ -336,7 +336,7 @@ bigfoot.smtp_mock.new_session() \
 
 **Logging**
 ```python
-bigfoot.log_mock.assert_info("User logged in", "myapp")
+bigfoot.log.assert_info("User logged in", "myapp")
 ```
 
 **Mock (general)**

--- a/docs/guides/async-subprocess-plugin.md
+++ b/docs/guides/async-subprocess-plugin.md
@@ -8,14 +8,14 @@
 
 ## Setup
 
-In pytest, access `AsyncSubprocessPlugin` through the `bigfoot.async_subprocess_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `AsyncSubprocessPlugin` through the `bigfoot.async_subprocess` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import asyncio
 import bigfoot
 
 async def test_run_command():
-    (bigfoot.async_subprocess_mock
+    (bigfoot.async_subprocess
         .new_session()
         .expect("spawn",       returns=None)
         .expect("communicate", returns=(b"hello\n", b"", 0)))
@@ -27,8 +27,8 @@ async def test_run_command():
     assert stdout == b"hello\n"
     assert proc.returncode == 0
 
-    bigfoot.async_subprocess_mock.assert_spawn(command=["echo", "hello"], stdin=None)
-    bigfoot.async_subprocess_mock.assert_communicate(input=None)
+    bigfoot.async_subprocess.assert_spawn(command=["echo", "hello"], stdin=None)
+    bigfoot.async_subprocess.assert_communicate(input=None)
 ```
 
 For manual use outside pytest, construct `AsyncSubprocessPlugin` explicitly:
@@ -60,7 +60,7 @@ The `spawn` step fires automatically during `asyncio.create_subprocess_exec(...)
 Use `new_session()` to create a `SessionHandle` and chain `.expect()` calls to build the script:
 
 ```python
-(bigfoot.async_subprocess_mock
+(bigfoot.async_subprocess
     .new_session()
     .expect("spawn",       returns=None)
     .expect("communicate", returns=(b"output", b"errors", 0)))
@@ -85,7 +85,7 @@ Use `new_session()` to create a `SessionHandle` and chain `.expect()` calls to b
 
 ## Asserting interactions
 
-Each step records an interaction on the timeline. Use the typed assertion helpers on `bigfoot.async_subprocess_mock`:
+Each step records an interaction on the timeline. Use the typed assertion helpers on `bigfoot.async_subprocess`:
 
 ### `assert_spawn(*, command, stdin)`
 
@@ -93,10 +93,10 @@ Asserts the next spawn interaction. Both `command` and `stdin` are required fiel
 
 ```python
 # For exec:
-bigfoot.async_subprocess_mock.assert_spawn(command=["git", "status"], stdin=None)
+bigfoot.async_subprocess.assert_spawn(command=["git", "status"], stdin=None)
 
 # For shell:
-bigfoot.async_subprocess_mock.assert_spawn(command="ls -la | grep foo", stdin=None)
+bigfoot.async_subprocess.assert_spawn(command="ls -la | grep foo", stdin=None)
 ```
 
 ### `assert_communicate(*, input)`
@@ -104,7 +104,7 @@ bigfoot.async_subprocess_mock.assert_spawn(command="ls -la | grep foo", stdin=No
 Asserts the next communicate interaction. The `input` field is required.
 
 ```python
-bigfoot.async_subprocess_mock.assert_communicate(input=None)
+bigfoot.async_subprocess.assert_communicate(input=None)
 ```
 
 ### `assert_wait()`
@@ -112,7 +112,7 @@ bigfoot.async_subprocess_mock.assert_communicate(input=None)
 Asserts the next wait interaction. No fields are required.
 
 ```python
-bigfoot.async_subprocess_mock.assert_wait()
+bigfoot.async_subprocess.assert_wait()
 ```
 
 ## Full example

--- a/docs/guides/asyncpg-plugin.md
+++ b/docs/guides/asyncpg-plugin.md
@@ -10,13 +10,13 @@ pip install bigfoot[asyncpg]
 
 ## Setup
 
-In pytest, access `AsyncpgPlugin` through the `bigfoot.asyncpg_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `AsyncpgPlugin` through the `bigfoot.asyncpg` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import bigfoot
 
 async def test_fetch_users():
-    (bigfoot.asyncpg_mock
+    (bigfoot.asyncpg
         .new_session()
         .expect("connect",  returns=None)
         .expect("fetch",    returns=[{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}])
@@ -30,9 +30,9 @@ async def test_fetch_users():
 
     assert rows == [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
 
-    bigfoot.asyncpg_mock.assert_connect(host="localhost", database="myapp", user="admin")
-    bigfoot.asyncpg_mock.assert_fetch(query="SELECT id, name FROM users", args=[])
-    bigfoot.asyncpg_mock.assert_close()
+    bigfoot.asyncpg.assert_connect(host="localhost", database="myapp", user="admin")
+    bigfoot.asyncpg.assert_fetch(query="SELECT id, name FROM users", args=[])
+    bigfoot.asyncpg.assert_close()
 ```
 
 For manual use outside pytest, construct `AsyncpgPlugin` explicitly:
@@ -65,7 +65,7 @@ Unlike psycopg2/sqlite3, asyncpg does not have an explicit transaction state for
 Use `new_session()` to create a `SessionHandle` and chain `.expect()` calls:
 
 ```python
-(bigfoot.asyncpg_mock
+(bigfoot.asyncpg
     .new_session()
     .expect("connect",  returns=None)
     .expect("fetch",    returns=[{"id": 1}])
@@ -109,22 +109,22 @@ The `assert_connect()` helper accepts whichever parameters were used:
 
 ```python
 # For DSN connections
-bigfoot.asyncpg_mock.assert_connect(dsn="postgresql://admin@localhost/myapp")
+bigfoot.asyncpg.assert_connect(dsn="postgresql://admin@localhost/myapp")
 
 # For keyword connections
-bigfoot.asyncpg_mock.assert_connect(host="localhost", port=5432, database="myapp", user="admin")
+bigfoot.asyncpg.assert_connect(host="localhost", port=5432, database="myapp", user="admin")
 ```
 
 ## Asserting interactions
 
-Each step records an interaction on the timeline. Use the typed assertion helpers on `bigfoot.asyncpg_mock`:
+Each step records an interaction on the timeline. Use the typed assertion helpers on `bigfoot.asyncpg`:
 
 ### `assert_connect(**kwargs)`
 
 Asserts the next connect interaction. Pass whichever connection fields were used.
 
 ```python
-bigfoot.asyncpg_mock.assert_connect(host="localhost", database="myapp", user="admin")
+bigfoot.asyncpg.assert_connect(host="localhost", database="myapp", user="admin")
 ```
 
 ### `assert_execute(*, query, args)`
@@ -132,7 +132,7 @@ bigfoot.asyncpg_mock.assert_connect(host="localhost", database="myapp", user="ad
 Asserts the next execute interaction. Both `query` and `args` are required.
 
 ```python
-bigfoot.asyncpg_mock.assert_execute(
+bigfoot.asyncpg.assert_execute(
     query="INSERT INTO users (name) VALUES ($1)",
     args=["Alice"],
 )
@@ -143,7 +143,7 @@ bigfoot.asyncpg_mock.assert_execute(
 Asserts the next fetch interaction. Both `query` and `args` are required.
 
 ```python
-bigfoot.asyncpg_mock.assert_fetch(query="SELECT id, name FROM users", args=[])
+bigfoot.asyncpg.assert_fetch(query="SELECT id, name FROM users", args=[])
 ```
 
 ### `assert_fetchrow(*, query, args)`
@@ -151,7 +151,7 @@ bigfoot.asyncpg_mock.assert_fetch(query="SELECT id, name FROM users", args=[])
 Asserts the next fetchrow interaction. Both `query` and `args` are required.
 
 ```python
-bigfoot.asyncpg_mock.assert_fetchrow(
+bigfoot.asyncpg.assert_fetchrow(
     query="SELECT id, name FROM users WHERE id = $1",
     args=[1],
 )
@@ -162,7 +162,7 @@ bigfoot.asyncpg_mock.assert_fetchrow(
 Asserts the next fetchval interaction. Both `query` and `args` are required.
 
 ```python
-bigfoot.asyncpg_mock.assert_fetchval(query="SELECT count(*) FROM users", args=[])
+bigfoot.asyncpg.assert_fetchval(query="SELECT count(*) FROM users", args=[])
 ```
 
 ### `assert_close()`
@@ -170,7 +170,7 @@ bigfoot.asyncpg_mock.assert_fetchval(query="SELECT count(*) FROM users", args=[]
 Asserts the next close interaction. No fields are required.
 
 ```python
-bigfoot.asyncpg_mock.assert_close()
+bigfoot.asyncpg.assert_close()
 ```
 
 ## Full example

--- a/docs/guides/boto3-plugin.md
+++ b/docs/guides/boto3-plugin.md
@@ -12,13 +12,13 @@ This installs `botocore`.
 
 ## Setup
 
-In pytest, access `Boto3Plugin` through the `bigfoot.boto3_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `Boto3Plugin` through the `bigfoot.boto3` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import bigfoot
 
 def test_s3_get_object():
-    bigfoot.boto3_mock.mock_call(
+    bigfoot.boto3.mock_call(
         "s3", "GetObject",
         returns={"Body": b"file-contents", "ContentLength": 13},
     )
@@ -30,7 +30,7 @@ def test_s3_get_object():
 
     assert response["ContentLength"] == 13
 
-    bigfoot.boto3_mock.assert_boto3_call(
+    bigfoot.boto3.assert_boto3_call(
         service="s3",
         operation="GetObject",
         params={"Bucket": "my-bucket", "Key": "data.csv"},
@@ -44,18 +44,18 @@ from bigfoot import StrictVerifier
 from bigfoot.plugins.boto3_plugin import Boto3Plugin
 
 verifier = StrictVerifier()
-boto3_mock = Boto3Plugin(verifier)
+boto3 = Boto3Plugin(verifier)
 ```
 
 Each verifier may have at most one `Boto3Plugin`. A second `Boto3Plugin(verifier)` raises `ValueError`.
 
 ## Registering mocks
 
-Use `bigfoot.boto3_mock.mock_call(service, operation, *, returns, ...)` to register a mock before entering the sandbox:
+Use `bigfoot.boto3.mock_call(service, operation, *, returns, ...)` to register a mock before entering the sandbox:
 
 ```python
-bigfoot.boto3_mock.mock_call("sqs", "SendMessage", returns={"MessageId": "abc123"})
-bigfoot.boto3_mock.mock_call("dynamodb", "PutItem", returns={})
+bigfoot.boto3.mock_call("sqs", "SendMessage", returns={"MessageId": "abc123"})
+bigfoot.boto3.mock_call("dynamodb", "PutItem", returns={})
 ```
 
 ### Parameters
@@ -74,11 +74,11 @@ Each service:operation pair has its own independent FIFO queue. Multiple `mock_c
 
 ```python
 def test_multiple_s3_gets():
-    bigfoot.boto3_mock.mock_call(
+    bigfoot.boto3.mock_call(
         "s3", "GetObject",
         returns={"Body": b"first", "ContentLength": 5},
     )
-    bigfoot.boto3_mock.mock_call(
+    bigfoot.boto3.mock_call(
         "s3", "GetObject",
         returns={"Body": b"second", "ContentLength": 6},
     )
@@ -92,11 +92,11 @@ def test_multiple_s3_gets():
     assert r1["Body"] == b"first"
     assert r2["Body"] == b"second"
 
-    bigfoot.boto3_mock.assert_boto3_call(
+    bigfoot.boto3.assert_boto3_call(
         service="s3", operation="GetObject",
         params={"Bucket": "bucket", "Key": "a.txt"},
     )
-    bigfoot.boto3_mock.assert_boto3_call(
+    bigfoot.boto3.assert_boto3_call(
         service="s3", operation="GetObject",
         params={"Bucket": "bucket", "Key": "b.txt"},
     )
@@ -104,12 +104,12 @@ def test_multiple_s3_gets():
 
 ## Asserting interactions
 
-Use the `assert_boto3_call` helper on `bigfoot.boto3_mock`. All three fields (`service`, `operation`, `params`) are required:
+Use the `assert_boto3_call` helper on `bigfoot.boto3`. All three fields (`service`, `operation`, `params`) are required:
 
 ### `assert_boto3_call(service, operation, *, params)`
 
 ```python
-bigfoot.boto3_mock.assert_boto3_call(
+bigfoot.boto3.assert_boto3_call(
     service="sqs",
     operation="SendMessage",
     params={"QueueUrl": "https://sqs.us-east-1.amazonaws.com/123/my-queue", "MessageBody": "hello"},
@@ -132,7 +132,7 @@ import bigfoot
 
 def test_s3_not_found():
     error_response = {"Error": {"Code": "NoSuchKey", "Message": "The specified key does not exist."}}
-    bigfoot.boto3_mock.mock_call(
+    bigfoot.boto3.mock_call(
         "s3", "GetObject",
         returns=None,
         raises=ClientError(error_response, "GetObject"),
@@ -146,7 +146,7 @@ def test_s3_not_found():
 
     assert exc_info.value.response["Error"]["Code"] == "NoSuchKey"
 
-    bigfoot.boto3_mock.assert_boto3_call(
+    bigfoot.boto3.assert_boto3_call(
         service="s3", operation="GetObject",
         params={"Bucket": "my-bucket", "Key": "missing.csv"},
     )
@@ -171,7 +171,7 @@ def test_s3_not_found():
 Mark a mock as optional with `required=False`:
 
 ```python
-bigfoot.boto3_mock.mock_call("cloudwatch", "PutMetricData", returns={}, required=False)
+bigfoot.boto3.mock_call("cloudwatch", "PutMetricData", returns={}, required=False)
 ```
 
 An optional mock that is never triggered does not cause `UnusedMocksError` at teardown.
@@ -183,5 +183,5 @@ When code calls a boto3 API operation that has no remaining mocks in its queue, 
 ```
 s3.GetObject(...) was called but no mock was registered.
 Register a mock with:
-    bigfoot.boto3_mock.mock_call('s3', 'GetObject', returns=...)
+    bigfoot.boto3.mock_call('s3', 'GetObject', returns=...)
 ```

--- a/docs/guides/celery-plugin.md
+++ b/docs/guides/celery-plugin.md
@@ -12,13 +12,13 @@ This installs `celery`.
 
 ## Setup
 
-In pytest, access `CeleryPlugin` through the `bigfoot.celery_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `CeleryPlugin` through the `bigfoot.celery` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import bigfoot
 
 def test_send_welcome_email():
-    bigfoot.celery_mock.mock_delay(
+    bigfoot.celery.mock_delay(
         "myapp.tasks.send_email",
         returns=None,
     )
@@ -27,7 +27,7 @@ def test_send_welcome_email():
         from myapp.tasks import send_email
         send_email.delay("user@example.com", "Welcome!")
 
-    bigfoot.celery_mock.assert_delay(
+    bigfoot.celery.assert_delay(
         task_name="myapp.tasks.send_email",
         args=("user@example.com", "Welcome!"),
         kwargs={},
@@ -42,7 +42,7 @@ from bigfoot import StrictVerifier
 from bigfoot.plugins.celery_plugin import CeleryPlugin
 
 verifier = StrictVerifier()
-celery_mock = CeleryPlugin(verifier)
+celery = CeleryPlugin(verifier)
 ```
 
 Each verifier may have at most one `CeleryPlugin`. A second `CeleryPlugin(verifier)` raises `ValueError`.
@@ -54,7 +54,7 @@ CeleryPlugin provides two mock registration methods, one for each dispatch metho
 ### `mock_delay(task_name, *, returns, ...)`
 
 ```python
-bigfoot.celery_mock.mock_delay("myapp.tasks.process_order", returns=None)
+bigfoot.celery.mock_delay("myapp.tasks.process_order", returns=None)
 ```
 
 | Parameter | Type | Default | Description |
@@ -67,7 +67,7 @@ bigfoot.celery_mock.mock_delay("myapp.tasks.process_order", returns=None)
 ### `mock_apply_async(task_name, *, returns, ...)`
 
 ```python
-bigfoot.celery_mock.mock_apply_async("myapp.tasks.generate_report", returns=None)
+bigfoot.celery.mock_apply_async("myapp.tasks.generate_report", returns=None)
 ```
 
 | Parameter | Type | Default | Description |
@@ -83,21 +83,21 @@ Each task_name:dispatch_method pair has its own independent FIFO queue. Multiple
 
 ```python
 def test_multiple_email_dispatches():
-    bigfoot.celery_mock.mock_delay("myapp.tasks.send_email", returns=None)
-    bigfoot.celery_mock.mock_delay("myapp.tasks.send_email", returns=None)
+    bigfoot.celery.mock_delay("myapp.tasks.send_email", returns=None)
+    bigfoot.celery.mock_delay("myapp.tasks.send_email", returns=None)
 
     with bigfoot:
         from myapp.tasks import send_email
         send_email.delay("alice@example.com", "Hello Alice")
         send_email.delay("bob@example.com", "Hello Bob")
 
-    bigfoot.celery_mock.assert_delay(
+    bigfoot.celery.assert_delay(
         task_name="myapp.tasks.send_email",
         args=("alice@example.com", "Hello Alice"),
         kwargs={},
         options={},
     )
-    bigfoot.celery_mock.assert_delay(
+    bigfoot.celery.assert_delay(
         task_name="myapp.tasks.send_email",
         args=("bob@example.com", "Hello Bob"),
         kwargs={},
@@ -107,12 +107,12 @@ def test_multiple_email_dispatches():
 
 ## Asserting interactions
 
-Use the typed assertion helpers on `bigfoot.celery_mock`. All four fields (`task_name`, `args`, `kwargs`, `options`) are required:
+Use the typed assertion helpers on `bigfoot.celery`. All four fields (`task_name`, `args`, `kwargs`, `options`) are required:
 
 ### `assert_delay(task_name, args, kwargs, options)`
 
 ```python
-bigfoot.celery_mock.assert_delay(
+bigfoot.celery.assert_delay(
     task_name="myapp.tasks.send_email",
     args=("user@example.com", "Welcome!"),
     kwargs={},
@@ -130,7 +130,7 @@ bigfoot.celery_mock.assert_delay(
 ### `assert_apply_async(task_name, args, kwargs, options)`
 
 ```python
-bigfoot.celery_mock.assert_apply_async(
+bigfoot.celery.assert_apply_async(
     task_name="myapp.tasks.generate_report",
     args=("q1", 2024),
     kwargs={"format": "pdf"},
@@ -153,7 +153,7 @@ Use the `raises` parameter to simulate Celery dispatch failures:
 import bigfoot
 
 def test_celery_dispatch_error():
-    bigfoot.celery_mock.mock_delay(
+    bigfoot.celery.mock_delay(
         "myapp.tasks.send_email",
         returns=None,
         raises=ConnectionError("Broker unavailable"),
@@ -164,7 +164,7 @@ def test_celery_dispatch_error():
         with pytest.raises(ConnectionError):
             send_email.delay("user@example.com", "Hello")
 
-    bigfoot.celery_mock.assert_delay(
+    bigfoot.celery.assert_delay(
         task_name="myapp.tasks.send_email",
         args=("user@example.com", "Hello"),
         kwargs={},
@@ -191,7 +191,7 @@ def test_celery_dispatch_error():
 Mark a mock as optional with `required=False`:
 
 ```python
-bigfoot.celery_mock.mock_delay("myapp.tasks.update_metrics", returns=None, required=False)
+bigfoot.celery.mock_delay("myapp.tasks.update_metrics", returns=None, required=False)
 ```
 
 An optional mock that is never triggered does not cause `UnusedMocksError` at teardown.
@@ -203,5 +203,5 @@ When code calls `delay()` or `apply_async()` on a task that has no remaining moc
 ```
 celery.delay('myapp.tasks.send_email', ...) was called but no mock was registered.
 Register a mock with:
-    bigfoot.celery_mock.mock_delay('myapp.tasks.send_email', returns=...)
+    bigfoot.celery.mock_delay('myapp.tasks.send_email', returns=...)
 ```

--- a/docs/guides/crypto-plugin.md
+++ b/docs/guides/crypto-plugin.md
@@ -12,13 +12,13 @@ This installs `cryptography`.
 
 ## Setup
 
-In pytest, access `CryptoPlugin` through the `bigfoot.crypto_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `CryptoPlugin` through the `bigfoot.crypto` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import bigfoot
 
 def test_encrypt_payload():
-    bigfoot.crypto_mock.mock_encrypt(returns=b"gAAAAABencrypted...")
+    bigfoot.crypto.mock_encrypt(returns=b"gAAAAABencrypted...")
 
     with bigfoot:
         from cryptography.fernet import Fernet
@@ -27,7 +27,7 @@ def test_encrypt_payload():
 
     assert ciphertext == b"gAAAAABencrypted..."
 
-    bigfoot.crypto_mock.assert_encrypt(plaintext_length=14)
+    bigfoot.crypto.assert_encrypt(plaintext_length=14)
 ```
 
 For manual use outside pytest, construct `CryptoPlugin` explicitly:
@@ -37,7 +37,7 @@ from bigfoot import StrictVerifier
 from bigfoot.plugins.crypto_plugin import CryptoPlugin
 
 verifier = StrictVerifier()
-crypto_mock = CryptoPlugin(verifier)
+crypto = CryptoPlugin(verifier)
 ```
 
 Each verifier may have at most one `CryptoPlugin`. A second `CryptoPlugin(verifier)` raises `ValueError`.
@@ -51,7 +51,7 @@ Each verifier may have at most one `CryptoPlugin`. A second `CryptoPlugin(verifi
 Register a mock for `Fernet.encrypt()`:
 
 ```python
-bigfoot.crypto_mock.mock_encrypt(returns=b"gAAAAABencrypted_token")
+bigfoot.crypto.mock_encrypt(returns=b"gAAAAABencrypted_token")
 ```
 
 | Parameter | Type | Default | Description |
@@ -65,7 +65,7 @@ bigfoot.crypto_mock.mock_encrypt(returns=b"gAAAAABencrypted_token")
 Register a mock for `Fernet.decrypt()`:
 
 ```python
-bigfoot.crypto_mock.mock_decrypt(returns=b"decrypted plaintext")
+bigfoot.crypto.mock_decrypt(returns=b"decrypted plaintext")
 ```
 
 | Parameter | Type | Default | Description |
@@ -79,7 +79,7 @@ bigfoot.crypto_mock.mock_decrypt(returns=b"decrypted plaintext")
 Register a mock for `rsa.generate_private_key()`:
 
 ```python
-bigfoot.crypto_mock.mock_generate_key(returns=mock_private_key)
+bigfoot.crypto.mock_generate_key(returns=mock_private_key)
 ```
 
 | Parameter | Type | Default | Description |
@@ -94,8 +94,8 @@ Each operation (`fernet_encrypt`, `fernet_decrypt`, `generate_key`) has its own 
 
 ```python
 def test_encrypt_multiple_fields():
-    bigfoot.crypto_mock.mock_encrypt(returns=b"encrypted_email")
-    bigfoot.crypto_mock.mock_encrypt(returns=b"encrypted_ssn")
+    bigfoot.crypto.mock_encrypt(returns=b"encrypted_email")
+    bigfoot.crypto.mock_encrypt(returns=b"encrypted_ssn")
 
     with bigfoot:
         from cryptography.fernet import Fernet
@@ -106,20 +106,20 @@ def test_encrypt_multiple_fields():
     assert ct1 == b"encrypted_email"
     assert ct2 == b"encrypted_ssn"
 
-    bigfoot.crypto_mock.assert_encrypt(plaintext_length=17)
-    bigfoot.crypto_mock.assert_encrypt(plaintext_length=11)
+    bigfoot.crypto.assert_encrypt(plaintext_length=17)
+    bigfoot.crypto.assert_encrypt(plaintext_length=11)
 ```
 
 ## Asserting interactions
 
-Use the typed assertion helpers on `bigfoot.crypto_mock`.
+Use the typed assertion helpers on `bigfoot.crypto`.
 
 ### `assert_encrypt(*, plaintext_length)`
 
 Asserts the next `Fernet.encrypt()` interaction. Only the plaintext length is recorded, not the actual data.
 
 ```python
-bigfoot.crypto_mock.assert_encrypt(plaintext_length=14)
+bigfoot.crypto.assert_encrypt(plaintext_length=14)
 ```
 
 | Parameter | Type | Description |
@@ -131,7 +131,7 @@ bigfoot.crypto_mock.assert_encrypt(plaintext_length=14)
 Asserts the next `Fernet.decrypt()` interaction. The token (ciphertext) is safe to record since it is not secret.
 
 ```python
-bigfoot.crypto_mock.assert_decrypt(token=b"gAAAAABencrypted_token", ttl=None)
+bigfoot.crypto.assert_decrypt(token=b"gAAAAABencrypted_token", ttl=None)
 ```
 
 | Parameter | Type | Default | Description |
@@ -144,7 +144,7 @@ bigfoot.crypto_mock.assert_decrypt(token=b"gAAAAABencrypted_token", ttl=None)
 Asserts the next `rsa.generate_private_key()` interaction.
 
 ```python
-bigfoot.crypto_mock.assert_generate_key(algorithm="RSA", key_size=2048)
+bigfoot.crypto.assert_generate_key(algorithm="RSA", key_size=2048)
 ```
 
 | Parameter | Type | Description |
@@ -169,7 +169,7 @@ from cryptography.fernet import InvalidToken
 import bigfoot
 
 def test_invalid_token():
-    bigfoot.crypto_mock.mock_decrypt(
+    bigfoot.crypto.mock_decrypt(
         returns=None,
         raises=InvalidToken(),
     )
@@ -180,7 +180,7 @@ def test_invalid_token():
         with pytest.raises(InvalidToken):
             f.decrypt(b"corrupted_ciphertext")
 
-    bigfoot.crypto_mock.assert_decrypt(token=b"corrupted_ciphertext", ttl=None)
+    bigfoot.crypto.assert_decrypt(token=b"corrupted_ciphertext", ttl=None)
 ```
 
 ## Full example
@@ -202,7 +202,7 @@ def test_invalid_token():
 Mark a mock as optional with `required=False`:
 
 ```python
-bigfoot.crypto_mock.mock_encrypt(returns=b"optional_ct", required=False)
+bigfoot.crypto.mock_encrypt(returns=b"optional_ct", required=False)
 ```
 
 An optional mock that is never triggered does not cause `UnusedMocksError` at teardown.
@@ -214,5 +214,5 @@ When code calls an intercepted cryptography function with no remaining mocks in 
 ```
 crypto.fernet_encrypt(...) was called but no mock was registered.
 Register a mock with:
-    bigfoot.crypto_mock.mock_encrypt(returns=...)
+    bigfoot.crypto.mock_encrypt(returns=...)
 ```

--- a/docs/guides/database-plugin.md
+++ b/docs/guides/database-plugin.md
@@ -4,13 +4,13 @@
 
 ## Setup
 
-In pytest, access `DatabasePlugin` through the `bigfoot.db_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `DatabasePlugin` through the `bigfoot.db` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import bigfoot
 
 def test_select_users():
-    (bigfoot.db_mock
+    (bigfoot.db
         .new_session()
         .expect("connect",  returns=None)
         .expect("execute",  returns=[[1, "Alice"], [2, "Bob"]])
@@ -25,9 +25,9 @@ def test_select_users():
 
     assert rows == [[1, "Alice"], [2, "Bob"]]
 
-    bigfoot.db_mock.assert_connect(database=":memory:")
-    bigfoot.db_mock.assert_execute(sql="SELECT id, name FROM users", parameters=())
-    bigfoot.db_mock.assert_close()
+    bigfoot.db.assert_connect(database=":memory:")
+    bigfoot.db.assert_execute(sql="SELECT id, name FROM users", parameters=())
+    bigfoot.db.assert_close()
 ```
 
 For manual use outside pytest, construct `DatabasePlugin` explicitly:
@@ -60,7 +60,7 @@ in_transaction --close--> closed
 Use `new_session()` to create a `SessionHandle` and chain `.expect()` calls:
 
 ```python
-(bigfoot.db_mock
+(bigfoot.db
     .new_session()
     .expect("connect",  returns=None)
     .expect("execute",  returns=[["row1"], ["row2"]])
@@ -92,7 +92,7 @@ Use `new_session()` to create a `SessionHandle` and chain `.expect()` calls:
 The fake connection's `execute()` method returns a cursor proxy. The rows you specify in `returns=` are available through the standard cursor methods:
 
 ```python
-(bigfoot.db_mock
+(bigfoot.db
     .new_session()
     .expect("connect",  returns=None)
     .expect("execute",  returns=[[1, "Alice"], [2, "Bob"], [3, "Carol"]])
@@ -129,14 +129,14 @@ Both styles produce the same interactions on the timeline.
 
 ## Asserting interactions
 
-Each step records an interaction on the timeline. Use the typed assertion helpers on `bigfoot.db_mock`:
+Each step records an interaction on the timeline. Use the typed assertion helpers on `bigfoot.db`:
 
 ### `assert_connect(*, database)`
 
 Asserts the next connect interaction. The `database` field is required.
 
 ```python
-bigfoot.db_mock.assert_connect(database=":memory:")
+bigfoot.db.assert_connect(database=":memory:")
 ```
 
 ### `assert_execute(*, sql, parameters)`
@@ -144,7 +144,7 @@ bigfoot.db_mock.assert_connect(database=":memory:")
 Asserts the next execute interaction. Both `sql` and `parameters` are required.
 
 ```python
-bigfoot.db_mock.assert_execute(sql="INSERT INTO users (name) VALUES (?)", parameters=("Alice",))
+bigfoot.db.assert_execute(sql="INSERT INTO users (name) VALUES (?)", parameters=("Alice",))
 ```
 
 ### `assert_commit()`
@@ -152,7 +152,7 @@ bigfoot.db_mock.assert_execute(sql="INSERT INTO users (name) VALUES (?)", parame
 Asserts the next commit interaction. No fields are required.
 
 ```python
-bigfoot.db_mock.assert_commit()
+bigfoot.db.assert_commit()
 ```
 
 ### `assert_rollback()`
@@ -160,7 +160,7 @@ bigfoot.db_mock.assert_commit()
 Asserts the next rollback interaction. No fields are required.
 
 ```python
-bigfoot.db_mock.assert_rollback()
+bigfoot.db.assert_rollback()
 ```
 
 ### `assert_close()`
@@ -168,7 +168,7 @@ bigfoot.db_mock.assert_rollback()
 Asserts the next close interaction. No fields are required.
 
 ```python
-bigfoot.db_mock.assert_close()
+bigfoot.db.assert_close()
 ```
 
 ## Commit and rollback
@@ -177,7 +177,7 @@ Each `execute()` moves the connection into `in_transaction`. `commit()` and `rol
 
 ```python
 def test_commit_then_execute():
-    (bigfoot.db_mock
+    (bigfoot.db
         .new_session()
         .expect("connect",  returns=None)
         .expect("execute",  returns=[])
@@ -192,11 +192,11 @@ def test_commit_then_execute():
         conn.execute("INSERT INTO t VALUES (2)")
         conn.close()
 
-    bigfoot.db_mock.assert_connect(database=":memory:")
-    bigfoot.db_mock.assert_execute(sql="INSERT INTO t VALUES (1)", parameters=())
-    bigfoot.db_mock.assert_commit()
-    bigfoot.db_mock.assert_execute(sql="INSERT INTO t VALUES (2)", parameters=())
-    bigfoot.db_mock.assert_close()
+    bigfoot.db.assert_connect(database=":memory:")
+    bigfoot.db.assert_execute(sql="INSERT INTO t VALUES (1)", parameters=())
+    bigfoot.db.assert_commit()
+    bigfoot.db.assert_execute(sql="INSERT INTO t VALUES (2)", parameters=())
+    bigfoot.db.assert_close()
 ```
 
 Calling `commit()` from `connected` (before any `execute()`) raises `InvalidStateError`.

--- a/docs/guides/dns-plugin.md
+++ b/docs/guides/dns-plugin.md
@@ -6,21 +6,21 @@
 
 `DnsPlugin` intercepts stdlib `socket` functions, so no extra installation is needed. If you also want to intercept `dnspython` resolution, install it separately.
 
-In pytest, access `DnsPlugin` through the `bigfoot.dns_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `DnsPlugin` through the `bigfoot.dns` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import socket
 import bigfoot
 
 def test_hostname_resolution():
-    bigfoot.dns_mock.mock_gethostbyname("api.example.com", returns="93.184.216.34")
+    bigfoot.dns.mock_gethostbyname("api.example.com", returns="93.184.216.34")
 
     with bigfoot:
         ip = socket.gethostbyname("api.example.com")
 
     assert ip == "93.184.216.34"
 
-    bigfoot.dns_mock.assert_gethostbyname(hostname="api.example.com")
+    bigfoot.dns.assert_gethostbyname(hostname="api.example.com")
 ```
 
 For manual use outside pytest, construct `DnsPlugin` explicitly:
@@ -30,7 +30,7 @@ from bigfoot import StrictVerifier
 from bigfoot.plugins.dns_plugin import DnsPlugin
 
 verifier = StrictVerifier()
-dns_mock = DnsPlugin(verifier)
+dns = DnsPlugin(verifier)
 ```
 
 Each verifier may have at most one `DnsPlugin`. A second `DnsPlugin(verifier)` raises `ValueError`.
@@ -44,7 +44,7 @@ Each verifier may have at most one `DnsPlugin`. A second `DnsPlugin(verifier)` r
 Register a mock for `socket.getaddrinfo()`:
 
 ```python
-bigfoot.dns_mock.mock_getaddrinfo(
+bigfoot.dns.mock_getaddrinfo(
     "api.example.com",
     returns=[(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))],
 )
@@ -62,7 +62,7 @@ bigfoot.dns_mock.mock_getaddrinfo(
 Register a mock for `socket.gethostbyname()`:
 
 ```python
-bigfoot.dns_mock.mock_gethostbyname("db.internal", returns="10.0.1.5")
+bigfoot.dns.mock_gethostbyname("db.internal", returns="10.0.1.5")
 ```
 
 | Parameter | Type | Default | Description |
@@ -77,7 +77,7 @@ bigfoot.dns_mock.mock_gethostbyname("db.internal", returns="10.0.1.5")
 Register a mock for `dns.resolver.resolve()` (requires dnspython):
 
 ```python
-bigfoot.dns_mock.mock_resolve("mail.example.com", "MX", returns=mock_mx_answer)
+bigfoot.dns.mock_resolve("mail.example.com", "MX", returns=mock_mx_answer)
 ```
 
 | Parameter | Type | Default | Description |
@@ -94,8 +94,8 @@ Each hostname (scoped by operation type) has its own independent FIFO queue. Mul
 
 ```python
 def test_multiple_resolutions():
-    bigfoot.dns_mock.mock_gethostbyname("api.example.com", returns="93.184.216.34")
-    bigfoot.dns_mock.mock_gethostbyname("api.example.com", returns="93.184.216.35")
+    bigfoot.dns.mock_gethostbyname("api.example.com", returns="93.184.216.34")
+    bigfoot.dns.mock_gethostbyname("api.example.com", returns="93.184.216.35")
 
     with bigfoot:
         ip1 = socket.gethostbyname("api.example.com")
@@ -104,18 +104,18 @@ def test_multiple_resolutions():
     assert ip1 == "93.184.216.34"
     assert ip2 == "93.184.216.35"
 
-    bigfoot.dns_mock.assert_gethostbyname(hostname="api.example.com")
-    bigfoot.dns_mock.assert_gethostbyname(hostname="api.example.com")
+    bigfoot.dns.assert_gethostbyname(hostname="api.example.com")
+    bigfoot.dns.assert_gethostbyname(hostname="api.example.com")
 ```
 
 ## Asserting interactions
 
-Use the typed assertion helpers on `bigfoot.dns_mock`. Each helper requires all detail fields for its operation type.
+Use the typed assertion helpers on `bigfoot.dns`. Each helper requires all detail fields for its operation type.
 
 ### `assert_getaddrinfo(host, port, family, type, proto)`
 
 ```python
-bigfoot.dns_mock.assert_getaddrinfo(
+bigfoot.dns.assert_getaddrinfo(
     host="api.example.com",
     port=443,
     family=socket.AF_INET,
@@ -135,7 +135,7 @@ bigfoot.dns_mock.assert_getaddrinfo(
 ### `assert_gethostbyname(hostname)`
 
 ```python
-bigfoot.dns_mock.assert_gethostbyname(hostname="api.example.com")
+bigfoot.dns.assert_gethostbyname(hostname="api.example.com")
 ```
 
 | Parameter | Type | Description |
@@ -145,7 +145,7 @@ bigfoot.dns_mock.assert_gethostbyname(hostname="api.example.com")
 ### `assert_resolve(qname, rdtype)`
 
 ```python
-bigfoot.dns_mock.assert_resolve(qname="mail.example.com", rdtype="MX")
+bigfoot.dns.assert_resolve(qname="mail.example.com", rdtype="MX")
 ```
 
 | Parameter | Type | Description |
@@ -162,7 +162,7 @@ import socket
 import bigfoot
 
 def test_dns_resolution_failure():
-    bigfoot.dns_mock.mock_gethostbyname(
+    bigfoot.dns.mock_gethostbyname(
         "nonexistent.example.com",
         returns=None,
         raises=socket.gaierror(8, "nodename nor servname provided, or not known"),
@@ -172,7 +172,7 @@ def test_dns_resolution_failure():
         with pytest.raises(socket.gaierror):
             socket.gethostbyname("nonexistent.example.com")
 
-    bigfoot.dns_mock.assert_gethostbyname(hostname="nonexistent.example.com")
+    bigfoot.dns.assert_gethostbyname(hostname="nonexistent.example.com")
 ```
 
 ## Full example
@@ -194,7 +194,7 @@ def test_dns_resolution_failure():
 Mark a mock as optional with `required=False`:
 
 ```python
-bigfoot.dns_mock.mock_gethostbyname("optional.host", returns="127.0.0.1", required=False)
+bigfoot.dns.mock_gethostbyname("optional.host", returns="127.0.0.1", required=False)
 ```
 
 An optional mock that is never triggered does not cause `UnusedMocksError` at teardown.
@@ -206,5 +206,5 @@ When code calls a DNS function for a hostname that has no remaining mocks in its
 ```
 socket.gethostbyname('unknown.host') was called but no mock was registered.
 Register a mock with:
-    bigfoot.dns_mock.mock_gethostbyname('unknown.host', returns=...)
+    bigfoot.dns.mock_gethostbyname('unknown.host', returns=...)
 ```

--- a/docs/guides/elasticsearch-plugin.md
+++ b/docs/guides/elasticsearch-plugin.md
@@ -12,13 +12,13 @@ This installs `elasticsearch`.
 
 ## Setup
 
-In pytest, access `ElasticsearchPlugin` through the `bigfoot.elasticsearch_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `ElasticsearchPlugin` through the `bigfoot.elasticsearch` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import bigfoot
 
 def test_index_document():
-    bigfoot.elasticsearch_mock.mock_operation(
+    bigfoot.elasticsearch.mock_operation(
         "index",
         returns={"_id": "doc_1", "result": "created"},
     )
@@ -30,7 +30,7 @@ def test_index_document():
 
     assert result["result"] == "created"
 
-    bigfoot.elasticsearch_mock.assert_index(
+    bigfoot.elasticsearch.assert_index(
         index="products",
         document={"name": "Widget", "price": 9.99},
         id="doc_1",
@@ -51,11 +51,11 @@ Each verifier may have at most one `ElasticsearchPlugin`. A second `Elasticsearc
 
 ## Registering mock operations
 
-Use `bigfoot.elasticsearch_mock.mock_operation(operation, *, returns, ...)` to register a mock before entering the sandbox:
+Use `bigfoot.elasticsearch.mock_operation(operation, *, returns, ...)` to register a mock before entering the sandbox:
 
 ```python
-bigfoot.elasticsearch_mock.mock_operation("search", returns={"hits": {"hits": [], "total": {"value": 0}}})
-bigfoot.elasticsearch_mock.mock_operation("index", returns={"_id": "1", "result": "created"})
+bigfoot.elasticsearch.mock_operation("search", returns={"hits": {"hits": [], "total": {"value": 0}}})
+bigfoot.elasticsearch.mock_operation("index", returns={"_id": "1", "result": "created"})
 ```
 
 ### Parameters
@@ -89,11 +89,11 @@ Each operation name has its own independent FIFO queue. Multiple `mock_operation
 
 ```python
 def test_paginated_search():
-    bigfoot.elasticsearch_mock.mock_operation(
+    bigfoot.elasticsearch.mock_operation(
         "search",
         returns={"hits": {"hits": [{"_id": "1"}], "total": {"value": 25}}},
     )
-    bigfoot.elasticsearch_mock.mock_operation(
+    bigfoot.elasticsearch.mock_operation(
         "search",
         returns={"hits": {"hits": [{"_id": "11"}], "total": {"value": 25}}},
     )
@@ -107,18 +107,18 @@ def test_paginated_search():
     assert page1["hits"]["hits"][0]["_id"] == "1"
     assert page2["hits"]["hits"][0]["_id"] == "11"
 
-    bigfoot.elasticsearch_mock.assert_search(index="logs", query={"match_all": {}}, size=10)
-    bigfoot.elasticsearch_mock.assert_search(index="logs", query={"match_all": {}}, size=10, from_=10)
+    bigfoot.elasticsearch.assert_search(index="logs", query={"match_all": {}}, size=10)
+    bigfoot.elasticsearch.assert_search(index="logs", query={"match_all": {}}, size=10, from_=10)
 ```
 
 ## Asserting interactions
 
-Use the typed assertion helpers on `bigfoot.elasticsearch_mock`. Each helper accepts keyword arguments matching the detail fields captured for that operation.
+Use the typed assertion helpers on `bigfoot.elasticsearch`. Each helper accepts keyword arguments matching the detail fields captured for that operation.
 
 ### `assert_index(*, index, document, id=None)`
 
 ```python
-bigfoot.elasticsearch_mock.assert_index(
+bigfoot.elasticsearch.assert_index(
     index="products",
     document={"name": "Widget", "price": 9.99},
     id="doc_1",
@@ -134,7 +134,7 @@ bigfoot.elasticsearch_mock.assert_index(
 ### `assert_search(*, index=None, query=None, size=None, from_=None)`
 
 ```python
-bigfoot.elasticsearch_mock.assert_search(
+bigfoot.elasticsearch.assert_search(
     index="logs",
     query={"match": {"level": "error"}},
     size=50,
@@ -151,7 +151,7 @@ bigfoot.elasticsearch_mock.assert_search(
 ### `assert_get(*, index, id)`
 
 ```python
-bigfoot.elasticsearch_mock.assert_get(index="products", id="doc_1")
+bigfoot.elasticsearch.assert_get(index="products", id="doc_1")
 ```
 
 | Parameter | Type | Description |
@@ -162,7 +162,7 @@ bigfoot.elasticsearch_mock.assert_get(index="products", id="doc_1")
 ### `assert_delete(*, index, id)`
 
 ```python
-bigfoot.elasticsearch_mock.assert_delete(index="products", id="doc_1")
+bigfoot.elasticsearch.assert_delete(index="products", id="doc_1")
 ```
 
 | Parameter | Type | Description |
@@ -173,7 +173,7 @@ bigfoot.elasticsearch_mock.assert_delete(index="products", id="doc_1")
 ### `assert_bulk(*, operations)`
 
 ```python
-bigfoot.elasticsearch_mock.assert_bulk(
+bigfoot.elasticsearch.assert_bulk(
     operations=[
         {"index": {"_index": "logs", "_id": "1"}},
         {"message": "first log entry"},
@@ -194,7 +194,7 @@ from elasticsearch import NotFoundError
 import bigfoot
 
 def test_document_not_found():
-    bigfoot.elasticsearch_mock.mock_operation(
+    bigfoot.elasticsearch.mock_operation(
         "get",
         returns=None,
         raises=NotFoundError(404, "document_missing_exception", {"_index": "products", "_id": "missing"}),
@@ -206,7 +206,7 @@ def test_document_not_found():
         with pytest.raises(NotFoundError):
             es.get(index="products", id="missing")
 
-    bigfoot.elasticsearch_mock.assert_get(index="products", id="missing")
+    bigfoot.elasticsearch.assert_get(index="products", id="missing")
 ```
 
 ## Full example
@@ -228,7 +228,7 @@ def test_document_not_found():
 Mark a mock as optional with `required=False`:
 
 ```python
-bigfoot.elasticsearch_mock.mock_operation("count", returns={"count": 0}, required=False)
+bigfoot.elasticsearch.mock_operation("count", returns={"count": 0}, required=False)
 ```
 
 An optional mock that is never triggered does not cause `UnusedMocksError` at teardown.
@@ -240,5 +240,5 @@ When code calls an Elasticsearch method that has no remaining mocks in its queue
 ```
 elasticsearch.search(...) was called but no mock was registered.
 Register a mock with:
-    bigfoot.elasticsearch_mock.mock_operation('search', returns=...)
+    bigfoot.elasticsearch.mock_operation('search', returns=...)
 ```

--- a/docs/guides/file-io-plugin.md
+++ b/docs/guides/file-io-plugin.md
@@ -2,17 +2,17 @@
 
 `FileIoPlugin` intercepts file system operations across `builtins.open`, `pathlib.Path` read/write methods, `os` file operations, and `shutil` copy/remove operations. Each operation+path combination has its own independent FIFO queue. The plugin uses a `ContextVar`-based reentrancy guard to prevent self-interference with bigfoot's own file I/O.
 
-**Important:** `FileIoPlugin` is always available (no extra install required) but is NOT default enabled. You must explicitly enable it via `enabled_plugins = ["file_io"]` in your bigfoot config, or access it through the `bigfoot.file_io_mock` proxy.
+**Important:** `FileIoPlugin` is always available (no extra install required) but is NOT default enabled. You must explicitly enable it via `enabled_plugins = ["file_io"]` in your bigfoot config, or access it through the `bigfoot.file_io` proxy.
 
 ## Setup
 
-In pytest, access `FileIoPlugin` through the `bigfoot.file_io_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `FileIoPlugin` through the `bigfoot.file_io` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import bigfoot
 
 def test_read_config():
-    bigfoot.file_io_mock.mock_operation(
+    bigfoot.file_io.mock_operation(
         "read_text", "/etc/myapp/config.yaml",
         returns="database:\n  host: localhost\n  port: 5432",
     )
@@ -23,7 +23,7 @@ def test_read_config():
 
     assert "localhost" in config
 
-    bigfoot.file_io_mock.assert_read_text(path="/etc/myapp/config.yaml")
+    bigfoot.file_io.assert_read_text(path="/etc/myapp/config.yaml")
 ```
 
 For manual use outside pytest, construct `FileIoPlugin` explicitly:
@@ -33,18 +33,18 @@ from bigfoot import StrictVerifier
 from bigfoot.plugins.file_io_plugin import FileIoPlugin
 
 verifier = StrictVerifier()
-file_io_mock = FileIoPlugin(verifier)
+file_io = FileIoPlugin(verifier)
 ```
 
 Each verifier may have at most one `FileIoPlugin`. A second `FileIoPlugin(verifier)` raises `ValueError`.
 
 ## Registering mocks
 
-Use `bigfoot.file_io_mock.mock_operation(operation, path_pattern, *, returns, ...)` to register a mock before entering the sandbox:
+Use `bigfoot.file_io.mock_operation(operation, path_pattern, *, returns, ...)` to register a mock before entering the sandbox:
 
 ```python
-bigfoot.file_io_mock.mock_operation("open", "/tmp/data.csv", returns="id,name\n1,Alice")
-bigfoot.file_io_mock.mock_operation("remove", "/tmp/data.csv", returns=None)
+bigfoot.file_io.mock_operation("open", "/tmp/data.csv", returns="id,name\n1,Alice")
+bigfoot.file_io.mock_operation("remove", "/tmp/data.csv", returns=None)
 ```
 
 ### Parameters
@@ -83,8 +83,8 @@ Each operation+path combination has its own independent FIFO queue. Multiple moc
 
 ```python
 def test_multiple_reads():
-    bigfoot.file_io_mock.mock_operation("read_text", "/etc/myapp/config.yaml", returns="v1")
-    bigfoot.file_io_mock.mock_operation("read_text", "/etc/myapp/config.yaml", returns="v2")
+    bigfoot.file_io.mock_operation("read_text", "/etc/myapp/config.yaml", returns="v1")
+    bigfoot.file_io.mock_operation("read_text", "/etc/myapp/config.yaml", returns="v2")
 
     with bigfoot:
         from pathlib import Path
@@ -94,44 +94,44 @@ def test_multiple_reads():
     assert first == "v1"
     assert second == "v2"
 
-    bigfoot.file_io_mock.assert_read_text(path="/etc/myapp/config.yaml")
-    bigfoot.file_io_mock.assert_read_text(path="/etc/myapp/config.yaml")
+    bigfoot.file_io.assert_read_text(path="/etc/myapp/config.yaml")
+    bigfoot.file_io.assert_read_text(path="/etc/myapp/config.yaml")
 ```
 
 ## Asserting interactions
 
-Use the typed assertion helpers on `bigfoot.file_io_mock`:
+Use the typed assertion helpers on `bigfoot.file_io`:
 
 ### `assert_open(**expected)`
 
 All three fields (`path`, `mode`, `encoding`) are required:
 
 ```python
-bigfoot.file_io_mock.assert_open(path="/tmp/data.csv", mode="r", encoding="utf-8")
+bigfoot.file_io.assert_open(path="/tmp/data.csv", mode="r", encoding="utf-8")
 ```
 
 ### `assert_read_text(path)`
 
 ```python
-bigfoot.file_io_mock.assert_read_text(path="/etc/myapp/config.yaml")
+bigfoot.file_io.assert_read_text(path="/etc/myapp/config.yaml")
 ```
 
 ### `assert_read_bytes(path)`
 
 ```python
-bigfoot.file_io_mock.assert_read_bytes(path="/var/data/image.png")
+bigfoot.file_io.assert_read_bytes(path="/var/data/image.png")
 ```
 
 ### `assert_write_text(path, data)`
 
 ```python
-bigfoot.file_io_mock.assert_write_text(path="/tmp/output.txt", data="result: success")
+bigfoot.file_io.assert_write_text(path="/tmp/output.txt", data="result: success")
 ```
 
 ### `assert_write_bytes(path, data)`
 
 ```python
-bigfoot.file_io_mock.assert_write_bytes(path="/tmp/output.bin", data=b"\x00\x01\x02")
+bigfoot.file_io.assert_write_bytes(path="/tmp/output.bin", data=b"\x00\x01\x02")
 ```
 
 ### `assert_remove(path)`
@@ -139,7 +139,7 @@ bigfoot.file_io_mock.assert_write_bytes(path="/tmp/output.bin", data=b"\x00\x01\
 Matches both `os.remove` and `os.unlink` interactions:
 
 ```python
-bigfoot.file_io_mock.assert_remove(path="/tmp/old-file.txt")
+bigfoot.file_io.assert_remove(path="/tmp/old-file.txt")
 ```
 
 ### `assert_rename(src, dst)`
@@ -147,19 +147,19 @@ bigfoot.file_io_mock.assert_remove(path="/tmp/old-file.txt")
 Matches both `os.rename` and `os.replace` interactions:
 
 ```python
-bigfoot.file_io_mock.assert_rename(src="/tmp/draft.txt", dst="/tmp/final.txt")
+bigfoot.file_io.assert_rename(src="/tmp/draft.txt", dst="/tmp/final.txt")
 ```
 
 ### `assert_makedirs(path, exist_ok)`
 
 ```python
-bigfoot.file_io_mock.assert_makedirs(path="/var/data/exports", exist_ok=True)
+bigfoot.file_io.assert_makedirs(path="/var/data/exports", exist_ok=True)
 ```
 
 ### `assert_mkdir(path)`
 
 ```python
-bigfoot.file_io_mock.assert_mkdir(path="/tmp/workdir")
+bigfoot.file_io.assert_mkdir(path="/tmp/workdir")
 ```
 
 ### `assert_copy(src, dst)`
@@ -167,19 +167,19 @@ bigfoot.file_io_mock.assert_mkdir(path="/tmp/workdir")
 Matches both `shutil.copy` and `shutil.copy2` interactions:
 
 ```python
-bigfoot.file_io_mock.assert_copy(src="/etc/myapp/config.yaml", dst="/tmp/config-backup.yaml")
+bigfoot.file_io.assert_copy(src="/etc/myapp/config.yaml", dst="/tmp/config-backup.yaml")
 ```
 
 ### `assert_copytree(src, dst)`
 
 ```python
-bigfoot.file_io_mock.assert_copytree(src="/var/data/source", dst="/var/data/archive")
+bigfoot.file_io.assert_copytree(src="/var/data/source", dst="/var/data/archive")
 ```
 
 ### `assert_rmtree(path)`
 
 ```python
-bigfoot.file_io_mock.assert_rmtree(path="/tmp/build-artifacts")
+bigfoot.file_io.assert_rmtree(path="/tmp/build-artifacts")
 ```
 
 ## Simulating errors
@@ -190,7 +190,7 @@ Use the `raises` parameter to simulate file system errors:
 import bigfoot
 
 def test_file_not_found():
-    bigfoot.file_io_mock.mock_operation(
+    bigfoot.file_io.mock_operation(
         "read_text", "/etc/myapp/config.yaml",
         raises=FileNotFoundError("[Errno 2] No such file or directory: '/etc/myapp/config.yaml'"),
     )
@@ -200,7 +200,7 @@ def test_file_not_found():
         with pytest.raises(FileNotFoundError):
             Path("/etc/myapp/config.yaml").read_text()
 
-    bigfoot.file_io_mock.assert_read_text(path="/etc/myapp/config.yaml")
+    bigfoot.file_io.assert_read_text(path="/etc/myapp/config.yaml")
 ```
 
 ## Full example
@@ -227,7 +227,7 @@ When mocking `open()`, the return value is automatically wrapped in the appropri
 
 ```python
 def test_open_read():
-    bigfoot.file_io_mock.mock_operation(
+    bigfoot.file_io.mock_operation(
         "open", "/tmp/data.csv",
         returns="id,name\n1,Alice\n2,Bob",
     )
@@ -238,7 +238,7 @@ def test_open_read():
 
     assert len(lines) == 3
 
-    bigfoot.file_io_mock.assert_open(path="/tmp/data.csv", mode="r", encoding="utf-8")
+    bigfoot.file_io.assert_open(path="/tmp/data.csv", mode="r", encoding="utf-8")
 ```
 
 ## Optional mocks
@@ -246,7 +246,7 @@ def test_open_read():
 Mark a mock as optional with `required=False`:
 
 ```python
-bigfoot.file_io_mock.mock_operation("read_text", "/tmp/cache.json", returns="{}", required=False)
+bigfoot.file_io.mock_operation("read_text", "/tmp/cache.json", returns="{}", required=False)
 ```
 
 An optional mock that is never triggered does not cause `UnusedMocksError` at teardown.
@@ -258,5 +258,5 @@ When code performs a file operation that has no remaining mocks in its queue, bi
 ```
 Path.read_text('/etc/myapp/config.yaml', ...) was called but no mock was registered.
 Register a mock with:
-    bigfoot.file_io_mock.mock_operation('read_text', '/etc/myapp/config.yaml', returns=...)
+    bigfoot.file_io.mock_operation('read_text', '/etc/myapp/config.yaml', returns=...)
 ```

--- a/docs/guides/grpc-plugin.md
+++ b/docs/guides/grpc-plugin.md
@@ -12,13 +12,13 @@ This installs `grpcio`.
 
 ## Setup
 
-In pytest, access `GrpcPlugin` through the `bigfoot.grpc_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `GrpcPlugin` through the `bigfoot.grpc` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import bigfoot
 
 def test_grpc_unary_call():
-    bigfoot.grpc_mock.mock_unary_unary(
+    bigfoot.grpc.mock_unary_unary(
         "/mypackage.UserService/GetUser",
         returns={"id": 1, "name": "Alice"},
     )
@@ -31,7 +31,7 @@ def test_grpc_unary_call():
 
     assert response["name"] == "Alice"
 
-    bigfoot.grpc_mock.assert_unary_unary(
+    bigfoot.grpc.assert_unary_unary(
         "/mypackage.UserService/GetUser",
         request={"id": 1},
         metadata=None,
@@ -45,7 +45,7 @@ from bigfoot import StrictVerifier
 from bigfoot.plugins.grpc_plugin import GrpcPlugin
 
 verifier = StrictVerifier()
-grpc_mock = GrpcPlugin(verifier)
+grpc = GrpcPlugin(verifier)
 ```
 
 Each verifier may have at most one `GrpcPlugin`. A second `GrpcPlugin(verifier)` raises `ValueError`.
@@ -57,7 +57,7 @@ GrpcPlugin provides four mock registration methods, one for each call type:
 ### `mock_unary_unary(method, *, returns, ...)`
 
 ```python
-bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/DoThing", returns={"status": "ok"})
+bigfoot.grpc.mock_unary_unary("/pkg.Svc/DoThing", returns={"status": "ok"})
 ```
 
 | Parameter | Type | Default | Description |
@@ -72,7 +72,7 @@ bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/DoThing", returns={"status": "ok"})
 For server streaming RPCs, `returns` is a list of responses that are yielded to the caller:
 
 ```python
-bigfoot.grpc_mock.mock_unary_stream(
+bigfoot.grpc.mock_unary_stream(
     "/pkg.Svc/ListItems",
     returns=[{"id": 1}, {"id": 2}, {"id": 3}],
 )
@@ -90,7 +90,7 @@ bigfoot.grpc_mock.mock_unary_stream(
 For client streaming RPCs, the client sends a stream of requests and receives a single response:
 
 ```python
-bigfoot.grpc_mock.mock_stream_unary(
+bigfoot.grpc.mock_stream_unary(
     "/pkg.Svc/UploadChunks",
     returns={"bytes_received": 1024},
 )
@@ -108,7 +108,7 @@ bigfoot.grpc_mock.mock_stream_unary(
 For bidirectional streaming RPCs, `returns` is a list of responses yielded to the caller:
 
 ```python
-bigfoot.grpc_mock.mock_stream_stream(
+bigfoot.grpc.mock_stream_stream(
     "/pkg.Svc/Chat",
     returns=[{"text": "Hello"}, {"text": "How can I help?"}],
 )
@@ -127,8 +127,8 @@ Each (call_type, method) pair has its own independent FIFO queue. Multiple mocks
 
 ```python
 def test_multiple_unary_calls():
-    bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/GetUser", returns={"id": 1, "name": "Alice"})
-    bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/GetUser", returns={"id": 2, "name": "Bob"})
+    bigfoot.grpc.mock_unary_unary("/pkg.Svc/GetUser", returns={"id": 1, "name": "Alice"})
+    bigfoot.grpc.mock_unary_unary("/pkg.Svc/GetUser", returns={"id": 2, "name": "Bob"})
 
     with bigfoot:
         import grpc
@@ -140,18 +140,18 @@ def test_multiple_unary_calls():
     assert r1["name"] == "Alice"
     assert r2["name"] == "Bob"
 
-    bigfoot.grpc_mock.assert_unary_unary("/pkg.Svc/GetUser", request={"id": 1})
-    bigfoot.grpc_mock.assert_unary_unary("/pkg.Svc/GetUser", request={"id": 2})
+    bigfoot.grpc.assert_unary_unary("/pkg.Svc/GetUser", request={"id": 1})
+    bigfoot.grpc.assert_unary_unary("/pkg.Svc/GetUser", request={"id": 2})
 ```
 
 ## Asserting interactions
 
-Use the typed assertion helpers on `bigfoot.grpc_mock`. All fields (`method`, `request`, `metadata`) are required:
+Use the typed assertion helpers on `bigfoot.grpc`. All fields (`method`, `request`, `metadata`) are required:
 
 ### `assert_unary_unary(method, request, metadata=None)`
 
 ```python
-bigfoot.grpc_mock.assert_unary_unary(
+bigfoot.grpc.assert_unary_unary(
     "/mypackage.UserService/GetUser",
     request={"id": 1},
     metadata=None,
@@ -161,7 +161,7 @@ bigfoot.grpc_mock.assert_unary_unary(
 ### `assert_unary_stream(method, request, metadata=None)`
 
 ```python
-bigfoot.grpc_mock.assert_unary_stream(
+bigfoot.grpc.assert_unary_stream(
     "/mypackage.ItemService/ListItems",
     request={"category": "electronics"},
     metadata=None,
@@ -173,7 +173,7 @@ bigfoot.grpc_mock.assert_unary_stream(
 For client streaming RPCs, `request` is a list (the iterator is eagerly consumed and stored):
 
 ```python
-bigfoot.grpc_mock.assert_stream_unary(
+bigfoot.grpc.assert_stream_unary(
     "/mypackage.UploadService/UploadChunks",
     request=[b"chunk1", b"chunk2", b"chunk3"],
     metadata=None,
@@ -185,7 +185,7 @@ bigfoot.grpc_mock.assert_stream_unary(
 For bidirectional streaming RPCs, `request` is a list:
 
 ```python
-bigfoot.grpc_mock.assert_stream_stream(
+bigfoot.grpc.assert_stream_stream(
     "/mypackage.ChatService/Chat",
     request=[{"text": "Hi"}, {"text": "Help me"}],
     metadata=None,
@@ -207,7 +207,7 @@ import grpc as grpc_lib
 import bigfoot
 
 def test_grpc_unavailable():
-    bigfoot.grpc_mock.mock_unary_unary(
+    bigfoot.grpc.mock_unary_unary(
         "/pkg.Svc/GetUser",
         returns=None,
         raises=grpc_lib.RpcError(),
@@ -220,14 +220,14 @@ def test_grpc_unavailable():
         with pytest.raises(grpc_lib.RpcError):
             stub({"id": 1})
 
-    bigfoot.grpc_mock.assert_unary_unary("/pkg.Svc/GetUser", request={"id": 1})
+    bigfoot.grpc.assert_unary_unary("/pkg.Svc/GetUser", request={"id": 1})
 ```
 
 For streaming responses, the `raises` parameter causes the exception to be raised after all responses have been yielded:
 
 ```python
 def test_stream_partial_failure():
-    bigfoot.grpc_mock.mock_unary_stream(
+    bigfoot.grpc.mock_unary_stream(
         "/pkg.Svc/ListItems",
         returns=[{"id": 1}, {"id": 2}],
         raises=grpc_lib.RpcError(),
@@ -244,7 +244,7 @@ def test_stream_partial_failure():
 
     assert len(results) == 2
 
-    bigfoot.grpc_mock.assert_unary_stream(
+    bigfoot.grpc.assert_unary_stream(
         "/pkg.Svc/ListItems", request={"category": "all"},
     )
 ```
@@ -269,7 +269,7 @@ def test_stream_partial_failure():
 
 ```python
 def test_secure_channel():
-    bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/GetSecret", returns={"value": "s3cr3t"})
+    bigfoot.grpc.mock_unary_unary("/pkg.Svc/GetSecret", returns={"value": "s3cr3t"})
 
     with bigfoot:
         import grpc
@@ -280,7 +280,7 @@ def test_secure_channel():
 
     assert response["value"] == "s3cr3t"
 
-    bigfoot.grpc_mock.assert_unary_unary("/pkg.Svc/GetSecret", request={"key": "api_token"})
+    bigfoot.grpc.assert_unary_unary("/pkg.Svc/GetSecret", request={"key": "api_token"})
 ```
 
 ## Optional mocks
@@ -288,7 +288,7 @@ def test_secure_channel():
 Mark a mock as optional with `required=False`:
 
 ```python
-bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/Ping", returns={"status": "ok"}, required=False)
+bigfoot.grpc.mock_unary_unary("/pkg.Svc/Ping", returns={"status": "ok"}, required=False)
 ```
 
 An optional mock that is never triggered does not cause `UnusedMocksError` at teardown.
@@ -300,5 +300,5 @@ When code makes a gRPC call that has no remaining mocks in its queue, bigfoot ra
 ```
 grpc.unary_unary('/pkg.Svc/GetUser') was called but no mock was registered.
 Register a mock with:
-    bigfoot.grpc_mock.mock_unary_unary('/pkg.Svc/GetUser', returns=...)
+    bigfoot.grpc.mock_unary_unary('/pkg.Svc/GetUser', returns=...)
 ```

--- a/docs/guides/guard-mode.md
+++ b/docs/guides/guard-mode.md
@@ -287,13 +287,13 @@ Widen the allowlist for a scoped block:
 import bigfoot
 
 def test_boto3_integration():
-    bigfoot.boto3_mock.mock_api_call("s3", "PutObject", returns={})
+    bigfoot.boto3.mock_api_call("s3", "PutObject", returns={})
 
     with bigfoot.allow("dns", "socket"):
         with bigfoot:
             upload_file("my-bucket", "key", b"data")
 
-    bigfoot.boto3_mock.assert_api_call(
+    bigfoot.boto3.assert_api_call(
         service="s3", operation="PutObject", params={"Bucket": "my-bucket"},
     )
 ```
@@ -493,12 +493,12 @@ from bigfoot import M
 
 @pytest.mark.allow("dns", "socket")
 def test_s3_upload():
-    bigfoot.boto3_mock.mock_api_call("s3", "PutObject", returns={})
+    bigfoot.boto3.mock_api_call("s3", "PutObject", returns={})
 
     with bigfoot:
         upload_to_s3("my-bucket", "my-key", b"hello")
 
-    bigfoot.boto3_mock.assert_api_call(
+    bigfoot.boto3.assert_api_call(
         service="s3", operation="PutObject",
         params={"Bucket": "my-bucket", "Key": "my-key", "Body": b"hello"},
     )

--- a/docs/guides/jwt-plugin.md
+++ b/docs/guides/jwt-plugin.md
@@ -12,13 +12,13 @@ This installs `PyJWT`.
 
 ## Setup
 
-In pytest, access `JwtPlugin` through the `bigfoot.jwt_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `JwtPlugin` through the `bigfoot.jwt` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import bigfoot
 
 def test_token_generation():
-    bigfoot.jwt_mock.mock_encode(returns="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.test")
+    bigfoot.jwt.mock_encode(returns="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.test")
 
     with bigfoot:
         import jwt
@@ -26,7 +26,7 @@ def test_token_generation():
 
     assert token == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.test"
 
-    bigfoot.jwt_mock.assert_encode(
+    bigfoot.jwt.assert_encode(
         payload={"user_id": "42", "exp": 1700000000},
         algorithm="HS256",
         extra_kwargs={},
@@ -40,7 +40,7 @@ from bigfoot import StrictVerifier
 from bigfoot.plugins.jwt_plugin import JwtPlugin
 
 verifier = StrictVerifier()
-jwt_mock = JwtPlugin(verifier)
+jwt = JwtPlugin(verifier)
 ```
 
 Each verifier may have at most one `JwtPlugin`. A second `JwtPlugin(verifier)` raises `ValueError`.
@@ -54,7 +54,7 @@ Each verifier may have at most one `JwtPlugin`. A second `JwtPlugin(verifier)` r
 Register a mock for `jwt.encode()`:
 
 ```python
-bigfoot.jwt_mock.mock_encode(returns="mocked.jwt.token")
+bigfoot.jwt.mock_encode(returns="mocked.jwt.token")
 ```
 
 | Parameter | Type | Default | Description |
@@ -68,7 +68,7 @@ bigfoot.jwt_mock.mock_encode(returns="mocked.jwt.token")
 Register a mock for `jwt.decode()`:
 
 ```python
-bigfoot.jwt_mock.mock_decode(returns={"user_id": "42", "role": "admin"})
+bigfoot.jwt.mock_decode(returns={"user_id": "42", "role": "admin"})
 ```
 
 | Parameter | Type | Default | Description |
@@ -83,8 +83,8 @@ Each operation (`encode`, `decode`) has its own independent FIFO queue. Multiple
 
 ```python
 def test_multiple_decodes():
-    bigfoot.jwt_mock.mock_decode(returns={"user_id": "1", "role": "admin"})
-    bigfoot.jwt_mock.mock_decode(returns={"user_id": "2", "role": "viewer"})
+    bigfoot.jwt.mock_decode(returns={"user_id": "1", "role": "admin"})
+    bigfoot.jwt.mock_decode(returns={"user_id": "2", "role": "viewer"})
 
     with bigfoot:
         import jwt
@@ -94,20 +94,20 @@ def test_multiple_decodes():
     assert claims1["role"] == "admin"
     assert claims2["role"] == "viewer"
 
-    bigfoot.jwt_mock.assert_decode(token="token1", algorithms=["HS256"], options=None)
-    bigfoot.jwt_mock.assert_decode(token="token2", algorithms=["HS256"], options=None)
+    bigfoot.jwt.assert_decode(token="token1", algorithms=["HS256"], options=None)
+    bigfoot.jwt.assert_decode(token="token2", algorithms=["HS256"], options=None)
 ```
 
 ## Asserting interactions
 
-Use the typed assertion helpers on `bigfoot.jwt_mock`.
+Use the typed assertion helpers on `bigfoot.jwt`.
 
 ### `assert_encode(*, payload, algorithm, extra_kwargs=None)`
 
 Asserts the next `jwt.encode()` interaction.
 
 ```python
-bigfoot.jwt_mock.assert_encode(
+bigfoot.jwt.assert_encode(
     payload={"user_id": "42", "exp": 1700000000},
     algorithm="HS256",
     extra_kwargs={},
@@ -125,7 +125,7 @@ bigfoot.jwt_mock.assert_encode(
 Asserts the next `jwt.decode()` interaction.
 
 ```python
-bigfoot.jwt_mock.assert_decode(
+bigfoot.jwt.assert_decode(
     token="eyJ0eXAiOiJKV1Qi...",
     algorithms=["HS256"],
     options=None,
@@ -151,7 +151,7 @@ import jwt
 import bigfoot
 
 def test_expired_token():
-    bigfoot.jwt_mock.mock_decode(
+    bigfoot.jwt.mock_decode(
         returns=None,
         raises=jwt.ExpiredSignatureError("Signature has expired"),
     )
@@ -160,7 +160,7 @@ def test_expired_token():
         with pytest.raises(jwt.ExpiredSignatureError):
             jwt.decode("expired.token", "secret", algorithms=["HS256"])
 
-    bigfoot.jwt_mock.assert_decode(
+    bigfoot.jwt.assert_decode(
         token="expired.token",
         algorithms=["HS256"],
         options=None,
@@ -186,7 +186,7 @@ def test_expired_token():
 Mark a mock as optional with `required=False`:
 
 ```python
-bigfoot.jwt_mock.mock_decode(returns={"sub": "test"}, required=False)
+bigfoot.jwt.mock_decode(returns={"sub": "test"}, required=False)
 ```
 
 An optional mock that is never triggered does not cause `UnusedMocksError` at teardown.
@@ -198,5 +198,5 @@ When code calls `jwt.encode()` or `jwt.decode()` with no remaining mocks in the 
 ```
 jwt.encode(...) was called but no mock was registered.
 Register a mock with:
-    bigfoot.jwt_mock.mock_encode(returns=...)
+    bigfoot.jwt.mock_encode(returns=...)
 ```

--- a/docs/guides/logging-plugin.md
+++ b/docs/guides/logging-plugin.md
@@ -4,7 +4,7 @@
 
 ## Setup
 
-In pytest, access `LoggingPlugin` through the `bigfoot.log_mock` proxy. It auto-creates the plugin for the current test on first use -- no explicit instantiation needed:
+In pytest, access `LoggingPlugin` through the `bigfoot.log` proxy. It auto-creates the plugin for the current test on first use -- no explicit instantiation needed:
 
 ```python
 import bigfoot
@@ -16,7 +16,7 @@ def test_audit_trail():
     with bigfoot:
         logger.info("User logged in")
 
-    bigfoot.log_mock.assert_info("User logged in", "myapp.auth")
+    bigfoot.log.assert_info("User logged in", "myapp.auth")
 ```
 
 For manual use outside pytest, construct `LoggingPlugin` explicitly:
@@ -42,10 +42,10 @@ This is the same pattern used by `shutil.which` in `SubprocessPlugin`: unmocked 
 
 ## Registering log mocks
 
-Use `bigfoot.log_mock.mock_log(level, message, logger_name=None)` to register expected log calls before entering the sandbox:
+Use `bigfoot.log.mock_log(level, message, logger_name=None)` to register expected log calls before entering the sandbox:
 
 ```python
-bigfoot.log_mock.mock_log("INFO", "User logged in", logger_name="myapp.auth")
+bigfoot.log.mock_log("INFO", "User logged in", logger_name="myapp.auth")
 ```
 
 Parameters:
@@ -61,13 +61,13 @@ Mocks are consumed in FIFO order. If a log call matches the next mock in the que
 
 ## Asserting log interactions
 
-Use `bigfoot.log_mock.log` as the source in `assert_interaction()`, or use the typed assertion helpers.
+Use `bigfoot.log.log` as the source in `assert_interaction()`, or use the typed assertion helpers.
 
 ### Using assert_interaction directly
 
 ```python
 bigfoot.assert_interaction(
-    bigfoot.log_mock.log,
+    bigfoot.log.log,
     level="INFO",
     message="User logged in",
     logger_name="myapp.auth",
@@ -79,9 +79,9 @@ All three fields (`level`, `message`, `logger_name`) are required.
 ### Using assertion helpers
 
 ```python
-bigfoot.log_mock.assert_log("INFO", "User logged in", "myapp.auth")
-bigfoot.log_mock.assert_info("User logged in", "myapp.auth")
-bigfoot.log_mock.assert_warning("Rate limit approaching", "myapp.auth")
+bigfoot.log.assert_log("INFO", "User logged in", "myapp.auth")
+bigfoot.log.assert_info("User logged in", "myapp.auth")
+bigfoot.log.assert_warning("Rate limit approaching", "myapp.auth")
 ```
 
 Available helpers:
@@ -122,8 +122,8 @@ def test_multi_service():
         auth_logger.info("authenticated")
         payment_logger.warning("rate limited")
 
-    bigfoot.log_mock.assert_info("authenticated", "service.auth")
-    bigfoot.log_mock.assert_warning("rate limited", "service.payment")
+    bigfoot.log.assert_info("authenticated", "service.auth")
+    bigfoot.log.assert_warning("rate limited", "service.payment")
 ```
 
 ## ConflictError

--- a/docs/guides/mcp-plugin.md
+++ b/docs/guides/mcp-plugin.md
@@ -12,7 +12,7 @@ This installs the `mcp` SDK.
 
 ## Setup
 
-In pytest, access `McpPlugin` through the `bigfoot.mcp_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `McpPlugin` through the `bigfoot.mcp` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import pytest
@@ -22,7 +22,7 @@ import bigfoot
 async def test_call_tool():
     from mcp.client.session import ClientSession
 
-    bigfoot.mcp_mock.mock_call_tool(
+    bigfoot.mcp.mock_call_tool(
         "my_tool",
         returns={"result": "ok"},
     )
@@ -33,7 +33,7 @@ async def test_call_tool():
 
     assert result == {"result": "ok"}
 
-    bigfoot.mcp_mock.assert_call_tool(
+    bigfoot.mcp.assert_call_tool(
         "my_tool",
         arguments={"key": "value"},
         direction="client",
@@ -47,7 +47,7 @@ from bigfoot import StrictVerifier
 from bigfoot.plugins.mcp_plugin import McpPlugin
 
 verifier = StrictVerifier()
-mcp_mock = McpPlugin(verifier)
+mcp = McpPlugin(verifier)
 ```
 
 Each verifier may have at most one `McpPlugin`. A second `McpPlugin(verifier)` raises `ValueError`.
@@ -68,7 +68,7 @@ Client mocks intercept `ClientSession` method calls. Three methods are available
 ### `mock_call_tool(tool_name, *, returns, ...)`
 
 ```python
-bigfoot.mcp_mock.mock_call_tool("get_weather", returns={"temp": "72F"})
+bigfoot.mcp.mock_call_tool("get_weather", returns={"temp": "72F"})
 ```
 
 | Parameter | Type | Default | Description |
@@ -81,7 +81,7 @@ bigfoot.mcp_mock.mock_call_tool("get_weather", returns={"temp": "72F"})
 ### `mock_read_resource(uri, *, returns, ...)`
 
 ```python
-bigfoot.mcp_mock.mock_read_resource("file:///data.json", returns={"contents": "[1,2,3]"})
+bigfoot.mcp.mock_read_resource("file:///data.json", returns={"contents": "[1,2,3]"})
 ```
 
 | Parameter | Type | Default | Description |
@@ -94,7 +94,7 @@ bigfoot.mcp_mock.mock_read_resource("file:///data.json", returns={"contents": "[
 ### `mock_get_prompt(prompt_name, *, returns, ...)`
 
 ```python
-bigfoot.mcp_mock.mock_get_prompt("summarize", returns={"messages": [{"role": "user", "content": "..."}]})
+bigfoot.mcp.mock_get_prompt("summarize", returns={"messages": [{"role": "user", "content": "..."}]})
 ```
 
 | Parameter | Type | Default | Description |
@@ -111,19 +111,19 @@ Server mocks intercept incoming requests handled by `Server._handle_request`. Th
 ### `mock_server_call_tool(tool_name, *, returns, ...)`
 
 ```python
-bigfoot.mcp_mock.mock_server_call_tool("calculate", returns={"result": 42})
+bigfoot.mcp.mock_server_call_tool("calculate", returns={"result": 42})
 ```
 
 ### `mock_server_read_resource(uri, *, returns, ...)`
 
 ```python
-bigfoot.mcp_mock.mock_server_read_resource("db://users/1", returns={"name": "Alice"})
+bigfoot.mcp.mock_server_read_resource("db://users/1", returns={"name": "Alice"})
 ```
 
 ### `mock_server_get_prompt(prompt_name, *, returns, ...)`
 
 ```python
-bigfoot.mcp_mock.mock_server_get_prompt("greet", returns={"messages": [{"role": "assistant", "content": "Hello!"}]})
+bigfoot.mcp.mock_server_get_prompt("greet", returns={"messages": [{"role": "assistant", "content": "Hello!"}]})
 ```
 
 All three accept the same parameters as their client counterparts (`returns`, `raises`, `required`).
@@ -135,8 +135,8 @@ Each (direction, method, key) triple has its own independent FIFO queue. Multipl
 ```python
 @pytest.mark.asyncio
 async def test_multiple_tool_calls():
-    bigfoot.mcp_mock.mock_call_tool("search", returns={"results": ["a"]})
-    bigfoot.mcp_mock.mock_call_tool("search", returns={"results": ["b"]})
+    bigfoot.mcp.mock_call_tool("search", returns={"results": ["a"]})
+    bigfoot.mcp.mock_call_tool("search", returns={"results": ["b"]})
 
     with bigfoot:
         from mcp.client.session import ClientSession
@@ -147,18 +147,18 @@ async def test_multiple_tool_calls():
     assert r1 == {"results": ["a"]}
     assert r2 == {"results": ["b"]}
 
-    bigfoot.mcp_mock.assert_call_tool("search", arguments={"query": "first"})
-    bigfoot.mcp_mock.assert_call_tool("search", arguments={"query": "second"})
+    bigfoot.mcp.assert_call_tool("search", arguments={"query": "first"})
+    bigfoot.mcp.assert_call_tool("search", arguments={"query": "second"})
 ```
 
 ## Asserting interactions
 
-Use the typed assertion helpers on `bigfoot.mcp_mock`. All recorded fields are required.
+Use the typed assertion helpers on `bigfoot.mcp`. All recorded fields are required.
 
 ### `assert_call_tool(tool_name, *, arguments, direction)`
 
 ```python
-bigfoot.mcp_mock.assert_call_tool(
+bigfoot.mcp.assert_call_tool(
     "get_weather",
     arguments={"city": "San Francisco"},
     direction="client",
@@ -174,7 +174,7 @@ bigfoot.mcp_mock.assert_call_tool(
 ### `assert_read_resource(uri, *, direction)`
 
 ```python
-bigfoot.mcp_mock.assert_read_resource(
+bigfoot.mcp.assert_read_resource(
     "file:///data.json",
     direction="client",
 )
@@ -188,7 +188,7 @@ bigfoot.mcp_mock.assert_read_resource(
 ### `assert_get_prompt(prompt_name, *, arguments, direction)`
 
 ```python
-bigfoot.mcp_mock.assert_get_prompt(
+bigfoot.mcp.assert_get_prompt(
     "summarize",
     arguments={"length": "short"},
     direction="client",
@@ -208,7 +208,7 @@ Use the `raises` parameter to simulate MCP errors:
 ```python
 @pytest.mark.asyncio
 async def test_tool_error():
-    bigfoot.mcp_mock.mock_call_tool(
+    bigfoot.mcp.mock_call_tool(
         "flaky_tool",
         returns=None,
         raises=RuntimeError("MCP server unavailable"),
@@ -220,7 +220,7 @@ async def test_tool_error():
         with pytest.raises(RuntimeError, match="MCP server unavailable"):
             await session.call_tool("flaky_tool", {"input": "data"})
 
-    bigfoot.mcp_mock.assert_call_tool(
+    bigfoot.mcp.assert_call_tool(
         "flaky_tool",
         arguments={"input": "data"},
         direction="client",
@@ -246,7 +246,7 @@ async def test_tool_error():
 Mark a mock as optional with `required=False`:
 
 ```python
-bigfoot.mcp_mock.mock_call_tool("analytics_ping", returns={"status": "ok"}, required=False)
+bigfoot.mcp.mock_call_tool("analytics_ping", returns={"status": "ok"}, required=False)
 ```
 
 An optional mock that is never triggered does not cause `UnusedMocksError` at teardown.
@@ -258,5 +258,5 @@ When code makes an MCP call that has no remaining mocks in its queue, bigfoot ra
 ```
 mcp client call_tool('get_weather') was called but no mock was registered.
 Register a mock with:
-    bigfoot.mcp_mock.mock_call_tool('get_weather', returns=...)
+    bigfoot.mcp.mock_call_tool('get_weather', returns=...)
 ```

--- a/docs/guides/memcache-plugin.md
+++ b/docs/guides/memcache-plugin.md
@@ -12,13 +12,13 @@ This installs `pymemcache`.
 
 ## Setup
 
-In pytest, access `MemcachePlugin` through the `bigfoot.memcache_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `MemcachePlugin` through the `bigfoot.memcache` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import bigfoot
 
 def test_session_cache():
-    bigfoot.memcache_mock.mock_command("GET", returns=b"user:42")
+    bigfoot.memcache.mock_command("GET", returns=b"user:42")
 
     with bigfoot:
         from pymemcache.client.base import Client
@@ -27,7 +27,7 @@ def test_session_cache():
 
     assert value == b"user:42"
 
-    bigfoot.memcache_mock.assert_get(command="GET", key="session:abc")
+    bigfoot.memcache.assert_get(command="GET", key="session:abc")
 ```
 
 For manual use outside pytest, construct `MemcachePlugin` explicitly:
@@ -37,18 +37,18 @@ from bigfoot import StrictVerifier
 from bigfoot.plugins.memcache_plugin import MemcachePlugin
 
 verifier = StrictVerifier()
-memcache_mock = MemcachePlugin(verifier)
+memcache = MemcachePlugin(verifier)
 ```
 
 Each verifier may have at most one `MemcachePlugin`. A second `MemcachePlugin(verifier)` raises `ValueError`.
 
 ## Registering mock commands
 
-Use `bigfoot.memcache_mock.mock_command(command, *, returns, ...)` to register a mock before entering the sandbox:
+Use `bigfoot.memcache.mock_command(command, *, returns, ...)` to register a mock before entering the sandbox:
 
 ```python
-bigfoot.memcache_mock.mock_command("SET", returns=True)
-bigfoot.memcache_mock.mock_command("GET", returns=b"cached")
+bigfoot.memcache.mock_command("SET", returns=True)
+bigfoot.memcache.mock_command("GET", returns=b"cached")
 ```
 
 ### Parameters
@@ -80,8 +80,8 @@ Each command name has its own independent FIFO queue. Multiple `mock_command("GE
 
 ```python
 def test_multiple_gets():
-    bigfoot.memcache_mock.mock_command("GET", returns=b"first")
-    bigfoot.memcache_mock.mock_command("GET", returns=b"second")
+    bigfoot.memcache.mock_command("GET", returns=b"first")
+    bigfoot.memcache.mock_command("GET", returns=b"second")
 
     with bigfoot:
         from pymemcache.client.base import Client
@@ -92,22 +92,22 @@ def test_multiple_gets():
     assert v1 == b"first"
     assert v2 == b"second"
 
-    bigfoot.memcache_mock.assert_get(command="GET", key="key1")
-    bigfoot.memcache_mock.assert_get(command="GET", key="key2")
+    bigfoot.memcache.assert_get(command="GET", key="key1")
+    bigfoot.memcache.assert_get(command="GET", key="key2")
 ```
 
 Command names are case-insensitive: `mock_command("get", ...)` matches a `client.get(...)` call.
 
 ## Asserting interactions
 
-Use the typed assertion helpers on `bigfoot.memcache_mock`. Each helper requires all detail fields for its operation type.
+Use the typed assertion helpers on `bigfoot.memcache`. Each helper requires all detail fields for its operation type.
 
 ### `assert_get(command, key)`
 
 Asserts the next read interaction (GET, GETS, DELETE).
 
 ```python
-bigfoot.memcache_mock.assert_get(command="GET", key="session:abc")
+bigfoot.memcache.assert_get(command="GET", key="session:abc")
 ```
 
 | Parameter | Type | Description |
@@ -120,7 +120,7 @@ bigfoot.memcache_mock.assert_get(command="GET", key="session:abc")
 Asserts the next write interaction (SET, ADD, REPLACE, CAS, APPEND, PREPEND).
 
 ```python
-bigfoot.memcache_mock.assert_set(command="SET", key="session:abc", value=b"user:42", expire=3600)
+bigfoot.memcache.assert_set(command="SET", key="session:abc", value=b"user:42", expire=3600)
 ```
 
 | Parameter | Type | Default | Description |
@@ -135,7 +135,7 @@ bigfoot.memcache_mock.assert_set(command="SET", key="session:abc", value=b"user:
 Asserts the next delete interaction.
 
 ```python
-bigfoot.memcache_mock.assert_delete(command="DELETE", key="session:abc")
+bigfoot.memcache.assert_delete(command="DELETE", key="session:abc")
 ```
 
 | Parameter | Type | Description |
@@ -148,7 +148,7 @@ bigfoot.memcache_mock.assert_delete(command="DELETE", key="session:abc")
 Asserts the next counter interaction (INCR, DECR).
 
 ```python
-bigfoot.memcache_mock.assert_incr(command="INCR", key="page_views", value=1)
+bigfoot.memcache.assert_incr(command="INCR", key="page_views", value=1)
 ```
 
 | Parameter | Type | Default | Description |
@@ -165,7 +165,7 @@ Use the `raises` parameter to simulate memcache errors:
 import bigfoot
 
 def test_memcache_connection_error():
-    bigfoot.memcache_mock.mock_command(
+    bigfoot.memcache.mock_command(
         "GET",
         returns=None,
         raises=ConnectionError("memcached unreachable"),
@@ -177,7 +177,7 @@ def test_memcache_connection_error():
         with pytest.raises(ConnectionError):
             client.get("mykey")
 
-    bigfoot.memcache_mock.assert_get(command="GET", key="mykey")
+    bigfoot.memcache.assert_get(command="GET", key="mykey")
 ```
 
 ## Full example
@@ -199,7 +199,7 @@ def test_memcache_connection_error():
 Mark a mock as optional with `required=False`:
 
 ```python
-bigfoot.memcache_mock.mock_command("DELETE", returns=True, required=False)
+bigfoot.memcache.mock_command("DELETE", returns=True, required=False)
 ```
 
 An optional mock that is never triggered does not cause `UnusedMocksError` at teardown.
@@ -211,5 +211,5 @@ When code calls a memcache method that has no remaining mocks in its queue, bigf
 ```
 memcache.GET(...) was called but no mock was registered.
 Register a mock with:
-    bigfoot.memcache_mock.mock_command('GET', returns=...)
+    bigfoot.memcache.mock_command('GET', returns=...)
 ```

--- a/docs/guides/mongo-plugin.md
+++ b/docs/guides/mongo-plugin.md
@@ -12,13 +12,13 @@ This installs `pymongo`.
 
 ## Setup
 
-In pytest, access `MongoPlugin` through the `bigfoot.mongo_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `MongoPlugin` through the `bigfoot.mongo` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import bigfoot
 
 def test_find_user():
-    bigfoot.mongo_mock.mock_operation("find_one", returns={"_id": "abc", "name": "Alice"})
+    bigfoot.mongo.mock_operation("find_one", returns={"_id": "abc", "name": "Alice"})
 
     with bigfoot:
         import pymongo
@@ -27,7 +27,7 @@ def test_find_user():
 
     assert user == {"_id": "abc", "name": "Alice"}
 
-    bigfoot.mongo_mock.assert_find_one(
+    bigfoot.mongo.assert_find_one(
         database="mydb",
         collection="users",
         filter={"email": "alice@example.com"},
@@ -42,18 +42,18 @@ from bigfoot import StrictVerifier
 from bigfoot.plugins.mongo_plugin import MongoPlugin
 
 verifier = StrictVerifier()
-mongo_mock = MongoPlugin(verifier)
+mongo = MongoPlugin(verifier)
 ```
 
 Each verifier may have at most one `MongoPlugin`. A second `MongoPlugin(verifier)` raises `ValueError`.
 
 ## Registering mock operations
 
-Use `bigfoot.mongo_mock.mock_operation(operation, *, returns, ...)` to register a mock before entering the sandbox:
+Use `bigfoot.mongo.mock_operation(operation, *, returns, ...)` to register a mock before entering the sandbox:
 
 ```python
-bigfoot.mongo_mock.mock_operation("find_one", returns={"_id": "1", "status": "active"})
-bigfoot.mongo_mock.mock_operation("insert_one", returns=type("Result", (), {"inserted_id": "2"})())
+bigfoot.mongo.mock_operation("find_one", returns={"_id": "1", "status": "active"})
+bigfoot.mongo.mock_operation("insert_one", returns=type("Result", (), {"inserted_id": "2"})())
 ```
 
 ### Parameters
@@ -86,8 +86,8 @@ Each operation name has its own independent FIFO queue. Multiple `mock_operation
 
 ```python
 def test_sequential_queries():
-    bigfoot.mongo_mock.mock_operation("find_one", returns={"_id": "1", "role": "admin"})
-    bigfoot.mongo_mock.mock_operation("find_one", returns=None)
+    bigfoot.mongo.mock_operation("find_one", returns={"_id": "1", "role": "admin"})
+    bigfoot.mongo.mock_operation("find_one", returns=None)
 
     with bigfoot:
         import pymongo
@@ -100,11 +100,11 @@ def test_sequential_queries():
     assert admin == {"_id": "1", "role": "admin"}
     assert ghost is None
 
-    bigfoot.mongo_mock.assert_find_one(
+    bigfoot.mongo.assert_find_one(
         database="mydb", collection="users",
         filter={"role": "admin"}, projection=None,
     )
-    bigfoot.mongo_mock.assert_find_one(
+    bigfoot.mongo.assert_find_one(
         database="mydb", collection="users",
         filter={"role": "ghost"}, projection=None,
     )
@@ -112,12 +112,12 @@ def test_sequential_queries():
 
 ## Asserting interactions
 
-Use the typed assertion helpers on `bigfoot.mongo_mock`. Each helper requires `database` and `collection` plus the operation-specific fields.
+Use the typed assertion helpers on `bigfoot.mongo`. Each helper requires `database` and `collection` plus the operation-specific fields.
 
 ### `assert_find(database, collection, filter, projection=None)`
 
 ```python
-bigfoot.mongo_mock.assert_find(
+bigfoot.mongo.assert_find(
     database="mydb", collection="users",
     filter={"active": True}, projection=None,
 )
@@ -126,7 +126,7 @@ bigfoot.mongo_mock.assert_find(
 ### `assert_find_one(database, collection, filter, projection=None)`
 
 ```python
-bigfoot.mongo_mock.assert_find_one(
+bigfoot.mongo.assert_find_one(
     database="mydb", collection="users",
     filter={"_id": "abc"}, projection=None,
 )
@@ -135,7 +135,7 @@ bigfoot.mongo_mock.assert_find_one(
 ### `assert_insert_one(database, collection, document)`
 
 ```python
-bigfoot.mongo_mock.assert_insert_one(
+bigfoot.mongo.assert_insert_one(
     database="mydb", collection="users",
     document={"name": "Alice", "email": "alice@example.com"},
 )
@@ -144,7 +144,7 @@ bigfoot.mongo_mock.assert_insert_one(
 ### `assert_insert_many(database, collection, documents)`
 
 ```python
-bigfoot.mongo_mock.assert_insert_many(
+bigfoot.mongo.assert_insert_many(
     database="mydb", collection="events",
     documents=[{"type": "click"}, {"type": "view"}],
 )
@@ -153,7 +153,7 @@ bigfoot.mongo_mock.assert_insert_many(
 ### `assert_update_one(database, collection, filter, update)`
 
 ```python
-bigfoot.mongo_mock.assert_update_one(
+bigfoot.mongo.assert_update_one(
     database="mydb", collection="users",
     filter={"_id": "abc"},
     update={"$set": {"last_login": "2025-01-15"}},
@@ -163,7 +163,7 @@ bigfoot.mongo_mock.assert_update_one(
 ### `assert_update_many(database, collection, filter, update)`
 
 ```python
-bigfoot.mongo_mock.assert_update_many(
+bigfoot.mongo.assert_update_many(
     database="mydb", collection="sessions",
     filter={"expired": True},
     update={"$set": {"cleaned": True}},
@@ -173,7 +173,7 @@ bigfoot.mongo_mock.assert_update_many(
 ### `assert_delete_one(database, collection, filter)`
 
 ```python
-bigfoot.mongo_mock.assert_delete_one(
+bigfoot.mongo.assert_delete_one(
     database="mydb", collection="users",
     filter={"_id": "abc"},
 )
@@ -182,7 +182,7 @@ bigfoot.mongo_mock.assert_delete_one(
 ### `assert_delete_many(database, collection, filter)`
 
 ```python
-bigfoot.mongo_mock.assert_delete_many(
+bigfoot.mongo.assert_delete_many(
     database="mydb", collection="sessions",
     filter={"expired": True},
 )
@@ -191,7 +191,7 @@ bigfoot.mongo_mock.assert_delete_many(
 ### `assert_aggregate(database, collection, pipeline)`
 
 ```python
-bigfoot.mongo_mock.assert_aggregate(
+bigfoot.mongo.assert_aggregate(
     database="mydb", collection="orders",
     pipeline=[{"$match": {"status": "complete"}}, {"$group": {"_id": "$customer", "total": {"$sum": "$amount"}}}],
 )
@@ -200,7 +200,7 @@ bigfoot.mongo_mock.assert_aggregate(
 ### `assert_count_documents(database, collection, filter)`
 
 ```python
-bigfoot.mongo_mock.assert_count_documents(
+bigfoot.mongo.assert_count_documents(
     database="mydb", collection="users",
     filter={"active": True},
 )
@@ -215,7 +215,7 @@ import pymongo.errors
 import bigfoot
 
 def test_duplicate_key():
-    bigfoot.mongo_mock.mock_operation(
+    bigfoot.mongo.mock_operation(
         "insert_one",
         returns=None,
         raises=pymongo.errors.DuplicateKeyError("E11000 duplicate key error"),
@@ -227,7 +227,7 @@ def test_duplicate_key():
         with pytest.raises(pymongo.errors.DuplicateKeyError):
             client.mydb.users.insert_one({"_id": "abc", "name": "Alice"})
 
-    bigfoot.mongo_mock.assert_insert_one(
+    bigfoot.mongo.assert_insert_one(
         database="mydb", collection="users",
         document={"_id": "abc", "name": "Alice"},
     )
@@ -252,7 +252,7 @@ def test_duplicate_key():
 Mark a mock as optional with `required=False`:
 
 ```python
-bigfoot.mongo_mock.mock_operation("count_documents", returns=0, required=False)
+bigfoot.mongo.mock_operation("count_documents", returns=0, required=False)
 ```
 
 An optional mock that is never triggered does not cause `UnusedMocksError` at teardown.
@@ -264,5 +264,5 @@ When code calls a MongoDB collection method that has no remaining mocks in its q
 ```
 mongo.find_one(...) was called but no mock was registered.
 Register a mock with:
-    bigfoot.mongo_mock.mock_operation('find_one', returns=...)
+    bigfoot.mongo.mock_operation('find_one', returns=...)
 ```

--- a/docs/guides/native-plugin.md
+++ b/docs/guides/native-plugin.md
@@ -2,17 +2,17 @@
 
 `NativePlugin` intercepts `ctypes.CDLL` and `cffi.FFI.dlopen` at the class level, replacing loaded native libraries with proxy objects that route all function calls through bigfoot's FIFO queue. Each library:function pair has its own independent queue. Arguments are automatically serialized from ctypes types to Python equivalents for assertion.
 
-**Important:** `NativePlugin` is always available (no extra install required) but is NOT default enabled. You must explicitly enable it via `enabled_plugins = ["native"]` in your bigfoot config, or access it through the `bigfoot.native_mock` proxy. cffi interception is available when `cffi` is installed.
+**Important:** `NativePlugin` is always available (no extra install required) but is NOT default enabled. You must explicitly enable it via `enabled_plugins = ["native"]` in your bigfoot config, or access it through the `bigfoot.native` proxy. cffi interception is available when `cffi` is installed.
 
 ## Setup
 
-In pytest, access `NativePlugin` through the `bigfoot.native_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `NativePlugin` through the `bigfoot.native` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import bigfoot
 
 def test_call_native_sqrt():
-    bigfoot.native_mock.mock_call("libm", "sqrt", returns=3.0)
+    bigfoot.native.mock_call("libm", "sqrt", returns=3.0)
 
     with bigfoot:
         import ctypes
@@ -21,7 +21,7 @@ def test_call_native_sqrt():
 
     assert result == 3.0
 
-    bigfoot.native_mock.assert_call(
+    bigfoot.native.assert_call(
         library="libm", function="sqrt", args=(9.0,),
     )
 ```
@@ -33,18 +33,18 @@ from bigfoot import StrictVerifier
 from bigfoot.plugins.native_plugin import NativePlugin
 
 verifier = StrictVerifier()
-native_mock = NativePlugin(verifier)
+native = NativePlugin(verifier)
 ```
 
 Each verifier may have at most one `NativePlugin`. A second `NativePlugin(verifier)` raises `ValueError`.
 
 ## Registering mocks
 
-Use `bigfoot.native_mock.mock_call(library, function, *, returns, ...)` to register a mock before entering the sandbox:
+Use `bigfoot.native.mock_call(library, function, *, returns, ...)` to register a mock before entering the sandbox:
 
 ```python
-bigfoot.native_mock.mock_call("libcrypto", "RAND_bytes", returns=0)
-bigfoot.native_mock.mock_call("libm", "pow", returns=8.0)
+bigfoot.native.mock_call("libcrypto", "RAND_bytes", returns=0)
+bigfoot.native.mock_call("libm", "pow", returns=8.0)
 ```
 
 ### Parameters
@@ -63,8 +63,8 @@ Each library:function pair has its own independent FIFO queue. Multiple mocks fo
 
 ```python
 def test_multiple_native_calls():
-    bigfoot.native_mock.mock_call("libm", "sqrt", returns=2.0)
-    bigfoot.native_mock.mock_call("libm", "sqrt", returns=3.0)
+    bigfoot.native.mock_call("libm", "sqrt", returns=2.0)
+    bigfoot.native.mock_call("libm", "sqrt", returns=3.0)
 
     with bigfoot:
         import ctypes
@@ -75,18 +75,18 @@ def test_multiple_native_calls():
     assert r1 == 2.0
     assert r2 == 3.0
 
-    bigfoot.native_mock.assert_call(library="libm", function="sqrt", args=(4.0,))
-    bigfoot.native_mock.assert_call(library="libm", function="sqrt", args=(9.0,))
+    bigfoot.native.assert_call(library="libm", function="sqrt", args=(4.0,))
+    bigfoot.native.assert_call(library="libm", function="sqrt", args=(9.0,))
 ```
 
 ## Asserting interactions
 
-Use the `assert_call` helper on `bigfoot.native_mock`. All three fields (`library`, `function`, `args`) are required:
+Use the `assert_call` helper on `bigfoot.native`. All three fields (`library`, `function`, `args`) are required:
 
 ### `assert_call(library, function, *, args)`
 
 ```python
-bigfoot.native_mock.assert_call(
+bigfoot.native.assert_call(
     library="libm", function="pow", args=(2.0, 3.0),
 )
 ```
@@ -119,7 +119,7 @@ Use the `raises` parameter to simulate native function failures:
 import bigfoot
 
 def test_library_load_error():
-    bigfoot.native_mock.mock_call(
+    bigfoot.native.mock_call(
         "libcustom", "initialize",
         returns=None,
         raises=OSError("Symbol not found: initialize"),
@@ -131,7 +131,7 @@ def test_library_load_error():
         with pytest.raises(OSError, match="Symbol not found"):
             lib.initialize()
 
-    bigfoot.native_mock.assert_call(library="libcustom", function="initialize", args=())
+    bigfoot.native.assert_call(library="libcustom", function="initialize", args=())
 ```
 
 ## Full example
@@ -156,7 +156,7 @@ When `cffi` is installed, `NativePlugin` also intercepts `cffi.FFI.dlopen`. The 
 import bigfoot
 
 def test_cffi_library():
-    bigfoot.native_mock.mock_call("libz", "compressBound", returns=1024)
+    bigfoot.native.mock_call("libz", "compressBound", returns=1024)
 
     with bigfoot:
         import cffi
@@ -167,7 +167,7 @@ def test_cffi_library():
 
     assert bound == 1024
 
-    bigfoot.native_mock.assert_call(
+    bigfoot.native.assert_call(
         library="libz", function="compressBound", args=(512,),
     )
 ```
@@ -177,7 +177,7 @@ def test_cffi_library():
 Mark a mock as optional with `required=False`:
 
 ```python
-bigfoot.native_mock.mock_call("libm", "log", returns=0.0, required=False)
+bigfoot.native.mock_call("libm", "log", returns=0.0, required=False)
 ```
 
 An optional mock that is never triggered does not cause `UnusedMocksError` at teardown.
@@ -189,5 +189,5 @@ When code calls a native function that has no remaining mocks in its queue, bigf
 ```
 libm.sqrt(...) was called but no mock was registered.
 Register a mock with:
-    bigfoot.native_mock.mock_call('libm', 'sqrt', returns=...)
+    bigfoot.native.mock_call('libm', 'sqrt', returns=...)
 ```

--- a/docs/guides/pika-plugin.md
+++ b/docs/guides/pika-plugin.md
@@ -12,13 +12,13 @@ This installs `pika`.
 
 ## Setup
 
-In pytest, access `PikaPlugin` through the `bigfoot.pika_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `PikaPlugin` through the `bigfoot.pika` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import bigfoot
 
 def test_publish_message():
-    (bigfoot.pika_mock
+    (bigfoot.pika
         .new_session()
         .expect("connect",  returns=None)
         .expect("channel",  returns=None)
@@ -34,12 +34,12 @@ def test_publish_message():
         channel.basic_publish(exchange="", routing_key="tasks", body=b"hello")
         connection.close()
 
-    bigfoot.pika_mock.assert_connect(host="rabbitmq.example.com", port=5672, virtual_host="/")
-    bigfoot.pika_mock.assert_channel()
-    bigfoot.pika_mock.assert_publish(
+    bigfoot.pika.assert_connect(host="rabbitmq.example.com", port=5672, virtual_host="/")
+    bigfoot.pika.assert_channel()
+    bigfoot.pika.assert_publish(
         exchange="", routing_key="tasks", body=b"hello", properties=None,
     )
-    bigfoot.pika_mock.assert_close()
+    bigfoot.pika.assert_close()
 ```
 
 For manual use outside pytest, construct `PikaPlugin` explicitly:
@@ -49,7 +49,7 @@ from bigfoot import StrictVerifier
 from bigfoot.plugins.pika_plugin import PikaPlugin
 
 verifier = StrictVerifier()
-pika_mock = PikaPlugin(verifier)
+pika = PikaPlugin(verifier)
 ```
 
 Each verifier may have at most one `PikaPlugin`. A second `PikaPlugin(verifier)` raises `ValueError`.
@@ -74,7 +74,7 @@ The `connect` step fires automatically during `pika.BlockingConnection(...)` con
 Use `new_session()` to create a `SessionHandle` and chain `.expect()` calls:
 
 ```python
-(bigfoot.pika_mock
+(bigfoot.pika
     .new_session()
     .expect("connect",  returns=None)
     .expect("channel",  returns=None)
@@ -106,12 +106,12 @@ Use `new_session()` to create a `SessionHandle` and chain `.expect()` calls:
 
 ## Asserting interactions
 
-Each step records an interaction on the timeline. Use the typed assertion helpers on `bigfoot.pika_mock`:
+Each step records an interaction on the timeline. Use the typed assertion helpers on `bigfoot.pika`:
 
 ### `assert_connect(*, host, port, virtual_host)`
 
 ```python
-bigfoot.pika_mock.assert_connect(host="rabbitmq.example.com", port=5672, virtual_host="/")
+bigfoot.pika.assert_connect(host="rabbitmq.example.com", port=5672, virtual_host="/")
 ```
 
 ### `assert_channel()`
@@ -119,13 +119,13 @@ bigfoot.pika_mock.assert_connect(host="rabbitmq.example.com", port=5672, virtual
 No fields are required.
 
 ```python
-bigfoot.pika_mock.assert_channel()
+bigfoot.pika.assert_channel()
 ```
 
 ### `assert_publish(*, exchange, routing_key, body, properties)`
 
 ```python
-bigfoot.pika_mock.assert_publish(
+bigfoot.pika.assert_publish(
     exchange="", routing_key="tasks", body=b"process this", properties=None,
 )
 ```
@@ -133,19 +133,19 @@ bigfoot.pika_mock.assert_publish(
 ### `assert_consume(*, queue, auto_ack)`
 
 ```python
-bigfoot.pika_mock.assert_consume(queue="tasks", auto_ack=False)
+bigfoot.pika.assert_consume(queue="tasks", auto_ack=False)
 ```
 
 ### `assert_ack(*, delivery_tag)`
 
 ```python
-bigfoot.pika_mock.assert_ack(delivery_tag=1)
+bigfoot.pika.assert_ack(delivery_tag=1)
 ```
 
 ### `assert_nack(*, delivery_tag, requeue)`
 
 ```python
-bigfoot.pika_mock.assert_nack(delivery_tag=1, requeue=True)
+bigfoot.pika.assert_nack(delivery_tag=1, requeue=True)
 ```
 
 ### `assert_close()`
@@ -153,7 +153,7 @@ bigfoot.pika_mock.assert_nack(delivery_tag=1, requeue=True)
 No fields are required.
 
 ```python
-bigfoot.pika_mock.assert_close()
+bigfoot.pika.assert_close()
 ```
 
 ## Full example
@@ -179,7 +179,7 @@ import pika
 import bigfoot
 
 def test_consume_and_ack():
-    (bigfoot.pika_mock
+    (bigfoot.pika
         .new_session()
         .expect("connect",  returns=None)
         .expect("channel",  returns=None)
@@ -195,11 +195,11 @@ def test_consume_and_ack():
         channel.basic_ack(delivery_tag=1)
         connection.close()
 
-    bigfoot.pika_mock.assert_connect(host="localhost", port=5672, virtual_host="/")
-    bigfoot.pika_mock.assert_channel()
-    bigfoot.pika_mock.assert_consume(queue="work", auto_ack=False)
-    bigfoot.pika_mock.assert_ack(delivery_tag=1)
-    bigfoot.pika_mock.assert_close()
+    bigfoot.pika.assert_connect(host="localhost", port=5672, virtual_host="/")
+    bigfoot.pika.assert_channel()
+    bigfoot.pika.assert_consume(queue="work", auto_ack=False)
+    bigfoot.pika.assert_ack(delivery_tag=1)
+    bigfoot.pika.assert_close()
 ```
 
 ## Negative acknowledgement
@@ -208,7 +208,7 @@ Use `nack` to reject and optionally requeue a message:
 
 ```python
 def test_nack_and_requeue():
-    (bigfoot.pika_mock
+    (bigfoot.pika
         .new_session()
         .expect("connect",  returns=None)
         .expect("channel",  returns=None)
@@ -224,9 +224,9 @@ def test_nack_and_requeue():
         channel.basic_nack(delivery_tag=1, requeue=True)
         connection.close()
 
-    bigfoot.pika_mock.assert_connect(host="localhost", port=5672, virtual_host="/")
-    bigfoot.pika_mock.assert_channel()
-    bigfoot.pika_mock.assert_consume(queue="work", auto_ack=False)
-    bigfoot.pika_mock.assert_nack(delivery_tag=1, requeue=True)
-    bigfoot.pika_mock.assert_close()
+    bigfoot.pika.assert_connect(host="localhost", port=5672, virtual_host="/")
+    bigfoot.pika.assert_channel()
+    bigfoot.pika.assert_consume(queue="work", auto_ack=False)
+    bigfoot.pika.assert_nack(delivery_tag=1, requeue=True)
+    bigfoot.pika.assert_close()
 ```

--- a/docs/guides/plugin-layers.md
+++ b/docs/guides/plugin-layers.md
@@ -26,7 +26,7 @@ For example, with both `boto3` and `http` enabled:
 ```python
 def test_s3_both_layers():
     # Must mock at BOTH levels
-    bigfoot.boto3_mock.mock_call("s3", "GetObject", returns={"Body": b"data", "ContentLength": 4})
+    bigfoot.boto3.mock_call("s3", "GetObject", returns={"Body": b"data", "ContentLength": 4})
     bigfoot.http.mock_request("PUT", "https://s3.amazonaws.com/...", returns=httpx.Response(200))
 
     with bigfoot:
@@ -34,7 +34,7 @@ def test_s3_both_layers():
         client.get_object(Bucket="my-bucket", Key="file.txt")
 
     # Must assert at BOTH levels
-    bigfoot.boto3_mock.assert_boto3_call(service="s3", operation="GetObject", params={...})
+    bigfoot.boto3.assert_boto3_call(service="s3", operation="GetObject", params={...})
     bigfoot.http.assert_request("PUT", "https://s3.amazonaws.com/...")
 ```
 
@@ -55,12 +55,12 @@ disabled_plugins = ["http", "socket"]
 
 ```python
 def test_s3_get(bigfoot):
-    bigfoot.boto3_mock.mock_call("s3", "GetObject", returns={"Body": b"data", "ContentLength": 4})
+    bigfoot.boto3.mock_call("s3", "GetObject", returns={"Body": b"data", "ContentLength": 4})
 
     with bigfoot:
         response = boto3.client("s3").get_object(Bucket="b", Key="k")
 
-    bigfoot.boto3_mock.assert_boto3_call(
+    bigfoot.boto3.assert_boto3_call(
         service="s3", operation="GetObject",
         params={"Bucket": "b", "Key": "k"},
     )

--- a/docs/guides/popen-plugin.md
+++ b/docs/guides/popen-plugin.md
@@ -8,13 +8,13 @@
 
 ## Setup
 
-In pytest, access `PopenPlugin` through the `bigfoot.popen_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `PopenPlugin` through the `bigfoot.popen` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import bigfoot
 
 def test_run_command():
-    (bigfoot.popen_mock
+    (bigfoot.popen
         .new_session()
         .expect("spawn",       returns=None)
         .expect("communicate", returns=(b"hello\n", b"", 0)))
@@ -27,8 +27,8 @@ def test_run_command():
     assert stdout == b"hello\n"
     assert proc.returncode == 0
 
-    bigfoot.popen_mock.assert_spawn(command=["echo", "hello"], stdin=None)
-    bigfoot.popen_mock.assert_communicate(input=None)
+    bigfoot.popen.assert_spawn(command=["echo", "hello"], stdin=None)
+    bigfoot.popen.assert_communicate(input=None)
 ```
 
 For manual use outside pytest, construct `PopenPlugin` explicitly:
@@ -57,7 +57,7 @@ The `spawn` step fires automatically during `subprocess.Popen(...)` construction
 Use `new_session()` to create a `SessionHandle` and chain `.expect()` calls to build the script:
 
 ```python
-(bigfoot.popen_mock
+(bigfoot.popen
     .new_session()
     .expect("spawn",       returns=None)
     .expect("communicate", returns=(b"output", b"errors", 0)))
@@ -82,14 +82,14 @@ Use `new_session()` to create a `SessionHandle` and chain `.expect()` calls to b
 
 ## Asserting interactions
 
-Each step records an interaction on the timeline. Use the typed assertion helpers on `bigfoot.popen_mock`:
+Each step records an interaction on the timeline. Use the typed assertion helpers on `bigfoot.popen`:
 
 ### `assert_spawn(*, command, stdin)`
 
 Asserts the next spawn interaction. Both `command` and `stdin` are required fields.
 
 ```python
-bigfoot.popen_mock.assert_spawn(command=["git", "status"], stdin=None)
+bigfoot.popen.assert_spawn(command=["git", "status"], stdin=None)
 ```
 
 ### `assert_communicate(*, input)`
@@ -97,7 +97,7 @@ bigfoot.popen_mock.assert_spawn(command=["git", "status"], stdin=None)
 Asserts the next communicate interaction. The `input` field is required.
 
 ```python
-bigfoot.popen_mock.assert_communicate(input=None)
+bigfoot.popen.assert_communicate(input=None)
 ```
 
 ### `assert_wait()`
@@ -105,7 +105,7 @@ bigfoot.popen_mock.assert_communicate(input=None)
 Asserts the next wait interaction. No fields are required.
 
 ```python
-bigfoot.popen_mock.assert_wait()
+bigfoot.popen.assert_wait()
 ```
 
 ## Full example
@@ -126,7 +126,7 @@ bigfoot.popen_mock.assert_wait()
 
 ```python
 def test_failing_command():
-    (bigfoot.popen_mock
+    (bigfoot.popen
         .new_session()
         .expect("spawn",       returns=None)
         .expect("communicate", returns=(b"", b"command not found\n", 127)))
@@ -138,15 +138,15 @@ def test_failing_command():
     assert proc.returncode == 127
     assert stderr == b"command not found\n"
 
-    bigfoot.popen_mock.assert_spawn(command=["bogus-cmd"], stdin=None)
-    bigfoot.popen_mock.assert_communicate(input=None)
+    bigfoot.popen.assert_spawn(command=["bogus-cmd"], stdin=None)
+    bigfoot.popen.assert_communicate(input=None)
 ```
 
 ## Passing input to communicate()
 
 ```python
 def test_communicate_with_input():
-    (bigfoot.popen_mock
+    (bigfoot.popen
         .new_session()
         .expect("spawn",       returns=None)
         .expect("communicate", returns=(b"response\n", b"", 0)))
@@ -157,8 +157,8 @@ def test_communicate_with_input():
 
     assert stdout == b"response\n"
 
-    bigfoot.popen_mock.assert_spawn(command=["cat"], stdin=None)
-    bigfoot.popen_mock.assert_communicate(input=b"hello\n")
+    bigfoot.popen.assert_spawn(command=["cat"], stdin=None)
+    bigfoot.popen.assert_communicate(input=b"hello\n")
 ```
 
 ## ConflictError

--- a/docs/guides/psycopg2-plugin.md
+++ b/docs/guides/psycopg2-plugin.md
@@ -10,13 +10,13 @@ pip install bigfoot[psycopg2]
 
 ## Setup
 
-In pytest, access `Psycopg2Plugin` through the `bigfoot.psycopg2_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `Psycopg2Plugin` through the `bigfoot.psycopg2` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import bigfoot
 
 def test_select_users():
-    (bigfoot.psycopg2_mock
+    (bigfoot.psycopg2
         .new_session()
         .expect("connect",  returns=None)
         .expect("execute",  returns=[[1, "Alice"], [2, "Bob"]])
@@ -32,9 +32,9 @@ def test_select_users():
 
     assert rows == [[1, "Alice"], [2, "Bob"]]
 
-    bigfoot.psycopg2_mock.assert_connect(dsn="dbname=myapp")
-    bigfoot.psycopg2_mock.assert_execute(sql="SELECT id, name FROM users", parameters=None)
-    bigfoot.psycopg2_mock.assert_close()
+    bigfoot.psycopg2.assert_connect(dsn="dbname=myapp")
+    bigfoot.psycopg2.assert_execute(sql="SELECT id, name FROM users", parameters=None)
+    bigfoot.psycopg2.assert_close()
 ```
 
 For manual use outside pytest, construct `Psycopg2Plugin` explicitly:
@@ -67,7 +67,7 @@ in_transaction --close--> closed
 Use `new_session()` to create a `SessionHandle` and chain `.expect()` calls:
 
 ```python
-(bigfoot.psycopg2_mock
+(bigfoot.psycopg2
     .new_session()
     .expect("connect",  returns=None)
     .expect("execute",  returns=[["row1"], ["row2"]])
@@ -110,10 +110,10 @@ The `assert_connect()` helper accepts whichever parameters were used:
 
 ```python
 # For DSN connections
-bigfoot.psycopg2_mock.assert_connect(dsn="dbname=myapp host=localhost")
+bigfoot.psycopg2.assert_connect(dsn="dbname=myapp host=localhost")
 
 # For keyword connections
-bigfoot.psycopg2_mock.assert_connect(host="localhost", port=5432, dbname="myapp", user="admin")
+bigfoot.psycopg2.assert_connect(host="localhost", port=5432, dbname="myapp", user="admin")
 ```
 
 ## Cursor behavior
@@ -121,7 +121,7 @@ bigfoot.psycopg2_mock.assert_connect(host="localhost", port=5432, dbname="myapp"
 The fake connection's `cursor()` returns a cursor proxy. Call `execute()` on the cursor, then use standard fetch methods:
 
 ```python
-(bigfoot.psycopg2_mock
+(bigfoot.psycopg2
     .new_session()
     .expect("connect",  returns=None)
     .expect("execute",  returns=[[1, "Alice"], [2, "Bob"], [3, "Carol"]])
@@ -146,14 +146,14 @@ with bigfoot:
 
 ## Asserting interactions
 
-Each step records an interaction on the timeline. Use the typed assertion helpers on `bigfoot.psycopg2_mock`:
+Each step records an interaction on the timeline. Use the typed assertion helpers on `bigfoot.psycopg2`:
 
 ### `assert_connect(**kwargs)`
 
 Asserts the next connect interaction. Pass whichever connection fields were used.
 
 ```python
-bigfoot.psycopg2_mock.assert_connect(dsn="dbname=myapp")
+bigfoot.psycopg2.assert_connect(dsn="dbname=myapp")
 ```
 
 ### `assert_execute(*, sql, parameters)`
@@ -161,7 +161,7 @@ bigfoot.psycopg2_mock.assert_connect(dsn="dbname=myapp")
 Asserts the next execute interaction. Both `sql` and `parameters` are required.
 
 ```python
-bigfoot.psycopg2_mock.assert_execute(
+bigfoot.psycopg2.assert_execute(
     sql="INSERT INTO users (name) VALUES (%s)",
     parameters=("Alice",),
 )
@@ -172,7 +172,7 @@ bigfoot.psycopg2_mock.assert_execute(
 Asserts the next commit interaction. No fields are required.
 
 ```python
-bigfoot.psycopg2_mock.assert_commit()
+bigfoot.psycopg2.assert_commit()
 ```
 
 ### `assert_rollback()`
@@ -180,7 +180,7 @@ bigfoot.psycopg2_mock.assert_commit()
 Asserts the next rollback interaction. No fields are required.
 
 ```python
-bigfoot.psycopg2_mock.assert_rollback()
+bigfoot.psycopg2.assert_rollback()
 ```
 
 ### `assert_close()`
@@ -188,7 +188,7 @@ bigfoot.psycopg2_mock.assert_rollback()
 Asserts the next close interaction. No fields are required.
 
 ```python
-bigfoot.psycopg2_mock.assert_close()
+bigfoot.psycopg2.assert_close()
 ```
 
 ## Full example

--- a/docs/guides/redis-plugin.md
+++ b/docs/guides/redis-plugin.md
@@ -12,13 +12,13 @@ This installs `redis>=4.0.0`.
 
 ## Setup
 
-In pytest, access `RedisPlugin` through the `bigfoot.redis_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `RedisPlugin` through the `bigfoot.redis` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import bigfoot
 
 def test_cache_lookup():
-    bigfoot.redis_mock.mock_command("GET", returns="cached_value")
+    bigfoot.redis.mock_command("GET", returns="cached_value")
 
     with bigfoot:
         import redis
@@ -27,7 +27,7 @@ def test_cache_lookup():
 
     assert value == "cached_value"
 
-    bigfoot.redis_mock.assert_command("GET", args=("mykey",), kwargs={})
+    bigfoot.redis.assert_command("GET", args=("mykey",), kwargs={})
 ```
 
 For manual use outside pytest, construct `RedisPlugin` explicitly:
@@ -37,18 +37,18 @@ from bigfoot import StrictVerifier
 from bigfoot.plugins.redis_plugin import RedisPlugin
 
 verifier = StrictVerifier()
-redis_mock = RedisPlugin(verifier)
+redis = RedisPlugin(verifier)
 ```
 
 Each verifier may have at most one `RedisPlugin`. A second `RedisPlugin(verifier)` raises `ValueError`.
 
 ## Registering mock commands
 
-Use `bigfoot.redis_mock.mock_command(command, *, returns, ...)` to register a mock before entering the sandbox:
+Use `bigfoot.redis.mock_command(command, *, returns, ...)` to register a mock before entering the sandbox:
 
 ```python
-bigfoot.redis_mock.mock_command("SET", returns=True)
-bigfoot.redis_mock.mock_command("GET", returns="hello")
+bigfoot.redis.mock_command("SET", returns=True)
+bigfoot.redis.mock_command("GET", returns="hello")
 ```
 
 ### Parameters
@@ -66,8 +66,8 @@ Each command name has its own independent FIFO queue. Multiple `mock_command("GE
 
 ```python
 def test_multiple_gets():
-    bigfoot.redis_mock.mock_command("GET", returns="first")
-    bigfoot.redis_mock.mock_command("GET", returns="second")
+    bigfoot.redis.mock_command("GET", returns="first")
+    bigfoot.redis.mock_command("GET", returns="second")
 
     with bigfoot:
         r = redis.Redis()
@@ -77,20 +77,20 @@ def test_multiple_gets():
     assert v1 == "first"
     assert v2 == "second"
 
-    bigfoot.redis_mock.assert_command("GET", args=("key1",), kwargs={})
-    bigfoot.redis_mock.assert_command("GET", args=("key2",), kwargs={})
+    bigfoot.redis.assert_command("GET", args=("key1",), kwargs={})
+    bigfoot.redis.assert_command("GET", args=("key2",), kwargs={})
 ```
 
 Command names are case-insensitive: `mock_command("get", ...)` matches `execute_command("GET", ...)`.
 
 ## Asserting interactions
 
-Use the `assert_command` helper on `bigfoot.redis_mock`. All three fields (`command`, `args`, `kwargs`) are required:
+Use the `assert_command` helper on `bigfoot.redis`. All three fields (`command`, `args`, `kwargs`) are required:
 
 ### `assert_command(command, args, kwargs)`
 
 ```python
-bigfoot.redis_mock.assert_command("SET", args=("mykey", "myvalue"), kwargs={})
+bigfoot.redis.assert_command("SET", args=("mykey", "myvalue"), kwargs={})
 ```
 
 | Parameter | Type | Default | Description |
@@ -108,7 +108,7 @@ import redis as redis_lib
 import bigfoot
 
 def test_redis_error():
-    bigfoot.redis_mock.mock_command(
+    bigfoot.redis.mock_command(
         "GET",
         returns=None,
         raises=redis_lib.exceptions.ResponseError("WRONGTYPE"),
@@ -119,7 +119,7 @@ def test_redis_error():
         with pytest.raises(redis_lib.exceptions.ResponseError):
             r.execute_command("GET", "badkey")
 
-    bigfoot.redis_mock.assert_command("GET", args=("badkey",), kwargs={})
+    bigfoot.redis.assert_command("GET", args=("badkey",), kwargs={})
 ```
 
 ## Full example
@@ -141,7 +141,7 @@ def test_redis_error():
 Mark a mock as optional with `required=False`:
 
 ```python
-bigfoot.redis_mock.mock_command("PING", returns="PONG", required=False)
+bigfoot.redis.mock_command("PING", returns="PONG", required=False)
 ```
 
 An optional mock that is never triggered does not cause `UnusedMocksError` at teardown.
@@ -153,5 +153,5 @@ When code calls `execute_command` with a command that has no remaining mocks in 
 ```
 redis.GET(...) was called but no mock was registered.
 Register a mock with:
-    bigfoot.redis_mock.mock_command('GET', returns=...)
+    bigfoot.redis.mock_command('GET', returns=...)
 ```

--- a/docs/guides/smtp-plugin.md
+++ b/docs/guides/smtp-plugin.md
@@ -4,13 +4,13 @@
 
 ## Setup
 
-In pytest, access `SmtpPlugin` through the `bigfoot.smtp_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `SmtpPlugin` through the `bigfoot.smtp` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import bigfoot
 
 def test_send_email():
-    (bigfoot.smtp_mock
+    (bigfoot.smtp
         .new_session()
         .expect("connect",  returns=None)
         .expect("ehlo",     returns=(250, b"OK"))
@@ -24,14 +24,14 @@ def test_send_email():
         smtp.sendmail("from@example.com", ["to@example.com"], "Subject: hi\r\n\r\nhello")
         smtp.quit()
 
-    bigfoot.smtp_mock.assert_connect(host="mail.example.com", port=25)
-    bigfoot.smtp_mock.assert_ehlo(name="")
-    bigfoot.smtp_mock.assert_sendmail(
+    bigfoot.smtp.assert_connect(host="mail.example.com", port=25)
+    bigfoot.smtp.assert_ehlo(name="")
+    bigfoot.smtp.assert_sendmail(
         from_addr="from@example.com",
         to_addrs=["to@example.com"],
         msg="Subject: hi\r\n\r\nhello",
     )
-    bigfoot.smtp_mock.assert_quit()
+    bigfoot.smtp.assert_quit()
 ```
 
 For manual use outside pytest, construct `SmtpPlugin` explicitly:
@@ -63,7 +63,7 @@ The `connect` step fires automatically during `smtplib.SMTP(host, port)` constru
 Use `new_session()` to create a `SessionHandle` and chain `.expect()` calls:
 
 ```python
-(bigfoot.smtp_mock
+(bigfoot.smtp
     .new_session()
     .expect("connect",  returns=None)
     .expect("ehlo",     returns=(250, b"OK"))
@@ -97,24 +97,24 @@ Use `new_session()` to create a `SessionHandle` and chain `.expect()` calls:
 
 ## Asserting interactions
 
-Each step records an interaction on the timeline. Use the typed assertion helpers on `bigfoot.smtp_mock`:
+Each step records an interaction on the timeline. Use the typed assertion helpers on `bigfoot.smtp`:
 
 ### `assert_connect(*, host, port)`
 
 ```python
-bigfoot.smtp_mock.assert_connect(host="mail.example.com", port=587)
+bigfoot.smtp.assert_connect(host="mail.example.com", port=587)
 ```
 
 ### `assert_ehlo(*, name)`
 
 ```python
-bigfoot.smtp_mock.assert_ehlo(name="")
+bigfoot.smtp.assert_ehlo(name="")
 ```
 
 ### `assert_helo(*, name)`
 
 ```python
-bigfoot.smtp_mock.assert_helo(name="")
+bigfoot.smtp.assert_helo(name="")
 ```
 
 ### `assert_starttls()`
@@ -122,19 +122,19 @@ bigfoot.smtp_mock.assert_helo(name="")
 No fields are required.
 
 ```python
-bigfoot.smtp_mock.assert_starttls()
+bigfoot.smtp.assert_starttls()
 ```
 
 ### `assert_login(*, user, password)`
 
 ```python
-bigfoot.smtp_mock.assert_login(user="user@example.com", password="s3cret")
+bigfoot.smtp.assert_login(user="user@example.com", password="s3cret")
 ```
 
 ### `assert_sendmail(*, from_addr, to_addrs, msg)`
 
 ```python
-bigfoot.smtp_mock.assert_sendmail(
+bigfoot.smtp.assert_sendmail(
     from_addr="from@example.com",
     to_addrs=["to@example.com"],
     msg="Subject: hello\r\n\r\nhello",
@@ -144,7 +144,7 @@ bigfoot.smtp_mock.assert_sendmail(
 ### `assert_send_message(*, msg)`
 
 ```python
-bigfoot.smtp_mock.assert_send_message(msg=email_message_object)
+bigfoot.smtp.assert_send_message(msg=email_message_object)
 ```
 
 ### `assert_quit()`
@@ -152,7 +152,7 @@ bigfoot.smtp_mock.assert_send_message(msg=email_message_object)
 No fields are required.
 
 ```python
-bigfoot.smtp_mock.assert_quit()
+bigfoot.smtp.assert_quit()
 ```
 
 ## Full authenticated flow
@@ -172,7 +172,7 @@ def send_secure_email(host, port, user, password, from_addr, to_addrs, body):
     smtp.quit()
 
 def test_send_secure_email():
-    (bigfoot.smtp_mock
+    (bigfoot.smtp
         .new_session()
         .expect("connect",  returns=None)
         .expect("ehlo",     returns=(250, b"OK"))
@@ -189,16 +189,16 @@ def test_send_secure_email():
             "Subject: Report\r\n\r\nSee attached.",
         )
 
-    bigfoot.smtp_mock.assert_connect(host="smtp.example.com", port=587)
-    bigfoot.smtp_mock.assert_ehlo(name="")
-    bigfoot.smtp_mock.assert_starttls()
-    bigfoot.smtp_mock.assert_login(user="user@example.com", password="s3cret")
-    bigfoot.smtp_mock.assert_sendmail(
+    bigfoot.smtp.assert_connect(host="smtp.example.com", port=587)
+    bigfoot.smtp.assert_ehlo(name="")
+    bigfoot.smtp.assert_starttls()
+    bigfoot.smtp.assert_login(user="user@example.com", password="s3cret")
+    bigfoot.smtp.assert_sendmail(
         from_addr="user@example.com",
         to_addrs=["recipient@example.com"],
         msg="Subject: Report\r\n\r\nSee attached.",
     )
-    bigfoot.smtp_mock.assert_quit()
+    bigfoot.smtp.assert_quit()
 ```
 
 ## Unauthenticated flow
@@ -207,7 +207,7 @@ Skip `starttls` and `login` for servers that do not require authentication:
 
 ```python
 def test_send_unauthenticated_email():
-    (bigfoot.smtp_mock
+    (bigfoot.smtp
         .new_session()
         .expect("connect",  returns=None)
         .expect("ehlo",     returns=(250, b"OK"))
@@ -220,14 +220,14 @@ def test_send_unauthenticated_email():
         smtp.sendmail("from@example.com", ["to@example.com"], "Subject: test\r\n\r\ntest")
         smtp.quit()
 
-    bigfoot.smtp_mock.assert_connect(host="mail.example.com", port=25)
-    bigfoot.smtp_mock.assert_ehlo(name="")
-    bigfoot.smtp_mock.assert_sendmail(
+    bigfoot.smtp.assert_connect(host="mail.example.com", port=25)
+    bigfoot.smtp.assert_ehlo(name="")
+    bigfoot.smtp.assert_sendmail(
         from_addr="from@example.com",
         to_addrs=["to@example.com"],
         msg="Subject: test\r\n\r\ntest",
     )
-    bigfoot.smtp_mock.assert_quit()
+    bigfoot.smtp.assert_quit()
 ```
 
 The state machine validates that `sendmail` is called from `greeted` (after `ehlo` without login) or from `authenticated` (after login). Calling `sendmail` from `connected` (skipping `ehlo`) raises `InvalidStateError`.
@@ -238,7 +238,7 @@ Some legacy servers use `HELO` instead of `EHLO`. The state machine treats both 
 
 ```python
 def test_helo_flow():
-    (bigfoot.smtp_mock
+    (bigfoot.smtp
         .new_session()
         .expect("connect",  returns=None)
         .expect("helo",     returns=(250, b"OK"))
@@ -251,14 +251,14 @@ def test_helo_flow():
         smtp.sendmail("from@example.com", ["to@example.com"], "Subject: test\r\n\r\ntest")
         smtp.quit()
 
-    bigfoot.smtp_mock.assert_connect(host="mail.example.com", port=25)
-    bigfoot.smtp_mock.assert_helo(name="")
-    bigfoot.smtp_mock.assert_sendmail(
+    bigfoot.smtp.assert_connect(host="mail.example.com", port=25)
+    bigfoot.smtp.assert_helo(name="")
+    bigfoot.smtp.assert_sendmail(
         from_addr="from@example.com",
         to_addrs=["to@example.com"],
         msg="Subject: test\r\n\r\ntest",
     )
-    bigfoot.smtp_mock.assert_quit()
+    bigfoot.smtp.assert_quit()
 ```
 
 ## Using `send_message`
@@ -275,7 +275,7 @@ def test_send_message():
     msg["To"] = "to@example.com"
     msg.set_content("See attached.")
 
-    (bigfoot.smtp_mock
+    (bigfoot.smtp
         .new_session()
         .expect("connect",      returns=None)
         .expect("ehlo",         returns=(250, b"OK"))
@@ -288,8 +288,8 @@ def test_send_message():
         smtp.send_message(msg)
         smtp.quit()
 
-    bigfoot.smtp_mock.assert_connect(host="mail.example.com", port=25)
-    bigfoot.smtp_mock.assert_ehlo(name="")
-    bigfoot.smtp_mock.assert_send_message(msg=msg)
-    bigfoot.smtp_mock.assert_quit()
+    bigfoot.smtp.assert_connect(host="mail.example.com", port=25)
+    bigfoot.smtp.assert_ehlo(name="")
+    bigfoot.smtp.assert_send_message(msg=msg)
+    bigfoot.smtp.assert_quit()
 ```

--- a/docs/guides/socket-plugin.md
+++ b/docs/guides/socket-plugin.md
@@ -4,13 +4,13 @@
 
 ## Setup
 
-In pytest, access `SocketPlugin` through the `bigfoot.socket_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `SocketPlugin` through the `bigfoot.socket` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import bigfoot
 
 def test_echo_client():
-    (bigfoot.socket_mock
+    (bigfoot.socket
         .new_session()
         .expect("connect",  returns=None)
         .expect("sendall",  returns=None)
@@ -27,10 +27,10 @@ def test_echo_client():
 
     assert data == b"pong"
 
-    bigfoot.socket_mock.assert_connect(host="127.0.0.1", port=9999)
-    bigfoot.socket_mock.assert_sendall(data=b"ping")
-    bigfoot.socket_mock.assert_recv(size=1024, data=b"pong")
-    bigfoot.socket_mock.assert_close()
+    bigfoot.socket.assert_connect(host="127.0.0.1", port=9999)
+    bigfoot.socket.assert_sendall(data=b"ping")
+    bigfoot.socket.assert_recv(size=1024, data=b"pong")
+    bigfoot.socket.assert_close()
 ```
 
 For manual use outside pytest, construct `SocketPlugin` explicitly:
@@ -58,7 +58,7 @@ disconnected --connect--> connected --send/sendall/recv--> connected --close--> 
 Use `new_session()` to create a `SessionHandle` and chain `.expect()` calls:
 
 ```python
-(bigfoot.socket_mock
+(bigfoot.socket
     .new_session()
     .expect("connect",  returns=None)
     .expect("send",     returns=5)
@@ -87,24 +87,24 @@ Use `new_session()` to create a `SessionHandle` and chain `.expect()` calls:
 
 ## Asserting interactions
 
-Each step records an interaction on the timeline. Use the typed assertion helpers on `bigfoot.socket_mock`:
+Each step records an interaction on the timeline. Use the typed assertion helpers on `bigfoot.socket`:
 
 ### `assert_connect(*, host, port)`
 
 ```python
-bigfoot.socket_mock.assert_connect(host="127.0.0.1", port=8080)
+bigfoot.socket.assert_connect(host="127.0.0.1", port=8080)
 ```
 
 ### `assert_send(*, data)`
 
 ```python
-bigfoot.socket_mock.assert_send(data=b"hello")
+bigfoot.socket.assert_send(data=b"hello")
 ```
 
 ### `assert_sendall(*, data)`
 
 ```python
-bigfoot.socket_mock.assert_sendall(data=b"hello")
+bigfoot.socket.assert_sendall(data=b"hello")
 ```
 
 ### `assert_recv(*, size, data)`
@@ -112,7 +112,7 @@ bigfoot.socket_mock.assert_sendall(data=b"hello")
 Both `size` and `data` are required. `size` is the buffer size passed to `recv()`, and `data` is the bytes actually returned.
 
 ```python
-bigfoot.socket_mock.assert_recv(size=1024, data=b"response")
+bigfoot.socket.assert_recv(size=1024, data=b"response")
 ```
 
 ### `assert_close()`
@@ -120,7 +120,7 @@ bigfoot.socket_mock.assert_recv(size=1024, data=b"response")
 No fields are required.
 
 ```python
-bigfoot.socket_mock.assert_close()
+bigfoot.socket.assert_close()
 ```
 
 ## Multiple connections
@@ -129,13 +129,13 @@ Sessions are consumed in registration order. The first `socket.connect()` pops t
 
 ```python
 def test_two_connections():
-    (bigfoot.socket_mock
+    (bigfoot.socket
         .new_session()
         .expect("connect", returns=None)
         .expect("recv",    returns=b"first")
         .expect("close",   returns=None))
 
-    (bigfoot.socket_mock
+    (bigfoot.socket
         .new_session()
         .expect("connect", returns=None)
         .expect("recv",    returns=b"second")
@@ -151,12 +151,12 @@ def test_two_connections():
         s1.close()
         s2.close()
 
-    bigfoot.socket_mock.assert_connect(host="127.0.0.1", port=9001)
-    bigfoot.socket_mock.assert_connect(host="127.0.0.1", port=9002)
-    bigfoot.socket_mock.assert_recv(size=1024, data=b"first")
-    bigfoot.socket_mock.assert_recv(size=1024, data=b"second")
-    bigfoot.socket_mock.assert_close()
-    bigfoot.socket_mock.assert_close()
+    bigfoot.socket.assert_connect(host="127.0.0.1", port=9001)
+    bigfoot.socket.assert_connect(host="127.0.0.1", port=9002)
+    bigfoot.socket.assert_recv(size=1024, data=b"first")
+    bigfoot.socket.assert_recv(size=1024, data=b"second")
+    bigfoot.socket.assert_close()
+    bigfoot.socket.assert_close()
 ```
 
 ## Full example

--- a/docs/guides/ssh-plugin.md
+++ b/docs/guides/ssh-plugin.md
@@ -12,13 +12,13 @@ This installs `paramiko`.
 
 ## Setup
 
-In pytest, access `SshPlugin` through the `bigfoot.ssh_mock` proxy. It auto-creates the plugin for the current test on first use:
+In pytest, access `SshPlugin` through the `bigfoot.ssh` proxy. It auto-creates the plugin for the current test on first use:
 
 ```python
 import bigfoot
 
 def test_remote_command():
-    (bigfoot.ssh_mock
+    (bigfoot.ssh
         .new_session()
         .expect("connect",      returns=None)
         .expect("exec_command", returns=(None, b"hello\n", b""))
@@ -32,11 +32,11 @@ def test_remote_command():
         stdin, stdout, stderr = client.exec_command("echo hello")
         client.close()
 
-    bigfoot.ssh_mock.assert_connect(
+    bigfoot.ssh.assert_connect(
         hostname="server.example.com", port=22, username="deploy", auth_method="password",
     )
-    bigfoot.ssh_mock.assert_exec_command(command="echo hello")
-    bigfoot.ssh_mock.assert_close()
+    bigfoot.ssh.assert_exec_command(command="echo hello")
+    bigfoot.ssh.assert_close()
 ```
 
 For manual use outside pytest, construct `SshPlugin` explicitly:
@@ -46,7 +46,7 @@ from bigfoot import StrictVerifier
 from bigfoot.plugins.ssh_plugin import SshPlugin
 
 verifier = StrictVerifier()
-ssh_mock = SshPlugin(verifier)
+ssh = SshPlugin(verifier)
 ```
 
 Each verifier may have at most one `SshPlugin`. A second `SshPlugin(verifier)` raises `ValueError`.
@@ -69,7 +69,7 @@ Unlike pika.BlockingConnection, `paramiko.SSHClient()` does not connect on const
 Use `new_session()` to create a `SessionHandle` and chain `.expect()` calls:
 
 ```python
-(bigfoot.ssh_mock
+(bigfoot.ssh
     .new_session()
     .expect("connect",      returns=None)
     .expect("exec_command", returns=(None, b"output", b""))
@@ -103,14 +103,14 @@ Use `new_session()` to create a `SessionHandle` and chain `.expect()` calls:
 
 ## Asserting interactions
 
-Each step records an interaction on the timeline. Use the typed assertion helpers on `bigfoot.ssh_mock`:
+Each step records an interaction on the timeline. Use the typed assertion helpers on `bigfoot.ssh`:
 
 ### `assert_connect(*, hostname, port, username, auth_method)`
 
 The `auth_method` is automatically determined: `"key"` if `pkey` or `key_filename` is passed to `connect()`, otherwise `"password"`.
 
 ```python
-bigfoot.ssh_mock.assert_connect(
+bigfoot.ssh.assert_connect(
     hostname="server.example.com", port=22, username="deploy", auth_method="password",
 )
 ```
@@ -118,7 +118,7 @@ bigfoot.ssh_mock.assert_connect(
 ### `assert_exec_command(*, command)`
 
 ```python
-bigfoot.ssh_mock.assert_exec_command(command="systemctl restart nginx")
+bigfoot.ssh.assert_exec_command(command="systemctl restart nginx")
 ```
 
 ### `assert_open_sftp()`
@@ -126,43 +126,43 @@ bigfoot.ssh_mock.assert_exec_command(command="systemctl restart nginx")
 No fields are required.
 
 ```python
-bigfoot.ssh_mock.assert_open_sftp()
+bigfoot.ssh.assert_open_sftp()
 ```
 
 ### `assert_sftp_get(*, remotepath, localpath)`
 
 ```python
-bigfoot.ssh_mock.assert_sftp_get(remotepath="/var/log/app.log", localpath="/tmp/app.log")
+bigfoot.ssh.assert_sftp_get(remotepath="/var/log/app.log", localpath="/tmp/app.log")
 ```
 
 ### `assert_sftp_put(*, localpath, remotepath)`
 
 ```python
-bigfoot.ssh_mock.assert_sftp_put(localpath="/tmp/config.yaml", remotepath="/etc/app/config.yaml")
+bigfoot.ssh.assert_sftp_put(localpath="/tmp/config.yaml", remotepath="/etc/app/config.yaml")
 ```
 
 ### `assert_sftp_listdir(*, path)`
 
 ```python
-bigfoot.ssh_mock.assert_sftp_listdir(path="/var/log")
+bigfoot.ssh.assert_sftp_listdir(path="/var/log")
 ```
 
 ### `assert_sftp_stat(*, path)`
 
 ```python
-bigfoot.ssh_mock.assert_sftp_stat(path="/etc/app/config.yaml")
+bigfoot.ssh.assert_sftp_stat(path="/etc/app/config.yaml")
 ```
 
 ### `assert_sftp_mkdir(*, path)`
 
 ```python
-bigfoot.ssh_mock.assert_sftp_mkdir(path="/var/data/exports")
+bigfoot.ssh.assert_sftp_mkdir(path="/var/data/exports")
 ```
 
 ### `assert_sftp_remove(*, path)`
 
 ```python
-bigfoot.ssh_mock.assert_sftp_remove(path="/tmp/old-backup.tar.gz")
+bigfoot.ssh.assert_sftp_remove(path="/tmp/old-backup.tar.gz")
 ```
 
 ### `assert_close()`
@@ -170,7 +170,7 @@ bigfoot.ssh_mock.assert_sftp_remove(path="/tmp/old-backup.tar.gz")
 No fields are required.
 
 ```python
-bigfoot.ssh_mock.assert_close()
+bigfoot.ssh.assert_close()
 ```
 
 ## Full example
@@ -193,7 +193,7 @@ When `pkey` or `key_filename` is passed to `connect()`, the `auth_method` detail
 
 ```python
 def test_key_auth():
-    (bigfoot.ssh_mock
+    (bigfoot.ssh
         .new_session()
         .expect("connect",      returns=None)
         .expect("exec_command", returns=(None, b"ok", b""))
@@ -206,11 +206,11 @@ def test_key_auth():
         client.exec_command("whoami")
         client.close()
 
-    bigfoot.ssh_mock.assert_connect(
+    bigfoot.ssh.assert_connect(
         hostname="bastion.example.com", port=22, username="ops", auth_method="key",
     )
-    bigfoot.ssh_mock.assert_exec_command(command="whoami")
-    bigfoot.ssh_mock.assert_close()
+    bigfoot.ssh.assert_exec_command(command="whoami")
+    bigfoot.ssh.assert_close()
 ```
 
 ## SFTP file operations
@@ -219,7 +219,7 @@ A full SFTP session with multiple file operations:
 
 ```python
 def test_sftp_operations():
-    (bigfoot.ssh_mock
+    (bigfoot.ssh
         .new_session()
         .expect("connect",       returns=None)
         .expect("open_sftp",     returns=None)
@@ -242,14 +242,14 @@ def test_sftp_operations():
         sftp.remove("/data/incoming/data.csv")
         client.close()
 
-    bigfoot.ssh_mock.assert_connect(
+    bigfoot.ssh.assert_connect(
         hostname="fileserver.example.com", port=22, username="sync", auth_method="password",
     )
-    bigfoot.ssh_mock.assert_open_sftp()
-    bigfoot.ssh_mock.assert_sftp_listdir(path="/data/incoming")
-    bigfoot.ssh_mock.assert_sftp_get(remotepath="/data/incoming/data.csv", localpath="/tmp/data.csv")
-    bigfoot.ssh_mock.assert_sftp_mkdir(path="/data/processed")
-    bigfoot.ssh_mock.assert_sftp_put(localpath="/tmp/result.csv", remotepath="/data/processed/result.csv")
-    bigfoot.ssh_mock.assert_sftp_remove(path="/data/incoming/data.csv")
-    bigfoot.ssh_mock.assert_close()
+    bigfoot.ssh.assert_open_sftp()
+    bigfoot.ssh.assert_sftp_listdir(path="/data/incoming")
+    bigfoot.ssh.assert_sftp_get(remotepath="/data/incoming/data.csv", localpath="/tmp/data.csv")
+    bigfoot.ssh.assert_sftp_mkdir(path="/data/processed")
+    bigfoot.ssh.assert_sftp_put(localpath="/tmp/result.csv", remotepath="/data/processed/result.csv")
+    bigfoot.ssh.assert_sftp_remove(path="/data/incoming/data.csv")
+    bigfoot.ssh.assert_close()
 ```

--- a/docs/guides/stateful-plugins.md
+++ b/docs/guides/stateful-plugins.md
@@ -32,7 +32,7 @@ Every stateful plugin (except `RedisPlugin`, which is stateless) extends `StateM
 disconnected --connect--> connected --send/sendall/recv--> connected --close--> closed
 ```
 
-**Proxy:** `bigfoot.socket_mock`
+**Proxy:** `bigfoot.socket`
 
 ### Quickstart
 
@@ -41,7 +41,7 @@ import socket
 import bigfoot
 
 def test_echo_client():
-    (bigfoot.socket_mock
+    (bigfoot.socket
         .new_session()
         .expect("connect",  returns=None)
         .expect("sendall",  returns=None)
@@ -59,7 +59,7 @@ def test_echo_client():
     # verify_all() called automatically at teardown
 ```
 
-No imports other than `bigfoot` and `socket`. The proxy `bigfoot.socket_mock` auto-creates the plugin on the current test verifier the first time it is accessed.
+No imports other than `bigfoot` and `socket`. The proxy `bigfoot.socket` auto-creates the plugin on the current test verifier the first time it is accessed.
 
 ### Scripting multiple connections
 
@@ -67,13 +67,13 @@ Sessions are consumed in registration order:
 
 ```python
 def test_two_connections():
-    (bigfoot.socket_mock
+    (bigfoot.socket
         .new_session()
         .expect("connect", returns=None)
         .expect("recv",    returns=b"first")
         .expect("close",   returns=None))
 
-    (bigfoot.socket_mock
+    (bigfoot.socket
         .new_session()
         .expect("connect", returns=None)
         .expect("recv",    returns=b"second")
@@ -96,7 +96,7 @@ Calling a method from the wrong state raises `InvalidStateError` immediately:
 
 ```python
 def test_recv_before_connect():
-    bigfoot.socket_mock.new_session()  # empty session
+    bigfoot.socket.new_session()  # empty session
 
     with bigfoot:
         sock = socket.socket()
@@ -131,7 +131,7 @@ in_transaction --commit/rollback--> connected
 connected/in_transaction --close--> closed
 ```
 
-**Proxy:** `bigfoot.db_mock`
+**Proxy:** `bigfoot.db`
 
 ### Quickstart
 
@@ -140,7 +140,7 @@ import sqlite3
 import bigfoot
 
 def test_select_users():
-    (bigfoot.db_mock
+    (bigfoot.db
         .new_session()
         .expect("execute", returns=[[1, "Alice"], [2, "Bob"]])
         .expect("close",   returns=None))
@@ -158,7 +158,7 @@ def test_select_users():
 
 ```python
 def test_cursor_style():
-    (bigfoot.db_mock
+    (bigfoot.db
         .new_session()
         .expect("execute", returns=[["x"], ["y"]])
         .expect("close",   returns=None))
@@ -181,7 +181,7 @@ Each `execute()` moves the connection into `in_transaction`. `commit()` and `rol
 
 ```python
 def test_commit_then_execute():
-    (bigfoot.db_mock
+    (bigfoot.db
         .new_session()
         .expect("execute",  returns=[])
         .expect("commit",   returns=None)
@@ -223,7 +223,7 @@ assert exc_info.value.valid_states == frozenset({"in_transaction"})
 connecting --connect (on __aenter__)--> open --send/recv--> open --close--> closed
 ```
 
-**Proxy:** `bigfoot.async_websocket_mock`
+**Proxy:** `bigfoot.async_websocket`
 
 ### Quickstart
 
@@ -233,7 +233,7 @@ import bigfoot
 import pytest
 
 async def test_ws_echo():
-    (bigfoot.async_websocket_mock
+    (bigfoot.async_websocket
         .new_session()
         .expect("connect", returns=None)
         .expect("send",    returns=None)
@@ -257,13 +257,13 @@ Sessions are popped at `websockets.connect()` call time, not at `__aenter__` tim
 
 ```python
 async def test_two_ws_connections():
-    (bigfoot.async_websocket_mock
+    (bigfoot.async_websocket
         .new_session()
         .expect("connect", returns=None)
         .expect("recv",    returns="first")
         .expect("close",   returns=None))
 
-    (bigfoot.async_websocket_mock
+    (bigfoot.async_websocket
         .new_session()
         .expect("connect", returns=None)
         .expect("recv",    returns="second")
@@ -292,7 +292,7 @@ async def test_two_ws_connections():
 connecting --connect--> open --send/recv--> open --close--> closed
 ```
 
-**Proxy:** `bigfoot.sync_websocket_mock`
+**Proxy:** `bigfoot.sync_websocket`
 
 ### Quickstart
 
@@ -301,7 +301,7 @@ import websocket
 import bigfoot
 
 def test_sync_ws():
-    (bigfoot.sync_websocket_mock
+    (bigfoot.sync_websocket
         .new_session()
         .expect("connect", returns=None)
         .expect("send",    returns=None)
@@ -333,7 +333,7 @@ running --communicate--> terminated
 running --wait--> terminated (also releases the session)
 ```
 
-**Proxy:** `bigfoot.popen_mock`
+**Proxy:** `bigfoot.popen`
 
 **Coexistence with SubprocessPlugin:** `SubprocessPlugin` patches `subprocess.run` and `shutil.which`. `PopenPlugin` patches `subprocess.Popen`. Both can be active in the same sandbox without interference.
 
@@ -346,7 +346,7 @@ import subprocess
 import bigfoot
 
 def test_run_command():
-    (bigfoot.popen_mock
+    (bigfoot.popen
         .new_session()
         .expect("init",        returns=None)
         .expect("communicate", returns=(b"hello\n", b"", 0)))
@@ -364,7 +364,7 @@ def test_run_command():
 
 ```python
 def test_failing_command():
-    (bigfoot.popen_mock
+    (bigfoot.popen
         .new_session()
         .expect("init",        returns=None)
         .expect("communicate", returns=(b"", b"command not found", 127)))
@@ -383,7 +383,7 @@ def test_failing_command():
 
 ```python
 def test_wait():
-    (bigfoot.popen_mock
+    (bigfoot.popen
         .new_session()
         .expect("init", returns=None)
         .expect("wait", returns=0))
@@ -402,7 +402,7 @@ For code that reads `proc.stdout` and `proc.stderr` directly rather than using `
 
 ```python
 def test_stream_read():
-    (bigfoot.popen_mock
+    (bigfoot.popen
         .new_session()
         .expect("init",        returns=None)
         .expect("stdout.read", returns=b"output data"))
@@ -432,7 +432,7 @@ sending/greeted/authenticated --quit--> closed
 
 `starttls` and `login` are optional steps. Skip them in your session script for an unauthenticated flow.
 
-**Proxy:** `bigfoot.smtp_mock`
+**Proxy:** `bigfoot.smtp`
 
 ### Full authenticated flow (ehlo + starttls + login + sendmail + quit)
 
@@ -441,7 +441,7 @@ import smtplib
 import bigfoot
 
 def test_send_authenticated_email():
-    (bigfoot.smtp_mock
+    (bigfoot.smtp
         .new_session()
         .expect("connect",  returns=None)
         .expect("ehlo",     returns=(250, b"OK"))
@@ -467,7 +467,7 @@ def test_send_authenticated_email():
 
 ```python
 def test_send_unauthenticated_email():
-    (bigfoot.smtp_mock
+    (bigfoot.smtp
         .new_session()
         .expect("connect",  returns=None)
         .expect("ehlo",     returns=(250, b"OK"))
@@ -495,7 +495,7 @@ The state machine validates that `sendmail` is called from `greeted` (after `ehl
 
 **Requires:** `pip install bigfoot[redis]`
 
-**Proxy:** `bigfoot.redis_mock`
+**Proxy:** `bigfoot.redis`
 
 ### Quickstart
 
@@ -504,7 +504,7 @@ import redis
 import bigfoot
 
 def test_cache_lookup():
-    bigfoot.redis_mock.mock_command("GET", returns="cached_value")
+    bigfoot.redis.mock_command("GET", returns="cached_value")
 
     with bigfoot:
         r = redis.Redis()
@@ -519,9 +519,9 @@ Each command name has its own independent FIFO queue. Multiple `mock_command("GE
 
 ```python
 def test_get_set():
-    bigfoot.redis_mock.mock_command("SET", returns=True)
-    bigfoot.redis_mock.mock_command("GET", returns="first")
-    bigfoot.redis_mock.mock_command("GET", returns="second")
+    bigfoot.redis.mock_command("SET", returns=True)
+    bigfoot.redis.mock_command("GET", returns="first")
+    bigfoot.redis.mock_command("GET", returns="second")
 
     with bigfoot:
         r = redis.Redis()
@@ -540,7 +540,7 @@ Command names are case-insensitive: `mock_command("get", ...)` matches `execute_
 ```python
 def test_redis_error():
     import redis as redis_lib
-    bigfoot.redis_mock.mock_command(
+    bigfoot.redis.mock_command(
         "GET",
         returns=None,
         raises=redis_lib.exceptions.ResponseError("WRONGTYPE"),
@@ -574,10 +574,10 @@ Raised when a connection entry point fires (e.g., `socket.connect()`, `sqlite3.c
 UnmockedInteractionError: source_id='socket:connect'
 hint='socket.socket.connect(...) was called but no session was queued.
 Register a session with:
-    bigfoot.socket_mock.new_session().expect("connect", returns=...)'
+    bigfoot.socket.new_session().expect("connect", returns=...)'
 ```
 
-**Fix:** Call `bigfoot.socket_mock.new_session()` (or the appropriate proxy) before entering the sandbox.
+**Fix:** Call `bigfoot.socket.new_session()` (or the appropriate proxy) before entering the sandbox.
 
 Also raised when the session script is exhausted but the code under test makes another call. In this case the hint shows the method that ran out of steps.
 

--- a/docs/guides/subprocess-plugin.md
+++ b/docs/guides/subprocess-plugin.md
@@ -4,18 +4,18 @@
 
 ## Setup
 
-In pytest, access `SubprocessPlugin` through the `bigfoot.subprocess_mock` proxy. It auto-creates the plugin for the current test on first use — no explicit instantiation needed:
+In pytest, access `SubprocessPlugin` through the `bigfoot.subprocess` proxy. It auto-creates the plugin for the current test on first use — no explicit instantiation needed:
 
 ```python
 import bigfoot
 
 def test_build():
-    bigfoot.subprocess_mock.mock_run(["make", "all"], returncode=0)
+    bigfoot.subprocess.mock_run(["make", "all"], returncode=0)
 
     with bigfoot:
         run_build()
 
-    bigfoot.subprocess_mock.assert_run(command=["make", "all"], returncode=0, stdout="", stderr="")
+    bigfoot.subprocess.assert_run(command=["make", "all"], returncode=0, stdout="", stderr="")
 ```
 
 For manual use outside pytest, construct `SubprocessPlugin` explicitly:
@@ -32,10 +32,10 @@ Each verifier may have at most one `SubprocessPlugin`. A second `SubprocessPlugi
 
 ## Registering `subprocess.run` mocks
 
-Use `bigfoot.subprocess_mock.mock_run(command, ...)` to register a mock before entering the sandbox:
+Use `bigfoot.subprocess.mock_run(command, ...)` to register a mock before entering the sandbox:
 
 ```python
-bigfoot.subprocess_mock.mock_run(["git", "status"], returncode=0, stdout="On branch main\n")
+bigfoot.subprocess.mock_run(["git", "status"], returncode=0, stdout="On branch main\n")
 ```
 
 Parameters:
@@ -54,8 +54,8 @@ Parameters:
 `subprocess.run` uses a strict FIFO queue. Each registered mock is consumed in registration order. If code calls `subprocess.run` with a command that does not match the next entry in the queue, `UnmockedInteractionError` is raised immediately at call time.
 
 ```python
-bigfoot.subprocess_mock.mock_run(["git", "fetch"], returncode=0)
-bigfoot.subprocess_mock.mock_run(["git", "merge", "origin/main"], returncode=0)
+bigfoot.subprocess.mock_run(["git", "fetch"], returncode=0)
+bigfoot.subprocess.mock_run(["git", "merge", "origin/main"], returncode=0)
 # The first subprocess.run call must be ["git", "fetch"],
 # the second must be ["git", "merge", "origin/main"].
 ```
@@ -64,31 +64,31 @@ Calling `subprocess.run` with an unregistered command or in the wrong order rais
 
 ## Asserting `subprocess.run` interactions
 
-Use `bigfoot.subprocess_mock.assert_run()` to assert subprocess interactions:
+Use `bigfoot.subprocess.assert_run()` to assert subprocess interactions:
 
 ```python
-bigfoot.subprocess_mock.assert_run(command=["git", "fetch"], returncode=0, stdout="", stderr="")
-bigfoot.subprocess_mock.assert_run(command=["git", "merge", "origin/main"], returncode=0, stdout="", stderr="")
+bigfoot.subprocess.assert_run(command=["git", "fetch"], returncode=0, stdout="", stderr="")
+bigfoot.subprocess.assert_run(command=["git", "merge", "origin/main"], returncode=0, stdout="", stderr="")
 ```
 
 `assert_run()` is a convenience wrapper around the lower-level `assert_interaction()` call:
 
 ```python
 # Convenience (recommended):
-bigfoot.subprocess_mock.assert_run(command=["git", "fetch"], returncode=0, stdout="", stderr="")
+bigfoot.subprocess.assert_run(command=["git", "fetch"], returncode=0, stdout="", stderr="")
 
 # Equivalent low-level call:
-bigfoot.assert_interaction(bigfoot.subprocess_mock.run, command=["git", "fetch"],
+bigfoot.assert_interaction(bigfoot.subprocess.run, command=["git", "fetch"],
                            returncode=0, stdout="", stderr="")
 ```
 
 ## Registering `shutil.which` mocks
 
-Use `bigfoot.subprocess_mock.mock_which(name, returns, ...)` to register a mock before entering the sandbox:
+Use `bigfoot.subprocess.mock_which(name, returns, ...)` to register a mock before entering the sandbox:
 
 ```python
-bigfoot.subprocess_mock.mock_which("git", returns="/usr/bin/git")
-bigfoot.subprocess_mock.mock_which("svn", returns=None)  # simulate not found
+bigfoot.subprocess.mock_which("git", returns="/usr/bin/git")
+bigfoot.subprocess.mock_which("svn", returns=None)  # simulate not found
 ```
 
 Parameters:
@@ -107,31 +107,31 @@ This differs from `subprocess.run`, which enforces a strict queue. The rationale
 
 ## Asserting `shutil.which` interactions
 
-Use `bigfoot.subprocess_mock.assert_which()` to assert `shutil.which` interactions:
+Use `bigfoot.subprocess.assert_which()` to assert `shutil.which` interactions:
 
 ```python
-bigfoot.subprocess_mock.assert_which(name="git", returns="/usr/bin/git")
+bigfoot.subprocess.assert_which(name="git", returns="/usr/bin/git")
 ```
 
 `assert_which()` is a convenience wrapper around the lower-level `assert_interaction()` call:
 
 ```python
 # Convenience (recommended):
-bigfoot.subprocess_mock.assert_which(name="git", returns="/usr/bin/git")
+bigfoot.subprocess.assert_which(name="git", returns="/usr/bin/git")
 
 # Equivalent low-level call:
-bigfoot.assert_interaction(bigfoot.subprocess_mock.which, name="git", returns="/usr/bin/git")
+bigfoot.assert_interaction(bigfoot.subprocess.which, name="git", returns="/usr/bin/git")
 ```
 
 Only registered names record interactions. Calls to unregistered names are not recorded and cannot be asserted.
 
 ## Activating without mocks
 
-`subprocess_mock.install()` activates the bouncer with no mocks registered. Any call to `subprocess.run` during the sandbox will raise `UnmockedInteractionError` immediately. Use this when you want to assert that a code path does not call subprocess at all:
+`bigfoot.subprocess.install()` activates the bouncer with no mocks registered. Any call to `subprocess.run` during the sandbox will raise `UnmockedInteractionError` immediately. Use this when you want to assert that a code path does not call subprocess at all:
 
 ```python
 def test_no_subprocess_calls():
-    bigfoot.subprocess_mock.install()  # any subprocess.run call will raise UnmockedInteractionError
+    bigfoot.subprocess.install()  # any subprocess.run call will raise UnmockedInteractionError
 
     with bigfoot:
         result = function_that_should_not_call_subprocess()

--- a/docs/guides/websocket-plugin.md
+++ b/docs/guides/websocket-plugin.md
@@ -35,7 +35,7 @@ The `connect` step fires during `websockets.connect().__aenter__()` (async) or `
 
 ## AsyncWebSocketPlugin
 
-**Proxy:** `bigfoot.async_websocket_mock`
+**Proxy:** `bigfoot.async_websocket`
 
 ### Setup
 
@@ -43,7 +43,7 @@ The `connect` step fires during `websockets.connect().__aenter__()` (async) or `
 import bigfoot
 
 async def test_ws_echo():
-    (bigfoot.async_websocket_mock
+    (bigfoot.async_websocket
         .new_session()
         .expect("connect", returns=None)
         .expect("send",    returns=None)
@@ -59,10 +59,10 @@ async def test_ws_echo():
 
     assert message == "pong"
 
-    bigfoot.async_websocket_mock.assert_connect(uri="ws://localhost:8765")
-    bigfoot.async_websocket_mock.assert_send(message="ping")
-    bigfoot.async_websocket_mock.assert_recv(message="pong")
-    bigfoot.async_websocket_mock.assert_close()
+    bigfoot.async_websocket.assert_connect(uri="ws://localhost:8765")
+    bigfoot.async_websocket.assert_send(message="ping")
+    bigfoot.async_websocket.assert_recv(message="pong")
+    bigfoot.async_websocket.assert_close()
 ```
 
 For manual use outside pytest:
@@ -87,13 +87,13 @@ Sessions are consumed in registration order:
 
 ```python
 async def test_two_ws_connections():
-    (bigfoot.async_websocket_mock
+    (bigfoot.async_websocket
         .new_session()
         .expect("connect", returns=None)
         .expect("recv",    returns="first")
         .expect("close",   returns=None))
 
-    (bigfoot.async_websocket_mock
+    (bigfoot.async_websocket
         .new_session()
         .expect("connect", returns=None)
         .expect("recv",    returns="second")
@@ -107,12 +107,12 @@ async def test_two_ws_connections():
                 assert await ws1.recv() == "first"
                 assert await ws2.recv() == "second"
 
-    bigfoot.async_websocket_mock.assert_connect(uri="ws://localhost:8765")
-    bigfoot.async_websocket_mock.assert_connect(uri="ws://localhost:8765")
-    bigfoot.async_websocket_mock.assert_recv(message="first")
-    bigfoot.async_websocket_mock.assert_recv(message="second")
-    bigfoot.async_websocket_mock.assert_close()
-    bigfoot.async_websocket_mock.assert_close()
+    bigfoot.async_websocket.assert_connect(uri="ws://localhost:8765")
+    bigfoot.async_websocket.assert_connect(uri="ws://localhost:8765")
+    bigfoot.async_websocket.assert_recv(message="first")
+    bigfoot.async_websocket.assert_recv(message="second")
+    bigfoot.async_websocket.assert_close()
+    bigfoot.async_websocket.assert_close()
 ```
 
 ### Assertion helpers
@@ -120,19 +120,19 @@ async def test_two_ws_connections():
 #### `assert_connect(*, uri)`
 
 ```python
-bigfoot.async_websocket_mock.assert_connect(uri="ws://localhost:8765")
+bigfoot.async_websocket.assert_connect(uri="ws://localhost:8765")
 ```
 
 #### `assert_send(*, message)`
 
 ```python
-bigfoot.async_websocket_mock.assert_send(message="hello")
+bigfoot.async_websocket.assert_send(message="hello")
 ```
 
 #### `assert_recv(*, message)`
 
 ```python
-bigfoot.async_websocket_mock.assert_recv(message="world")
+bigfoot.async_websocket.assert_recv(message="world")
 ```
 
 #### `assert_close()`
@@ -140,14 +140,14 @@ bigfoot.async_websocket_mock.assert_recv(message="world")
 No fields are required.
 
 ```python
-bigfoot.async_websocket_mock.assert_close()
+bigfoot.async_websocket.assert_close()
 ```
 
 ---
 
 ## SyncWebSocketPlugin
 
-**Proxy:** `bigfoot.sync_websocket_mock`
+**Proxy:** `bigfoot.sync_websocket`
 
 ### Setup
 
@@ -155,7 +155,7 @@ bigfoot.async_websocket_mock.assert_close()
 import bigfoot
 
 def test_sync_ws():
-    (bigfoot.sync_websocket_mock
+    (bigfoot.sync_websocket
         .new_session()
         .expect("connect", returns=None)
         .expect("send",    returns=None)
@@ -171,10 +171,10 @@ def test_sync_ws():
 
     assert message == "hello"
 
-    bigfoot.sync_websocket_mock.assert_connect(uri="ws://localhost:8765")
-    bigfoot.sync_websocket_mock.assert_send(message="hi")
-    bigfoot.sync_websocket_mock.assert_recv(message="hello")
-    bigfoot.sync_websocket_mock.assert_close()
+    bigfoot.sync_websocket.assert_connect(uri="ws://localhost:8765")
+    bigfoot.sync_websocket.assert_send(message="hi")
+    bigfoot.sync_websocket.assert_recv(message="hello")
+    bigfoot.sync_websocket.assert_close()
 ```
 
 For manual use outside pytest:
@@ -196,19 +196,19 @@ The `connect` step executes immediately inside `create_connection()` before the 
 #### `assert_connect(*, uri)`
 
 ```python
-bigfoot.sync_websocket_mock.assert_connect(uri="ws://localhost:8765")
+bigfoot.sync_websocket.assert_connect(uri="ws://localhost:8765")
 ```
 
 #### `assert_send(*, message)`
 
 ```python
-bigfoot.sync_websocket_mock.assert_send(message="hello")
+bigfoot.sync_websocket.assert_send(message="hello")
 ```
 
 #### `assert_recv(*, message)`
 
 ```python
-bigfoot.sync_websocket_mock.assert_recv(message="world")
+bigfoot.sync_websocket.assert_recv(message="world")
 ```
 
 #### `assert_close()`
@@ -216,7 +216,7 @@ bigfoot.sync_websocket_mock.assert_recv(message="world")
 No fields are required.
 
 ```python
-bigfoot.sync_websocket_mock.assert_close()
+bigfoot.sync_websocket.assert_close()
 ```
 
 ---

--- a/docs/guides/writing-plugins.md
+++ b/docs/guides/writing-plugins.md
@@ -415,7 +415,7 @@ def _unmocked_source_id(self) -> str:
 Before the sandbox runs, register one session per expected connection:
 
 ```python
-handle = bigfoot.socket_mock.new_session()
+handle = bigfoot.socket.new_session()
 handle.expect("connect", returns=None)
 handle.expect("recv",    returns=b"pong")
 handle.expect("close",   returns=None)
@@ -424,7 +424,7 @@ handle.expect("close",   returns=None)
 `new_session()` returns a `SessionHandle`. `expect()` appends one `ScriptStep` to the handle's FIFO script and returns the handle, so calls chain naturally:
 
 ```python
-(bigfoot.socket_mock
+(bigfoot.socket
     .new_session()
     .expect("connect", returns=None)
     .expect("send",    returns=4)
@@ -507,14 +507,14 @@ class FtpPlugin(StateMachinePlugin):
 
     def format_mock_hint(self, interaction: Interaction) -> str:
         method = interaction.details.get("method", "?")
-        return f"    bigfoot.ftp_mock.new_session().expect({method!r}, returns=...)"
+        return f"    bigfoot.ftp.new_session().expect({method!r}, returns=...)"
 
     def format_unmocked_hint(self, source_id: str, args: tuple, kwargs: dict) -> str:
         method = source_id.split(":")[-1] if ":" in source_id else source_id
         return (
             f"ftp.{method}(...) was called but no session was queued.\n"
             f"Register a session with:\n"
-            f"    bigfoot.ftp_mock.new_session().expect({method!r}, returns=...)"
+            f"    bigfoot.ftp.new_session().expect({method!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -12,7 +12,7 @@ All public symbols are importable from `bigfoot` directly. `HttpPlugin` requires
 | `MockPlugin` | class | Intercepts method calls on named proxy objects. Created automatically by `verifier.mock()`. |
 | `HttpPlugin` | class | Intercepts `httpx`, `requests`, and `urllib` HTTP calls. Requires `bigfoot[http]`. Import from `bigfoot.plugins.http`. |
 | `SubprocessPlugin` | class | Intercepts `subprocess.run` and `shutil.which`. Included in core bigfoot. Import from `bigfoot.plugins.subprocess`. |
-| `subprocess_mock` | proxy | Module-level proxy to `SubprocessPlugin` for the current test. Auto-creates the plugin on first access. |
+| `subprocess` | proxy | Module-level proxy to `SubprocessPlugin` for the current test. Auto-creates the plugin on first access. |
 | `BigfootError` | exception | Base class for all bigfoot exceptions. |
 | `UnmockedInteractionError` | exception | Raised at call time when an intercepted call has no matching mock. |
 | `UnassertedInteractionsError` | exception | Raised at teardown when interactions were recorded but never asserted. |
@@ -32,8 +32,8 @@ These types appear in error messages, docstrings, and plugin implementations but
 | `MethodProxy` | `bigfoot._mock_plugin` | Per-method interceptor with `.returns()`, `.raises()`, `.calls()`, `.required()`. |
 | `MockConfig` | `bigfoot._mock_plugin` | Internal record of one configured side effect. |
 | `HttpRequestSentinel` | `bigfoot.plugins.http` | Opaque object returned by `http.request`. Used as source in `assert_interaction()`. |
-| `SubprocessRunSentinel` | `bigfoot.plugins.subprocess` | Opaque handle returned by `subprocess_mock.run`. Used as source in `assert_interaction()`. |
-| `SubprocessWhichSentinel` | `bigfoot.plugins.subprocess` | Opaque handle returned by `subprocess_mock.which`. Used as source in `assert_interaction()`. |
+| `SubprocessRunSentinel` | `bigfoot.plugins.subprocess` | Opaque handle returned by `subprocess.run`. Used as source in `assert_interaction()`. |
+| `SubprocessWhichSentinel` | `bigfoot.plugins.subprocess` | Opaque handle returned by `subprocess.which`. Used as source in `assert_interaction()`. |
 | `RunMockConfig` | `bigfoot.plugins.subprocess` | Internal record of a registered `mock_run` configuration. |
 | `WhichMockConfig` | `bigfoot.plugins.subprocess` | Internal record of a registered `mock_which` configuration. |
 | `HttpMockConfig` | `bigfoot.plugins.http` | Internal record of a registered mock response. |

--- a/examples/async_api/test_app.py
+++ b/examples/async_api/test_app.py
@@ -17,7 +17,7 @@ async def test_sync_user_data_fetches_and_stores():
     )
 
     # Script the asyncpg session
-    bigfoot.asyncpg_mock.new_session() \
+    bigfoot.asyncpg.new_session() \
         .expect("connect", returns=None) \
         .expect("execute", returns="INSERT 0 1") \
         .expect("fetchrow", returns={"id": 1, "name": "Alice", "email": "alice@example.com"}) \
@@ -43,16 +43,16 @@ async def test_sync_user_data_fetches_and_stores():
     )
 
     # Assert the log message
-    bigfoot.log_mock.assert_info("Fetched user 1 from API", "sync_api")
+    bigfoot.log.assert_info("Fetched user 1 from API", "sync_api")
 
     # Assert the database interactions
-    bigfoot.asyncpg_mock.assert_connect(dsn="postgresql://localhost/app")
-    bigfoot.asyncpg_mock.assert_execute(
+    bigfoot.asyncpg.assert_connect(dsn="postgresql://localhost/app")
+    bigfoot.asyncpg.assert_execute(
         query="INSERT INTO users (id, name, email) VALUES ($1, $2, $3)",
         args=[1, "Alice", "alice@example.com"],
     )
-    bigfoot.asyncpg_mock.assert_fetchrow(
+    bigfoot.asyncpg.assert_fetchrow(
         query="SELECT * FROM users WHERE id = $1",
         args=[1],
     )
-    bigfoot.asyncpg_mock.assert_close()
+    bigfoot.asyncpg.assert_close()

--- a/examples/async_subprocess_example/test_app.py
+++ b/examples/async_subprocess_example/test_app.py
@@ -1,4 +1,4 @@
-"""Test run_linter using bigfoot async_subprocess_mock."""
+"""Test run_linter using bigfoot async_subprocess."""
 
 import bigfoot
 
@@ -6,7 +6,7 @@ from .app import run_linter
 
 
 async def test_linter_clean():
-    (bigfoot.async_subprocess_mock
+    (bigfoot.async_subprocess
         .new_session()
         .expect("spawn",       returns=None)
         .expect("communicate", returns=(b"All checks passed.\n", b"", 0)))
@@ -17,7 +17,7 @@ async def test_linter_clean():
     assert rc == 0
     assert output == "All checks passed.\n"
 
-    bigfoot.async_subprocess_mock.assert_spawn(
+    bigfoot.async_subprocess.assert_spawn(
         command=["ruff", "check", "src/"], stdin=None
     )
-    bigfoot.async_subprocess_mock.assert_communicate(input=None)
+    bigfoot.async_subprocess.assert_communicate(input=None)

--- a/examples/asyncpg_example/test_app.py
+++ b/examples/asyncpg_example/test_app.py
@@ -1,4 +1,4 @@
-"""Test get_user_count using bigfoot asyncpg_mock."""
+"""Test get_user_count using bigfoot asyncpg."""
 
 import bigfoot
 
@@ -6,7 +6,7 @@ from .app import get_user_count
 
 
 async def test_get_user_count():
-    (bigfoot.asyncpg_mock
+    (bigfoot.asyncpg
         .new_session()
         .expect("connect",  returns=None)
         .expect("fetchval", returns=42)
@@ -17,6 +17,6 @@ async def test_get_user_count():
 
     assert result == 42
 
-    bigfoot.asyncpg_mock.assert_connect(host="localhost", database="app", user="app")
-    bigfoot.asyncpg_mock.assert_fetchval(query="SELECT count(*) FROM users", args=[])
-    bigfoot.asyncpg_mock.assert_close()
+    bigfoot.asyncpg.assert_connect(host="localhost", database="app", user="app")
+    bigfoot.asyncpg.assert_fetchval(query="SELECT count(*) FROM users", args=[])
+    bigfoot.asyncpg.assert_close()

--- a/examples/boto3_service/test_app.py
+++ b/examples/boto3_service/test_app.py
@@ -1,4 +1,4 @@
-"""Test boto3 S3 upload with SQS notification using bigfoot boto3_mock."""
+"""Test boto3 S3 upload with SQS notification using bigfoot boto3."""
 
 import logging
 
@@ -17,8 +17,8 @@ def _silence_botocore():
 
 
 def test_upload_and_notify():
-    bigfoot.boto3_mock.mock_call("s3", "PutObject", returns={})
-    bigfoot.boto3_mock.mock_call("sqs", "SendMessage", returns={"MessageId": "msg-001"})
+    bigfoot.boto3.mock_call("s3", "PutObject", returns={})
+    bigfoot.boto3.mock_call("sqs", "SendMessage", returns={"MessageId": "msg-001"})
 
     with bigfoot:
         upload_and_notify(
@@ -26,11 +26,11 @@ def test_upload_and_notify():
             "https://sqs.us-east-1.amazonaws.com/123/notifications",
         )
 
-    bigfoot.boto3_mock.assert_boto3_call(
+    bigfoot.boto3.assert_boto3_call(
         service="s3", operation="PutObject",
         params={"Bucket": "data-bucket", "Key": "reports/q1.csv", "Body": b"revenue,100"},
     )
-    bigfoot.boto3_mock.assert_boto3_call(
+    bigfoot.boto3.assert_boto3_call(
         service="sqs", operation="SendMessage",
         params={
             "QueueUrl": "https://sqs.us-east-1.amazonaws.com/123/notifications",

--- a/examples/celery_tasks/test_app.py
+++ b/examples/celery_tasks/test_app.py
@@ -1,4 +1,4 @@
-"""Test Celery task dispatch using bigfoot celery_mock."""
+"""Test Celery task dispatch using bigfoot celery."""
 
 import logging
 
@@ -17,26 +17,26 @@ def _silence_celery():
 
 
 def test_enqueue_order_pipeline():
-    bigfoot.celery_mock.mock_delay("example.validate_order", returns=None)
-    bigfoot.celery_mock.mock_apply_async("example.charge_payment", returns=None)
-    bigfoot.celery_mock.mock_delay("example.send_confirmation", returns=None)
+    bigfoot.celery.mock_delay("example.validate_order", returns=None)
+    bigfoot.celery.mock_apply_async("example.charge_payment", returns=None)
+    bigfoot.celery.mock_delay("example.send_confirmation", returns=None)
 
     with bigfoot:
         enqueue_order_pipeline("order-42", "buyer@example.com")
 
-    bigfoot.celery_mock.assert_delay(
+    bigfoot.celery.assert_delay(
         task_name="example.validate_order",
         args=("order-42",),
         kwargs={},
         options={},
     )
-    bigfoot.celery_mock.assert_apply_async(
+    bigfoot.celery.assert_apply_async(
         task_name="example.charge_payment",
         args=("order-42",),
         kwargs={"currency": "USD"},
         options={"countdown": 5},
     )
-    bigfoot.celery_mock.assert_delay(
+    bigfoot.celery.assert_delay(
         task_name="example.send_confirmation",
         args=("buyer@example.com", "order-42"),
         kwargs={},

--- a/examples/cli_tool/README.md
+++ b/examples/cli_tool/README.md
@@ -5,7 +5,7 @@ and `shutil.which`.
 
 The application module (`app.py`) locates `gcc`, compiles a source file,
 and runs the resulting binary. The test (`test_app.py`) uses
-`bigfoot.subprocess_mock` to intercept both `which` and `run` calls,
+`bigfoot.subprocess` to intercept both `which` and `run` calls,
 verifying the exact commands and their ordering.
 
 Run: `python -m pytest examples/cli_tool/ -v`

--- a/examples/cli_tool/test_app.py
+++ b/examples/cli_tool/test_app.py
@@ -6,11 +6,11 @@ from .app import build_and_run
 
 
 def test_build_and_run_compiles_and_executes():
-    bigfoot.subprocess_mock.mock_which("gcc", returns="/usr/bin/gcc")
-    bigfoot.subprocess_mock.mock_run(
+    bigfoot.subprocess.mock_which("gcc", returns="/usr/bin/gcc")
+    bigfoot.subprocess.mock_run(
         ["/usr/bin/gcc", "-o", "/tmp/out", "hello.c"], returncode=0
     )
-    bigfoot.subprocess_mock.mock_run(
+    bigfoot.subprocess.mock_run(
         ["/tmp/out"], returncode=0, stdout="Hello, world!\n"
     )
 
@@ -20,17 +20,17 @@ def test_build_and_run_compiles_and_executes():
     assert output == "Hello, world!\n"
 
     bigfoot.assert_interaction(
-        bigfoot.subprocess_mock.which, name="gcc", returns="/usr/bin/gcc"
+        bigfoot.subprocess.which, name="gcc", returns="/usr/bin/gcc"
     )
     bigfoot.assert_interaction(
-        bigfoot.subprocess_mock.run,
+        bigfoot.subprocess.run,
         command=["/usr/bin/gcc", "-o", "/tmp/out", "hello.c"],
         returncode=0,
         stdout="",
         stderr="",
     )
     bigfoot.assert_interaction(
-        bigfoot.subprocess_mock.run,
+        bigfoot.subprocess.run,
         command=["/tmp/out"],
         returncode=0,
         stdout="Hello, world!\n",
@@ -39,7 +39,7 @@ def test_build_and_run_compiles_and_executes():
 
 
 def test_build_and_run_raises_when_gcc_missing():
-    bigfoot.subprocess_mock.mock_which("gcc", returns=None)
+    bigfoot.subprocess.mock_which("gcc", returns=None)
 
     with bigfoot:
         try:
@@ -50,5 +50,5 @@ def test_build_and_run_raises_when_gcc_missing():
             raise AssertionError("Expected RuntimeError")
 
     bigfoot.assert_interaction(
-        bigfoot.subprocess_mock.which, name="gcc", returns=None
+        bigfoot.subprocess.which, name="gcc", returns=None
     )

--- a/examples/crypto_sign/test_app.py
+++ b/examples/crypto_sign/test_app.py
@@ -1,4 +1,4 @@
-"""Test PII encryption and decryption using bigfoot crypto_mock."""
+"""Test PII encryption and decryption using bigfoot crypto."""
 
 from cryptography.fernet import Fernet
 
@@ -11,22 +11,22 @@ TEST_KEY = Fernet.generate_key()
 
 
 def test_encrypt_pii():
-    bigfoot.crypto_mock.mock_encrypt(returns=b"gAAAAABencrypted_ssn")
+    bigfoot.crypto.mock_encrypt(returns=b"gAAAAABencrypted_ssn")
 
     with bigfoot:
         ciphertext = encrypt_pii_field(TEST_KEY, "123-45-6789")
 
     assert ciphertext == b"gAAAAABencrypted_ssn"
 
-    bigfoot.crypto_mock.assert_encrypt(plaintext_length=11)
+    bigfoot.crypto.assert_encrypt(plaintext_length=11)
 
 
 def test_decrypt_pii():
-    bigfoot.crypto_mock.mock_decrypt(returns=b"123-45-6789")
+    bigfoot.crypto.mock_decrypt(returns=b"123-45-6789")
 
     with bigfoot:
         plaintext = decrypt_pii_field(TEST_KEY, b"gAAAAABencrypted_ssn")
 
     assert plaintext == "123-45-6789"
 
-    bigfoot.crypto_mock.assert_decrypt(token=b"gAAAAABencrypted_ssn", ttl=None)
+    bigfoot.crypto.assert_decrypt(token=b"gAAAAABencrypted_ssn", ttl=None)

--- a/examples/database_example/test_app.py
+++ b/examples/database_example/test_app.py
@@ -1,4 +1,4 @@
-"""Test save_user using bigfoot db_mock."""
+"""Test save_user using bigfoot db."""
 
 import bigfoot
 
@@ -6,7 +6,7 @@ from .app import save_user
 
 
 def test_save_user():
-    (bigfoot.db_mock
+    (bigfoot.db
         .new_session()
         .expect("connect",  returns=None)
         .expect("execute",  returns=[])
@@ -16,10 +16,10 @@ def test_save_user():
     with bigfoot:
         save_user("Alice", "alice@example.com")
 
-    bigfoot.db_mock.assert_connect(database="app.db")
-    bigfoot.db_mock.assert_execute(
+    bigfoot.db.assert_connect(database="app.db")
+    bigfoot.db.assert_execute(
         sql="INSERT INTO users (name, email) VALUES (?, ?)",
         parameters=("Alice", "alice@example.com"),
     )
-    bigfoot.db_mock.assert_commit()
-    bigfoot.db_mock.assert_close()
+    bigfoot.db.assert_commit()
+    bigfoot.db.assert_close()

--- a/examples/dns_lookup/test_app.py
+++ b/examples/dns_lookup/test_app.py
@@ -1,4 +1,4 @@
-"""Test DNS service resolution using bigfoot dns_mock."""
+"""Test DNS service resolution using bigfoot dns."""
 
 import socket
 
@@ -8,7 +8,7 @@ from .app import resolve_service_endpoint
 
 
 def test_resolve_service_endpoint():
-    bigfoot.dns_mock.mock_getaddrinfo(
+    bigfoot.dns.mock_getaddrinfo(
         "payments.internal",
         returns=[
             (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.2.15", 443)),
@@ -20,7 +20,7 @@ def test_resolve_service_endpoint():
 
     assert addr == ("10.0.2.15", 443)
 
-    bigfoot.dns_mock.assert_getaddrinfo(
+    bigfoot.dns.assert_getaddrinfo(
         host="payments.internal",
         port=443,
         family=socket.AF_INET,

--- a/examples/elasticsearch_search/test_app.py
+++ b/examples/elasticsearch_search/test_app.py
@@ -1,4 +1,4 @@
-"""Test Elasticsearch error log search using bigfoot elasticsearch_mock."""
+"""Test Elasticsearch error log search using bigfoot elasticsearch."""
 
 import bigfoot
 
@@ -6,7 +6,7 @@ from .app import search_error_logs
 
 
 def test_search_error_logs():
-    bigfoot.elasticsearch_mock.mock_operation(
+    bigfoot.elasticsearch.mock_operation(
         "search",
         returns={
             "hits": {
@@ -28,7 +28,7 @@ def test_search_error_logs():
     assert logs[0]["message"] == "timeout"
     assert logs[1]["message"] == "connection refused"
 
-    bigfoot.elasticsearch_mock.assert_search(
+    bigfoot.elasticsearch.assert_search(
         index="app-logs",
         query={
             "bool": {

--- a/examples/email_service/README.md
+++ b/examples/email_service/README.md
@@ -5,6 +5,6 @@ Demonstrates bigfoot's SMTP plugin with full state machine assertions.
 The application module (`app.py`) sends a welcome email through an SMTP
 server using `smtplib`. The test (`test_app.py`) scripts an entire SMTP
 session (connect, ehlo, starttls, login, send_message, quit) and verifies
-each step with `bigfoot.smtp_mock` assertion helpers.
+each step with `bigfoot.smtp` assertion helpers.
 
 Run: `python -m pytest examples/email_service/ -v`

--- a/examples/email_service/test_app.py
+++ b/examples/email_service/test_app.py
@@ -10,7 +10,7 @@ from .app import send_welcome_email
 
 
 def test_send_welcome_email_full_smtp_session():
-    bigfoot.smtp_mock.new_session() \
+    bigfoot.smtp.new_session() \
         .expect("connect", returns=(220, b"OK")) \
         .expect("ehlo", returns=(250, b"OK")) \
         .expect("starttls", returns=(220, b"Ready")) \
@@ -21,9 +21,9 @@ def test_send_welcome_email_full_smtp_session():
     with bigfoot:
         send_welcome_email("alice@example.com", "Alice")
 
-    bigfoot.smtp_mock.assert_connect(host="smtp.example.com", port=587)
-    bigfoot.smtp_mock.assert_ehlo(name="example.com")
-    bigfoot.smtp_mock.assert_starttls()
-    bigfoot.smtp_mock.assert_login(user="noreply@example.com", password="secret")
-    bigfoot.smtp_mock.assert_send_message(msg=IsInstance(EmailMessage))
-    bigfoot.smtp_mock.assert_quit()
+    bigfoot.smtp.assert_connect(host="smtp.example.com", port=587)
+    bigfoot.smtp.assert_ehlo(name="example.com")
+    bigfoot.smtp.assert_starttls()
+    bigfoot.smtp.assert_login(user="noreply@example.com", password="secret")
+    bigfoot.smtp.assert_send_message(msg=IsInstance(EmailMessage))
+    bigfoot.smtp.assert_quit()

--- a/examples/file_processor/test_app.py
+++ b/examples/file_processor/test_app.py
@@ -1,4 +1,4 @@
-"""Test file archival using bigfoot file_io_mock."""
+"""Test file archival using bigfoot file_io."""
 
 import bigfoot
 
@@ -6,23 +6,23 @@ from .app import archive_and_clean
 
 
 def test_archive_and_clean():
-    bigfoot.file_io_mock.mock_operation("makedirs", "/backups/2024", returns=None)
-    bigfoot.file_io_mock.mock_operation("copytree", "/var/data/reports", returns=None)
-    bigfoot.file_io_mock.mock_operation(
+    bigfoot.file_io.mock_operation("makedirs", "/backups/2024", returns=None)
+    bigfoot.file_io.mock_operation("copytree", "/var/data/reports", returns=None)
+    bigfoot.file_io.mock_operation(
         "write_text", "/var/log/manifest.txt", returns=None,
     )
-    bigfoot.file_io_mock.mock_operation("rmtree", "/var/data/reports", returns=None)
+    bigfoot.file_io.mock_operation("rmtree", "/var/data/reports", returns=None)
 
     with bigfoot:
         archive_and_clean(
             "/var/data/reports", "/backups/2024", "/var/log/manifest.txt",
         )
 
-    bigfoot.file_io_mock.assert_makedirs(path="/backups/2024", exist_ok=True)
-    bigfoot.file_io_mock.assert_copytree(
+    bigfoot.file_io.assert_makedirs(path="/backups/2024", exist_ok=True)
+    bigfoot.file_io.assert_copytree(
         src="/var/data/reports", dst="/backups/2024/latest",
     )
-    bigfoot.file_io_mock.assert_write_text(
+    bigfoot.file_io.assert_write_text(
         path="/var/log/manifest.txt", data="archived: /var/data/reports",
     )
-    bigfoot.file_io_mock.assert_rmtree(path="/var/data/reports")
+    bigfoot.file_io.assert_rmtree(path="/var/data/reports")

--- a/examples/flask_api/README.md
+++ b/examples/flask_api/README.md
@@ -4,6 +4,6 @@ Demonstrates bigfoot's HTTP and logging plugins together.
 
 The application module (`app.py`) makes an HTTP POST to a payment provider
 and logs the result. The test (`test_app.py`) uses `bigfoot.http` to mock
-the outbound HTTP call and `bigfoot.log_mock` to verify the log message.
+the outbound HTTP call and `bigfoot.log` to verify the log message.
 
 Run: `python -m pytest examples/flask_api/ -v`

--- a/examples/flask_api/test_app.py
+++ b/examples/flask_api/test_app.py
@@ -30,10 +30,10 @@ def test_create_charge_posts_to_stripe_and_logs():
         headers=IsInstance(dict),
         body='{"id": "ch_test_123", "amount": 5000, "currency": "usd"}',
     )
-    bigfoot.log_mock.assert_info(
+    bigfoot.log.assert_info(
         'HTTP Request: POST https://api.stripe.com/v1/charges "HTTP/1.1 200 OK"',
         "httpx",
     )
-    bigfoot.log_mock.assert_info(
+    bigfoot.log.assert_info(
         "Charge created: ch_test_123 for 5000 usd", "payments"
     )

--- a/examples/grpc_service/test_app.py
+++ b/examples/grpc_service/test_app.py
@@ -1,4 +1,4 @@
-"""Test gRPC service calls using bigfoot grpc_mock."""
+"""Test gRPC service calls using bigfoot grpc."""
 
 import bigfoot
 
@@ -6,11 +6,11 @@ from .app import fetch_user_orders
 
 
 def test_fetch_user_orders():
-    bigfoot.grpc_mock.mock_unary_unary(
+    bigfoot.grpc.mock_unary_unary(
         "/commerce.UserService/GetUser",
         returns={"id": 7, "name": "Alice", "email": "alice@example.com"},
     )
-    bigfoot.grpc_mock.mock_unary_stream(
+    bigfoot.grpc.mock_unary_stream(
         "/commerce.OrderService/ListOrders",
         returns=[
             {"order_id": "A1", "total": 29.99},
@@ -25,9 +25,9 @@ def test_fetch_user_orders():
     assert len(orders) == 2
     assert orders[0]["order_id"] == "A1"
 
-    bigfoot.grpc_mock.assert_unary_unary(
+    bigfoot.grpc.assert_unary_unary(
         "/commerce.UserService/GetUser", request={"id": 7},
     )
-    bigfoot.grpc_mock.assert_unary_stream(
+    bigfoot.grpc.assert_unary_stream(
         "/commerce.OrderService/ListOrders", request={"user_id": 7},
     )

--- a/examples/jwt_auth/test_app.py
+++ b/examples/jwt_auth/test_app.py
@@ -1,4 +1,4 @@
-"""Test JWT token issuance and verification using bigfoot jwt_mock."""
+"""Test JWT token issuance and verification using bigfoot jwt."""
 
 import bigfoot
 
@@ -6,8 +6,8 @@ from .app import issue_access_token, verify_access_token
 
 
 def test_issue_and_verify_token():
-    bigfoot.jwt_mock.mock_encode(returns="signed.access.token")
-    bigfoot.jwt_mock.mock_decode(returns={"sub": "user_42", "role": "editor", "iat": 1700000000})
+    bigfoot.jwt.mock_encode(returns="signed.access.token")
+    bigfoot.jwt.mock_decode(returns={"sub": "user_42", "role": "editor", "iat": 1700000000})
 
     with bigfoot:
         token = issue_access_token("user_42", "editor", "my-secret")
@@ -17,12 +17,12 @@ def test_issue_and_verify_token():
     assert claims["sub"] == "user_42"
     assert claims["role"] == "editor"
 
-    bigfoot.jwt_mock.assert_encode(
+    bigfoot.jwt.assert_encode(
         payload={"sub": "user_42", "role": "editor", "iat": 1700000000},
         algorithm="HS256",
         extra_kwargs={},
     )
-    bigfoot.jwt_mock.assert_decode(
+    bigfoot.jwt.assert_decode(
         token="signed.access.token",
         algorithms=["HS256"],
         options=None,

--- a/examples/logging_example/test_app.py
+++ b/examples/logging_example/test_app.py
@@ -1,4 +1,4 @@
-"""Test process_order using bigfoot log_mock."""
+"""Test process_order using bigfoot log."""
 
 import bigfoot
 
@@ -11,6 +11,6 @@ def test_process_order():
 
     assert result == "success"
 
-    bigfoot.log_mock.assert_info("Processing order 42", "orders")
-    bigfoot.log_mock.assert_debug("Validating payment for order 42", "orders")
-    bigfoot.log_mock.assert_info("Order 42 completed", "orders")
+    bigfoot.log.assert_info("Processing order 42", "orders")
+    bigfoot.log.assert_debug("Validating payment for order 42", "orders")
+    bigfoot.log.assert_info("Order 42 completed", "orders")

--- a/examples/mcp_tool/test_app.py
+++ b/examples/mcp_tool/test_app.py
@@ -1,4 +1,4 @@
-"""Test MCP tool call using bigfoot mcp_mock."""
+"""Test MCP tool call using bigfoot mcp."""
 
 import pytest
 
@@ -11,7 +11,7 @@ from .app import fetch_weather
 async def test_fetch_weather():
     from mcp.client.session import ClientSession
 
-    bigfoot.mcp_mock.mock_call_tool(
+    bigfoot.mcp.mock_call_tool(
         "get_weather",
         returns={"content": [{"type": "text", "text": "Sunny, 72F"}]},
     )
@@ -22,7 +22,7 @@ async def test_fetch_weather():
 
     assert result == {"content": [{"type": "text", "text": "Sunny, 72F"}]}
 
-    bigfoot.mcp_mock.assert_call_tool(
+    bigfoot.mcp.assert_call_tool(
         "get_weather",
         arguments={"city": "San Francisco"},
         direction="client",

--- a/examples/memcache_session/test_app.py
+++ b/examples/memcache_session/test_app.py
@@ -1,4 +1,4 @@
-"""Test memcache user profile caching using bigfoot memcache_mock."""
+"""Test memcache user profile caching using bigfoot memcache."""
 
 import bigfoot
 
@@ -6,7 +6,7 @@ from .app import cache_user_profile, get_user_profile
 
 
 def test_cache_hit():
-    bigfoot.memcache_mock.mock_command("GET", returns=b'{"name": "Alice"}')
+    bigfoot.memcache.mock_command("GET", returns=b'{"name": "Alice"}')
 
     with bigfoot:
         from pymemcache.client.base import Client
@@ -15,18 +15,18 @@ def test_cache_hit():
 
     assert result == '{"name": "Alice"}'
 
-    bigfoot.memcache_mock.assert_get(command="GET", key="profile:42")
+    bigfoot.memcache.assert_get(command="GET", key="profile:42")
 
 
 def test_cache_write():
-    bigfoot.memcache_mock.mock_command("SET", returns=True)
+    bigfoot.memcache.mock_command("SET", returns=True)
 
     with bigfoot:
         from pymemcache.client.base import Client
         client = Client(("localhost", 11211))
         cache_user_profile(client, "42", '{"name": "Alice"}', ttl=600)
 
-    bigfoot.memcache_mock.assert_set(
+    bigfoot.memcache.assert_set(
         command="SET",
         key="profile:42",
         value=b'{"name": "Alice"}',

--- a/examples/mongo_store/test_app.py
+++ b/examples/mongo_store/test_app.py
@@ -1,4 +1,4 @@
-"""Test MongoDB order creation using bigfoot mongo_mock."""
+"""Test MongoDB order creation using bigfoot mongo."""
 
 import logging
 
@@ -19,9 +19,9 @@ def _silence_pymongo():
 
 def test_create_order():
     mock_result = type("InsertOneResult", (), {"inserted_id": "order_789"})()
-    bigfoot.mongo_mock.mock_operation("insert_one", returns=mock_result)
+    bigfoot.mongo.mock_operation("insert_one", returns=mock_result)
     update_result = type("UpdateResult", (), {"modified_count": 1})()
-    bigfoot.mongo_mock.mock_operation("update_one", returns=update_result)
+    bigfoot.mongo.mock_operation("update_one", returns=update_result)
 
     with bigfoot:
         client = pymongo.MongoClient("mongodb://localhost:27017")
@@ -29,7 +29,7 @@ def test_create_order():
 
     assert order_id == "order_789"
 
-    bigfoot.mongo_mock.assert_insert_one(
+    bigfoot.mongo.assert_insert_one(
         database="shopdb",
         collection="orders",
         document={
@@ -38,7 +38,7 @@ def test_create_order():
             "status": "pending",
         },
     )
-    bigfoot.mongo_mock.assert_update_one(
+    bigfoot.mongo.assert_update_one(
         database="shopdb",
         collection="customers",
         filter={"_id": "cust_123"},

--- a/examples/native_lib/test_app.py
+++ b/examples/native_lib/test_app.py
@@ -1,4 +1,4 @@
-"""Test native library calls using bigfoot native_mock."""
+"""Test native library calls using bigfoot native."""
 
 import bigfoot
 
@@ -6,13 +6,13 @@ from .app import compute_distance
 
 
 def test_compute_distance():
-    bigfoot.native_mock.mock_call("libm", "sqrt", returns=5.0)
+    bigfoot.native.mock_call("libm", "sqrt", returns=5.0)
 
     with bigfoot:
         result = compute_distance(0.0, 0.0, 3.0, 4.0)
 
     assert result == 5.0
 
-    bigfoot.native_mock.assert_call(
+    bigfoot.native.assert_call(
         library="libm", function="sqrt", args=(25.0,),
     )

--- a/examples/pika_queue/test_app.py
+++ b/examples/pika_queue/test_app.py
@@ -1,4 +1,4 @@
-"""Test RabbitMQ publishing using bigfoot pika_mock."""
+"""Test RabbitMQ publishing using bigfoot pika."""
 
 import bigfoot
 
@@ -6,7 +6,7 @@ from .app import publish_event
 
 
 def test_publish_event():
-    (bigfoot.pika_mock
+    (bigfoot.pika
         .new_session()
         .expect("connect",  returns=None)
         .expect("channel",  returns=None)
@@ -16,12 +16,12 @@ def test_publish_event():
     with bigfoot:
         publish_event("mq.internal", "events", "order.created", b'{"order_id": 42}')
 
-    bigfoot.pika_mock.assert_connect(host="mq.internal", port=5672, virtual_host="/")
-    bigfoot.pika_mock.assert_channel()
-    bigfoot.pika_mock.assert_publish(
+    bigfoot.pika.assert_connect(host="mq.internal", port=5672, virtual_host="/")
+    bigfoot.pika.assert_channel()
+    bigfoot.pika.assert_publish(
         exchange="events",
         routing_key="order.created",
         body=b'{"order_id": 42}',
         properties=None,
     )
-    bigfoot.pika_mock.assert_close()
+    bigfoot.pika.assert_close()

--- a/examples/popen_example/test_app.py
+++ b/examples/popen_example/test_app.py
@@ -1,4 +1,4 @@
-"""Test run_linter using bigfoot popen_mock."""
+"""Test run_linter using bigfoot popen."""
 
 import bigfoot
 
@@ -6,7 +6,7 @@ from .app import run_linter
 
 
 def test_linter_clean():
-    (bigfoot.popen_mock
+    (bigfoot.popen
         .new_session()
         .expect("spawn",       returns=None)
         .expect("communicate", returns=(b"All checks passed.\n", b"", 0)))
@@ -17,5 +17,5 @@ def test_linter_clean():
     assert rc == 0
     assert output == "All checks passed.\n"
 
-    bigfoot.popen_mock.assert_spawn(command=["ruff", "check", "src/"], stdin=None)
-    bigfoot.popen_mock.assert_communicate(input=None)
+    bigfoot.popen.assert_spawn(command=["ruff", "check", "src/"], stdin=None)
+    bigfoot.popen.assert_communicate(input=None)

--- a/examples/psycopg2_example/test_app.py
+++ b/examples/psycopg2_example/test_app.py
@@ -1,4 +1,4 @@
-"""Test save_user using bigfoot psycopg2_mock."""
+"""Test save_user using bigfoot psycopg2."""
 
 import bigfoot
 
@@ -6,7 +6,7 @@ from .app import save_user
 
 
 def test_save_user():
-    (bigfoot.psycopg2_mock
+    (bigfoot.psycopg2
         .new_session()
         .expect("connect",  returns=None)
         .expect("execute",  returns=[])
@@ -16,10 +16,10 @@ def test_save_user():
     with bigfoot:
         save_user("Alice", "alice@example.com")
 
-    bigfoot.psycopg2_mock.assert_connect(host="localhost", dbname="app", user="app")
-    bigfoot.psycopg2_mock.assert_execute(
+    bigfoot.psycopg2.assert_connect(host="localhost", dbname="app", user="app")
+    bigfoot.psycopg2.assert_execute(
         sql="INSERT INTO users (name, email) VALUES (%s, %s)",
         parameters=("Alice", "alice@example.com"),
     )
-    bigfoot.psycopg2_mock.assert_commit()
-    bigfoot.psycopg2_mock.assert_close()
+    bigfoot.psycopg2.assert_commit()
+    bigfoot.psycopg2.assert_close()

--- a/examples/redis_cache/README.md
+++ b/examples/redis_cache/README.md
@@ -3,7 +3,7 @@
 Demonstrates bigfoot's Redis plugin for mocking Redis commands.
 
 The application module (`app.py`) reads from a Redis cache. The test
-(`test_app.py`) uses `bigfoot.redis_mock` to mock `GET` commands and
+(`test_app.py`) uses `bigfoot.redis` to mock `GET` commands and
 verify the exact key lookups, covering both cache hit and cache miss
 scenarios.
 

--- a/examples/redis_cache/test_app.py
+++ b/examples/redis_cache/test_app.py
@@ -1,4 +1,4 @@
-"""Test Redis cache using bigfoot redis_mock."""
+"""Test Redis cache using bigfoot's redis plugin."""
 
 import bigfoot
 from dirty_equals import IsInstance
@@ -7,7 +7,7 @@ from .app import get_user
 
 
 def test_get_user_cache_hit():
-    bigfoot.redis_mock.mock_command(
+    bigfoot.redis.mock_command(
         "GET", returns=b'{"id": 1, "name": "Alice"}'
     )
 
@@ -15,14 +15,14 @@ def test_get_user_cache_hit():
         result = get_user(1)
 
     assert result == {"id": 1, "name": "Alice"}
-    bigfoot.redis_mock.assert_command("GET", args=("user:1",), kwargs=IsInstance(dict))
+    bigfoot.redis.assert_command("GET", args=("user:1",), kwargs=IsInstance(dict))
 
 
 def test_get_user_cache_miss():
-    bigfoot.redis_mock.mock_command("GET", returns=None)
+    bigfoot.redis.mock_command("GET", returns=None)
 
     with bigfoot:
         result = get_user(42)
 
     assert result is None
-    bigfoot.redis_mock.assert_command("GET", args=("user:42",), kwargs=IsInstance(dict))
+    bigfoot.redis.assert_command("GET", args=("user:42",), kwargs=IsInstance(dict))

--- a/examples/socket_example/test_app.py
+++ b/examples/socket_example/test_app.py
@@ -1,4 +1,4 @@
-"""Test fetch_status using bigfoot socket_mock."""
+"""Test fetch_status using bigfoot socket."""
 
 import bigfoot
 
@@ -6,7 +6,7 @@ from .app import fetch_status
 
 
 def test_fetch_status():
-    (bigfoot.socket_mock
+    (bigfoot.socket
         .new_session()
         .expect("connect",  returns=None)
         .expect("sendall",  returns=None)
@@ -18,7 +18,7 @@ def test_fetch_status():
 
     assert result == "OK 200\r\n"
 
-    bigfoot.socket_mock.assert_connect(host="monitoring.internal", port=5000)
-    bigfoot.socket_mock.assert_sendall(data=b"STATUS\r\n")
-    bigfoot.socket_mock.assert_recv(size=4096, data=b"OK 200\r\n")
-    bigfoot.socket_mock.assert_close()
+    bigfoot.socket.assert_connect(host="monitoring.internal", port=5000)
+    bigfoot.socket.assert_sendall(data=b"STATUS\r\n")
+    bigfoot.socket.assert_recv(size=4096, data=b"OK 200\r\n")
+    bigfoot.socket.assert_close()

--- a/examples/ssh_remote/test_app.py
+++ b/examples/ssh_remote/test_app.py
@@ -1,4 +1,4 @@
-"""Test SSH deployment using bigfoot ssh_mock."""
+"""Test SSH deployment using bigfoot ssh."""
 
 import bigfoot
 
@@ -6,7 +6,7 @@ from .app import deploy_config
 
 
 def test_deploy_config():
-    (bigfoot.ssh_mock
+    (bigfoot.ssh
         .new_session()
         .expect("connect",      returns=None)
         .expect("open_sftp",    returns=None)
@@ -20,13 +20,13 @@ def test_deploy_config():
             "/tmp/app.conf", "/etc/myapp/app.conf",
         )
 
-    bigfoot.ssh_mock.assert_connect(
+    bigfoot.ssh.assert_connect(
         hostname="prod-1.example.com", port=22,
         username="deploy", auth_method="password",
     )
-    bigfoot.ssh_mock.assert_open_sftp()
-    bigfoot.ssh_mock.assert_sftp_put(
+    bigfoot.ssh.assert_open_sftp()
+    bigfoot.ssh.assert_sftp_put(
         localpath="/tmp/app.conf", remotepath="/etc/myapp/app.conf",
     )
-    bigfoot.ssh_mock.assert_exec_command(command="systemctl reload myapp")
-    bigfoot.ssh_mock.assert_close()
+    bigfoot.ssh.assert_exec_command(command="systemctl reload myapp")
+    bigfoot.ssh.assert_close()

--- a/examples/websocket_example/test_app.py
+++ b/examples/websocket_example/test_app.py
@@ -1,4 +1,4 @@
-"""Test chat_client using bigfoot sync_websocket_mock."""
+"""Test chat_client using bigfoot sync_websocket."""
 
 import bigfoot
 
@@ -6,7 +6,7 @@ from .app import chat_client
 
 
 def test_chat_client():
-    (bigfoot.sync_websocket_mock
+    (bigfoot.sync_websocket
         .new_session()
         .expect("connect", returns=None)
         .expect("send",    returns=None)
@@ -20,9 +20,9 @@ def test_chat_client():
 
     assert responses == ["echo: hello", "echo: world"]
 
-    bigfoot.sync_websocket_mock.assert_connect(uri="ws://chat.example.com/ws")
-    bigfoot.sync_websocket_mock.assert_send(message="hello")
-    bigfoot.sync_websocket_mock.assert_recv(message="echo: hello")
-    bigfoot.sync_websocket_mock.assert_send(message="world")
-    bigfoot.sync_websocket_mock.assert_recv(message="echo: world")
-    bigfoot.sync_websocket_mock.assert_close()
+    bigfoot.sync_websocket.assert_connect(uri="ws://chat.example.com/ws")
+    bigfoot.sync_websocket.assert_send(message="hello")
+    bigfoot.sync_websocket.assert_recv(message="echo: hello")
+    bigfoot.sync_websocket.assert_send(message="world")
+    bigfoot.sync_websocket.assert_recv(message="echo: world")
+    bigfoot.sync_websocket.assert_close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bigfoot"
-version = "0.19.2"
+version = "0.20.0"
 description = "Full-certainty test mocking: every call recorded and verified"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/bigfoot/__init__.py
+++ b/src/bigfoot/__init__.py
@@ -35,8 +35,9 @@ from __future__ import annotations
 import sys
 import threading
 import types
+import warnings
 from collections.abc import Callable
-from typing import TYPE_CHECKING, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from bigfoot._base_plugin import BasePlugin
 from bigfoot._context import GuardPassThrough, _get_test_verifier_or_raise, get_verifier_or_raise
@@ -301,38 +302,38 @@ __all__ = [
     "current_verifier",
     "spy",
     "http",
-    "subprocess_mock",
-    "popen_mock",
-    "smtp_mock",
-    "socket_mock",
-    "db_mock",
-    "async_websocket_mock",
-    "sync_websocket_mock",
-    "redis_mock",
-    "mongo_mock",
-    "dns_mock",
-    "memcache_mock",
-    "celery_mock",
-    "log_mock",
-    "async_subprocess_mock",
-    "psycopg2_mock",
-    "asyncpg_mock",
-    "boto3_mock",
-    "elasticsearch_mock",
-    "jwt_mock",
-    "crypto_mock",
+    "subprocess",
+    "popen",
+    "smtp",
+    "socket",
+    "db",
+    "async_websocket",
+    "sync_websocket",
+    "redis",
+    "mongo",
+    "dns",
+    "memcache",
+    "celery",
+    "log",
+    "async_subprocess",
+    "psycopg2",
+    "asyncpg",
+    "boto3",
+    "elasticsearch",
+    "jwt",
+    "crypto",
     "FileIoPlugin",
-    "file_io_mock",
+    "file_io",
     "PikaPlugin",
-    "pika_mock",
+    "pika",
     "SshPlugin",
-    "ssh_mock",
+    "ssh",
     "GrpcPlugin",
-    "grpc_mock",
+    "grpc",
     "McpPlugin",
-    "mcp_mock",
+    "mcp",
     "NativePlugin",
-    "native_mock",
+    "native",
 ]
 
 
@@ -475,7 +476,7 @@ class _SubprocessProxy:
         return getattr(plugin, name)
 
 
-subprocess_mock = _SubprocessProxy()
+subprocess = _SubprocessProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -495,7 +496,7 @@ class _PopenProxy:
         return getattr(plugin, name)
 
 
-popen_mock = _PopenProxy()
+popen = _PopenProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -515,7 +516,7 @@ class _SmtpProxy:
         return getattr(plugin, name)
 
 
-smtp_mock = _SmtpProxy()
+smtp = _SmtpProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -535,7 +536,7 @@ class _SocketProxy:
         return getattr(plugin, name)
 
 
-socket_mock = _SocketProxy()
+socket = _SocketProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -555,7 +556,7 @@ class _DatabaseProxy:
         return getattr(plugin, name)
 
 
-db_mock = _DatabaseProxy()
+db = _DatabaseProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -575,7 +576,7 @@ class _AsyncWebSocketProxy:
 
         if not _WEBSOCKETS_AVAILABLE:
             raise ImportError(
-                "bigfoot[websockets] is required to use bigfoot.async_websocket_mock. "
+                "bigfoot[websockets] is required to use bigfoot.async_websocket. "
                 "Install it with: pip install bigfoot[websockets]"
             )
         verifier = _get_test_verifier_or_raise()
@@ -583,7 +584,7 @@ class _AsyncWebSocketProxy:
         return getattr(plugin, name)
 
 
-async_websocket_mock = _AsyncWebSocketProxy()
+async_websocket = _AsyncWebSocketProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -603,7 +604,7 @@ class _SyncWebSocketProxy:
 
         if not _WEBSOCKET_CLIENT_AVAILABLE:
             raise ImportError(
-                "bigfoot[websocket-client] is required to use bigfoot.sync_websocket_mock. "
+                "bigfoot[websocket-client] is required to use bigfoot.sync_websocket. "
                 "Install it with: pip install bigfoot[websocket-client]"
             )
         verifier = _get_test_verifier_or_raise()
@@ -611,7 +612,7 @@ class _SyncWebSocketProxy:
         return getattr(plugin, name)
 
 
-sync_websocket_mock = _SyncWebSocketProxy()
+sync_websocket = _SyncWebSocketProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -631,7 +632,7 @@ class _RedisProxy:
 
         if not _REDIS_AVAILABLE:
             raise ImportError(
-                "bigfoot[redis] is required to use bigfoot.redis_mock. "
+                "bigfoot[redis] is required to use bigfoot.redis. "
                 "Install it with: pip install bigfoot[redis]"
             )
         verifier = _get_test_verifier_or_raise()
@@ -639,7 +640,7 @@ class _RedisProxy:
         return getattr(plugin, name)
 
 
-redis_mock = _RedisProxy()
+redis = _RedisProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -660,7 +661,7 @@ class _FileIoProxy:
         return getattr(plugin, name)
 
 
-file_io_mock = _FileIoProxy()
+file_io = _FileIoProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -681,7 +682,7 @@ class _NativeProxy:
         return getattr(plugin, name)
 
 
-native_mock = _NativeProxy()
+native = _NativeProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -701,7 +702,7 @@ class _PikaProxy:
 
         if not _PIKA_AVAILABLE:
             raise ImportError(
-                "bigfoot[pika] is required to use bigfoot.pika_mock. "
+                "bigfoot[pika] is required to use bigfoot.pika. "
                 "Install it with: pip install bigfoot[pika]"
             )
         verifier = _get_test_verifier_or_raise()
@@ -709,7 +710,7 @@ class _PikaProxy:
         return getattr(plugin, name)
 
 
-pika_mock = _PikaProxy()
+pika = _PikaProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -729,7 +730,7 @@ class _SshProxy:
 
         if not _PARAMIKO_AVAILABLE:
             raise ImportError(
-                "bigfoot[ssh] is required to use bigfoot.ssh_mock. "
+                "bigfoot[ssh] is required to use bigfoot.ssh. "
                 "Install it with: pip install bigfoot[ssh]"
             )
         verifier = _get_test_verifier_or_raise()
@@ -737,7 +738,7 @@ class _SshProxy:
         return getattr(plugin, name)
 
 
-ssh_mock = _SshProxy()
+ssh = _SshProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -757,7 +758,7 @@ class _GrpcProxy:
 
         if not _GRPC_AVAILABLE:
             raise ImportError(
-                "bigfoot[grpc] is required to use bigfoot.grpc_mock. "
+                "bigfoot[grpc] is required to use bigfoot.grpc. "
                 "Install it with: pip install bigfoot[grpc]"
             )
         verifier = _get_test_verifier_or_raise()
@@ -765,7 +766,7 @@ class _GrpcProxy:
         return getattr(plugin, name)
 
 
-grpc_mock = _GrpcProxy()
+grpc = _GrpcProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -785,7 +786,7 @@ class _McpProxy:
 
         if not _MCP_AVAILABLE:
             raise ImportError(
-                "bigfoot[mcp] is required to use bigfoot.mcp_mock. "
+                "bigfoot[mcp] is required to use bigfoot.mcp. "
                 "Install it with: pip install bigfoot[mcp]"
             )
         verifier = _get_test_verifier_or_raise()
@@ -793,7 +794,7 @@ class _McpProxy:
         return getattr(plugin, name)
 
 
-mcp_mock = _McpProxy()
+mcp = _McpProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -813,7 +814,7 @@ class _MongoProxy:
 
         if not _PYMONGO_AVAILABLE:
             raise ImportError(
-                "bigfoot[mongo] is required to use bigfoot.mongo_mock. "
+                "bigfoot[mongo] is required to use bigfoot.mongo. "
                 "Install it with: pip install bigfoot[mongo]"
             )
         verifier = _get_test_verifier_or_raise()
@@ -821,7 +822,7 @@ class _MongoProxy:
         return getattr(plugin, name)
 
 
-mongo_mock = _MongoProxy()
+mongo = _MongoProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -842,7 +843,7 @@ class _DnsProxy:
         return getattr(plugin, name)
 
 
-dns_mock = _DnsProxy()
+dns = _DnsProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -862,7 +863,7 @@ class _MemcacheProxy:
 
         if not _PYMEMCACHE_AVAILABLE:
             raise ImportError(
-                "bigfoot[pymemcache] is required to use bigfoot.memcache_mock. "
+                "bigfoot[pymemcache] is required to use bigfoot.memcache. "
                 "Install it with: pip install bigfoot[pymemcache]"
             )
         verifier = _get_test_verifier_or_raise()
@@ -870,7 +871,7 @@ class _MemcacheProxy:
         return getattr(plugin, name)
 
 
-memcache_mock = _MemcacheProxy()
+memcache = _MemcacheProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -890,7 +891,7 @@ class _CeleryProxy:
 
         if not _CELERY_AVAILABLE:
             raise ImportError(
-                "bigfoot[celery] is required to use bigfoot.celery_mock. "
+                "bigfoot[celery] is required to use bigfoot.celery. "
                 "Install it with: pip install bigfoot[celery]"
             )
         verifier = _get_test_verifier_or_raise()
@@ -898,7 +899,7 @@ class _CeleryProxy:
         return getattr(plugin, name)
 
 
-celery_mock = _CeleryProxy()
+celery = _CeleryProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -918,7 +919,7 @@ class _LoggingProxy:
         return getattr(plugin, name)
 
 
-log_mock = _LoggingProxy()
+log = _LoggingProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -938,7 +939,7 @@ class _Psycopg2Proxy:
 
         if not _PSYCOPG2_AVAILABLE:
             raise ImportError(
-                "bigfoot[psycopg2] is required to use bigfoot.psycopg2_mock. "
+                "bigfoot[psycopg2] is required to use bigfoot.psycopg2. "
                 "Install it with: pip install bigfoot[psycopg2]"
             )
         verifier = _get_test_verifier_or_raise()
@@ -946,7 +947,7 @@ class _Psycopg2Proxy:
         return getattr(plugin, name)
 
 
-psycopg2_mock = _Psycopg2Proxy()
+psycopg2 = _Psycopg2Proxy()
 
 
 # ---------------------------------------------------------------------------
@@ -966,7 +967,7 @@ class _AsyncpgProxy:
 
         if not _ASYNCPG_AVAILABLE:
             raise ImportError(
-                "bigfoot[asyncpg] is required to use bigfoot.asyncpg_mock. "
+                "bigfoot[asyncpg] is required to use bigfoot.asyncpg. "
                 "Install it with: pip install bigfoot[asyncpg]"
             )
         verifier = _get_test_verifier_or_raise()
@@ -974,7 +975,7 @@ class _AsyncpgProxy:
         return getattr(plugin, name)
 
 
-asyncpg_mock = _AsyncpgProxy()
+asyncpg = _AsyncpgProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -994,7 +995,7 @@ class _Boto3Proxy:
 
         if not _BOTO3_AVAILABLE:
             raise ImportError(
-                "bigfoot[boto3] is required to use bigfoot.boto3_mock. "
+                "bigfoot[boto3] is required to use bigfoot.boto3. "
                 "Install it with: pip install bigfoot[boto3]"
             )
         verifier = _get_test_verifier_or_raise()
@@ -1002,7 +1003,7 @@ class _Boto3Proxy:
         return getattr(plugin, name)
 
 
-boto3_mock = _Boto3Proxy()
+boto3 = _Boto3Proxy()
 
 
 # ---------------------------------------------------------------------------
@@ -1022,7 +1023,7 @@ class _ElasticsearchProxy:
 
         if not _ELASTICSEARCH_AVAILABLE:
             raise ImportError(
-                "bigfoot[elasticsearch] is required to use bigfoot.elasticsearch_mock. "
+                "bigfoot[elasticsearch] is required to use bigfoot.elasticsearch. "
                 "Install it with: pip install bigfoot[elasticsearch]"
             )
         verifier = _get_test_verifier_or_raise()
@@ -1030,7 +1031,7 @@ class _ElasticsearchProxy:
         return getattr(plugin, name)
 
 
-elasticsearch_mock = _ElasticsearchProxy()
+elasticsearch = _ElasticsearchProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -1050,7 +1051,7 @@ class _JwtProxy:
 
         if not _JWT_AVAILABLE:
             raise ImportError(
-                "bigfoot[jwt] is required to use bigfoot.jwt_mock. "
+                "bigfoot[jwt] is required to use bigfoot.jwt. "
                 "Install it with: pip install bigfoot[jwt]"
             )
         verifier = _get_test_verifier_or_raise()
@@ -1058,7 +1059,7 @@ class _JwtProxy:
         return getattr(plugin, name)
 
 
-jwt_mock = _JwtProxy()
+jwt = _JwtProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -1078,7 +1079,7 @@ class _CryptoProxy:
 
         if not _CRYPTOGRAPHY_AVAILABLE:
             raise ImportError(
-                "bigfoot[crypto] is required to use bigfoot.crypto_mock. "
+                "bigfoot[crypto] is required to use bigfoot.crypto. "
                 "Install it with: pip install bigfoot[crypto]"
             )
         verifier = _get_test_verifier_or_raise()
@@ -1086,7 +1087,7 @@ class _CryptoProxy:
         return getattr(plugin, name)
 
 
-crypto_mock = _CryptoProxy()
+crypto = _CryptoProxy()
 
 
 # ---------------------------------------------------------------------------
@@ -1106,7 +1107,70 @@ class _AsyncSubprocessProxy:
         return getattr(plugin, name)
 
 
-async_subprocess_mock = _AsyncSubprocessProxy()
+async_subprocess = _AsyncSubprocessProxy()
+
+
+# ---------------------------------------------------------------------------
+# Deprecated ``_mock`` aliases (backward compatibility, scheduled for removal)
+# ---------------------------------------------------------------------------
+# The canonical public names for plugin proxies are un-suffixed (e.g.
+# ``bigfoot.subprocess``, ``bigfoot.db``, ``bigfoot.redis``). The ``_mock``
+# suffixed names below are retained as deprecated aliases so existing user code
+# keeps working during the transition. Each access emits a DeprecationWarning
+# (first access per alias per process) pointing at the new name. All first-party
+# code, tests, docs, and examples have been migrated off these aliases; they
+# exist solely for external backward compatibility and will be removed in a
+# future release.
+
+_DEPRECATED_PROXY_ALIASES: dict[str, str] = {
+    "subprocess_mock": "subprocess",
+    "popen_mock": "popen",
+    "smtp_mock": "smtp",
+    "socket_mock": "socket",
+    "db_mock": "db",
+    "async_websocket_mock": "async_websocket",
+    "sync_websocket_mock": "sync_websocket",
+    "redis_mock": "redis",
+    "mongo_mock": "mongo",
+    "dns_mock": "dns",
+    "memcache_mock": "memcache",
+    "celery_mock": "celery",
+    "log_mock": "log",
+    "async_subprocess_mock": "async_subprocess",
+    "psycopg2_mock": "psycopg2",
+    "asyncpg_mock": "asyncpg",
+    "boto3_mock": "boto3",
+    "elasticsearch_mock": "elasticsearch",
+    "jwt_mock": "jwt",
+    "crypto_mock": "crypto",
+    "file_io_mock": "file_io",
+    "pika_mock": "pika",
+    "ssh_mock": "ssh",
+    "grpc_mock": "grpc",
+    "mcp_mock": "mcp",
+    "native_mock": "native",
+}
+
+_warned_aliases: set[str] = set()
+
+
+def __getattr__(name: str) -> Any:
+    """Module-level attribute lookup hook (PEP 562).
+
+    Resolves deprecated ``_mock`` aliases to their canonical un-suffixed proxy
+    singletons and emits a ``DeprecationWarning`` on first access per alias.
+    """
+    target = _DEPRECATED_PROXY_ALIASES.get(name)
+    if target is not None:
+        if name not in _warned_aliases:
+            _warned_aliases.add(name)
+            warnings.warn(
+                f"bigfoot.{name} is deprecated; use bigfoot.{target} instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return globals()[target]
+    raise AttributeError(f"module 'bigfoot' has no attribute {name!r}")
 
 
 # ---------------------------------------------------------------------------

--- a/src/bigfoot/__init__.py
+++ b/src/bigfoot/__init__.py
@@ -1154,7 +1154,7 @@ _DEPRECATED_PROXY_ALIASES: dict[str, str] = {
 _warned_aliases: set[str] = set()
 
 
-def __getattr__(name: str) -> Any:
+def __getattr__(name: str) -> Any:  # noqa: ANN401
     """Module-level attribute lookup hook (PEP 562).
 
     Resolves deprecated ``_mock`` aliases to their canonical un-suffixed proxy

--- a/src/bigfoot/__init__.pyi
+++ b/src/bigfoot/__init__.pyi
@@ -4,7 +4,7 @@ Enables Pyright/mypy to resolve:
 - ``with bigfoot:`` context manager protocol
 - Module-level functions (current_verifier, sandbox, assert_interaction, etc.)
 - Module-level factories (mock, spy)
-- Plugin proxy attributes (http, subprocess_mock, etc.)
+- Plugin proxy attributes (http, subprocess, etc.)
 - All error classes
 """
 
@@ -167,29 +167,62 @@ spy: _SpyFactory
 # ---------------------------------------------------------------------------
 
 http: Any  # HttpPlugin proxy; typed as Any because httpx/requests are optional
-subprocess_mock: Any  # SubprocessPlugin proxy
-popen_mock: Any  # PopenPlugin proxy
-smtp_mock: Any  # SmtpPlugin proxy
-socket_mock: Any  # SocketPlugin proxy
-db_mock: Any  # DatabasePlugin proxy
-async_websocket_mock: Any  # AsyncWebSocketPlugin proxy
-sync_websocket_mock: Any  # SyncWebSocketPlugin proxy
-redis_mock: Any  # RedisPlugin proxy
-mongo_mock: Any  # MongoPlugin proxy
-dns_mock: Any  # DnsPlugin proxy
-memcache_mock: Any  # MemcachePlugin proxy
-celery_mock: Any  # CeleryPlugin proxy
-log_mock: Any  # LoggingPlugin proxy
-async_subprocess_mock: Any  # AsyncSubprocessPlugin proxy
-psycopg2_mock: Any  # Psycopg2Plugin proxy
-asyncpg_mock: Any  # AsyncpgPlugin proxy
-boto3_mock: Any  # Boto3Plugin proxy
-elasticsearch_mock: Any  # ElasticsearchPlugin proxy
-jwt_mock: Any  # JwtPlugin proxy
-crypto_mock: Any  # CryptoPlugin proxy
-file_io_mock: Any  # FileIoPlugin proxy
-pika_mock: Any  # PikaPlugin proxy
-ssh_mock: Any  # SshPlugin proxy
-grpc_mock: Any  # GrpcPlugin proxy
-mcp_mock: Any  # McpPlugin proxy
-native_mock: Any  # NativePlugin proxy
+subprocess: Any  # SubprocessPlugin proxy
+popen: Any  # PopenPlugin proxy
+smtp: Any  # SmtpPlugin proxy
+socket: Any  # SocketPlugin proxy
+db: Any  # DatabasePlugin proxy
+async_websocket: Any  # AsyncWebSocketPlugin proxy
+sync_websocket: Any  # SyncWebSocketPlugin proxy
+redis: Any  # RedisPlugin proxy
+mongo: Any  # MongoPlugin proxy
+dns: Any  # DnsPlugin proxy
+memcache: Any  # MemcachePlugin proxy
+celery: Any  # CeleryPlugin proxy
+log: Any  # LoggingPlugin proxy
+async_subprocess: Any  # AsyncSubprocessPlugin proxy
+psycopg2: Any  # Psycopg2Plugin proxy
+asyncpg: Any  # AsyncpgPlugin proxy
+boto3: Any  # Boto3Plugin proxy
+elasticsearch: Any  # ElasticsearchPlugin proxy
+jwt: Any  # JwtPlugin proxy
+crypto: Any  # CryptoPlugin proxy
+file_io: Any  # FileIoPlugin proxy
+pika: Any  # PikaPlugin proxy
+ssh: Any  # SshPlugin proxy
+grpc: Any  # GrpcPlugin proxy
+mcp: Any  # McpPlugin proxy
+native: Any  # NativePlugin proxy
+
+# ---------------------------------------------------------------------------
+# Deprecated ``_mock`` aliases (backward compatibility, scheduled for removal)
+# ---------------------------------------------------------------------------
+# Kept for type-checker compatibility so existing user code resolves. At runtime,
+# accessing any of these names triggers a DeprecationWarning pointing at the new
+# un-suffixed name. Use the canonical names above in new code.
+subprocess_mock: Any  # Deprecated: use bigfoot.subprocess
+popen_mock: Any  # Deprecated: use bigfoot.popen
+smtp_mock: Any  # Deprecated: use bigfoot.smtp
+socket_mock: Any  # Deprecated: use bigfoot.socket
+db_mock: Any  # Deprecated: use bigfoot.db
+async_websocket_mock: Any  # Deprecated: use bigfoot.async_websocket
+sync_websocket_mock: Any  # Deprecated: use bigfoot.sync_websocket
+redis_mock: Any  # Deprecated: use bigfoot.redis
+mongo_mock: Any  # Deprecated: use bigfoot.mongo
+dns_mock: Any  # Deprecated: use bigfoot.dns
+memcache_mock: Any  # Deprecated: use bigfoot.memcache
+celery_mock: Any  # Deprecated: use bigfoot.celery
+log_mock: Any  # Deprecated: use bigfoot.log
+async_subprocess_mock: Any  # Deprecated: use bigfoot.async_subprocess
+psycopg2_mock: Any  # Deprecated: use bigfoot.psycopg2
+asyncpg_mock: Any  # Deprecated: use bigfoot.asyncpg
+boto3_mock: Any  # Deprecated: use bigfoot.boto3
+elasticsearch_mock: Any  # Deprecated: use bigfoot.elasticsearch
+jwt_mock: Any  # Deprecated: use bigfoot.jwt
+crypto_mock: Any  # Deprecated: use bigfoot.crypto
+file_io_mock: Any  # Deprecated: use bigfoot.file_io
+pika_mock: Any  # Deprecated: use bigfoot.pika
+ssh_mock: Any  # Deprecated: use bigfoot.ssh
+grpc_mock: Any  # Deprecated: use bigfoot.grpc
+mcp_mock: Any  # Deprecated: use bigfoot.mcp
+native_mock: Any  # Deprecated: use bigfoot.native

--- a/src/bigfoot/plugins/async_subprocess_plugin.py
+++ b/src/bigfoot/plugins/async_subprocess_plugin.py
@@ -297,15 +297,15 @@ class AsyncSubprocessPlugin(StateMachinePlugin):
 
     def format_mock_hint(self, interaction: Interaction) -> str:
         if interaction.source_id == _SOURCE_SPAWN:
-            return "    bigfoot.async_subprocess_mock.new_session().expect('spawn', returns=None)"
+            return "    bigfoot.async_subprocess.new_session().expect('spawn', returns=None)"
         if interaction.source_id == _SOURCE_COMMUNICATE:
             return (
-                "    bigfoot.async_subprocess_mock.new_session()"
+                "    bigfoot.async_subprocess.new_session()"
                 ".expect('communicate', returns=(b'', b'', 0))"
             )
         if interaction.source_id == _SOURCE_WAIT:
-            return "    bigfoot.async_subprocess_mock.new_session().expect('wait', returns=0)"
-        return "    bigfoot.async_subprocess_mock.new_session().expect('?', returns=...)"
+            return "    bigfoot.async_subprocess.new_session().expect('wait', returns=0)"
+        return "    bigfoot.async_subprocess.new_session().expect('?', returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -317,11 +317,11 @@ class AsyncSubprocessPlugin(StateMachinePlugin):
         return (
             f"asyncio.create_subprocess_{method}(...) was called but no session was queued.\n"
             f"Register a session with:\n"
-            f"    bigfoot.async_subprocess_mock.new_session().expect({method!r}, returns=...)"
+            f"    bigfoot.async_subprocess.new_session().expect({method!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
-        pm = "bigfoot.async_subprocess_mock"
+        pm = "bigfoot.async_subprocess"
         sid = interaction.source_id
         if sid == _SOURCE_SPAWN:
             command = interaction.details.get("command", [])

--- a/src/bigfoot/plugins/asyncpg_plugin.py
+++ b/src/bigfoot/plugins/asyncpg_plugin.py
@@ -247,7 +247,7 @@ class AsyncpgPlugin(StateMachinePlugin):
 
     def format_mock_hint(self, interaction: Interaction) -> str:
         method = interaction.details.get("method", "?")
-        return f"    bigfoot.asyncpg_mock.new_session().expect({method!r}, returns=...)"
+        return f"    bigfoot.asyncpg.new_session().expect({method!r}, returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -259,11 +259,11 @@ class AsyncpgPlugin(StateMachinePlugin):
         return (
             f"asyncpg.{method}(...) was called but no session was queued.\n"
             f"Register a session with:\n"
-            f"    bigfoot.asyncpg_mock.new_session().expect({method!r}, returns=...)"
+            f"    bigfoot.asyncpg.new_session().expect({method!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
-        sm = "bigfoot.asyncpg_mock"
+        sm = "bigfoot.asyncpg"
         sid = interaction.source_id
         if sid == _SOURCE_CONNECT:
             parts = []

--- a/src/bigfoot/plugins/boto3_plugin.py
+++ b/src/bigfoot/plugins/boto3_plugin.py
@@ -314,7 +314,7 @@ class Boto3Plugin(BasePlugin):
     def format_mock_hint(self, interaction: Interaction) -> str:
         service = interaction.details.get("service", "?")
         operation = interaction.details.get("operation", "?")
-        return f"    bigfoot.boto3_mock.mock_call({service!r}, {operation!r}, returns=...)"
+        return f"    bigfoot.boto3.mock_call({service!r}, {operation!r}, returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -328,7 +328,7 @@ class Boto3Plugin(BasePlugin):
         return (
             f"{service}.{operation}(...) was called but no mock was registered.\n"
             f"Register a mock with:\n"
-            f"    bigfoot.boto3_mock.mock_call({service!r}, {operation!r}, returns=...)"
+            f"    bigfoot.boto3.mock_call({service!r}, {operation!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
@@ -336,7 +336,7 @@ class Boto3Plugin(BasePlugin):
         operation = interaction.details.get("operation", "?")
         params = interaction.details.get("params", {})
         return (
-            f"    bigfoot.boto3_mock.assert_boto3_call(\n"
+            f"    bigfoot.boto3.assert_boto3_call(\n"
             f"        service={service!r},\n"
             f"        operation={operation!r},\n"
             f"        params={params!r},\n"

--- a/src/bigfoot/plugins/celery_plugin.py
+++ b/src/bigfoot/plugins/celery_plugin.py
@@ -323,7 +323,7 @@ class CeleryPlugin(BasePlugin):
     def format_mock_hint(self, interaction: Interaction) -> str:
         task_name = interaction.details.get("task_name", "?")
         dispatch = interaction.details.get("dispatch_method", "?")
-        return f"    bigfoot.celery_mock.mock_{dispatch}({task_name!r}, returns=...)"
+        return f"    bigfoot.celery.mock_{dispatch}({task_name!r}, returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -338,11 +338,11 @@ class CeleryPlugin(BasePlugin):
         return (
             f"celery.{dispatch}({task_name!r}, ...) was called but no mock was registered.\n"
             f"Register a mock with:\n"
-            f"    bigfoot.celery_mock.mock_{dispatch}({task_name!r}, returns=...)"
+            f"    bigfoot.celery.mock_{dispatch}({task_name!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
-        sm = "bigfoot.celery_mock"
+        sm = "bigfoot.celery"
         dispatch = interaction.details.get("dispatch_method", "?")
         parts = []
         for k, v in interaction.details.items():

--- a/src/bigfoot/plugins/crypto_plugin.py
+++ b/src/bigfoot/plugins/crypto_plugin.py
@@ -338,7 +338,7 @@ class CryptoPlugin(BasePlugin):
         source_id = interaction.source_id
         operation = source_id.split(":", 1)[-1] if ":" in source_id else "?"
         mock_name = _OPERATION_MOCK_NAMES.get(operation, f"mock_{operation}")
-        return f"    bigfoot.crypto_mock.{mock_name}(returns=...)"
+        return f"    bigfoot.crypto.{mock_name}(returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -351,7 +351,7 @@ class CryptoPlugin(BasePlugin):
         return (
             f"crypto.{operation}(...) was called but no mock was registered.\n"
             f"Register a mock with:\n"
-            f"    bigfoot.crypto_mock.{mock_name}(returns=...)"
+            f"    bigfoot.crypto.{mock_name}(returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
@@ -366,7 +366,7 @@ class CryptoPlugin(BasePlugin):
             "generate_key": "assert_generate_key",
         }.get(operation, f"assert_{operation}")
         return (
-            f"    bigfoot.crypto_mock.{helper_name}(\n"
+            f"    bigfoot.crypto.{helper_name}(\n"
             f"{lines}\n"
             f"    )"
         )

--- a/src/bigfoot/plugins/database_plugin.py
+++ b/src/bigfoot/plugins/database_plugin.py
@@ -263,7 +263,7 @@ class DatabasePlugin(StateMachinePlugin):
 
     def format_mock_hint(self, interaction: Interaction) -> str:
         method = interaction.details.get("method", "?")
-        return f"    bigfoot.db_mock.new_session().expect({method!r}, returns=...)"
+        return f"    bigfoot.db.new_session().expect({method!r}, returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -275,11 +275,11 @@ class DatabasePlugin(StateMachinePlugin):
         return (
             f"sqlite3.{method}(...) was called but no session was queued.\n"
             f"Register a session with:\n"
-            f"    bigfoot.db_mock.new_session().expect({method!r}, returns=...)"
+            f"    bigfoot.db.new_session().expect({method!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
-        sm = "bigfoot.db_mock"
+        sm = "bigfoot.db"
         sid = interaction.source_id
         if sid == _SOURCE_CONNECT:
             database = interaction.details.get("database", "?")

--- a/src/bigfoot/plugins/dns_plugin.py
+++ b/src/bigfoot/plugins/dns_plugin.py
@@ -423,13 +423,13 @@ class DnsPlugin(BasePlugin):
         hostname = parts[2] if len(parts) > 2 else "?"
 
         if operation == "getaddrinfo":
-            return f"    bigfoot.dns_mock.mock_getaddrinfo({hostname!r}, returns=...)"
+            return f"    bigfoot.dns.mock_getaddrinfo({hostname!r}, returns=...)"
         elif operation == "gethostbyname":
-            return f"    bigfoot.dns_mock.mock_gethostbyname({hostname!r}, returns=...)"
+            return f"    bigfoot.dns.mock_gethostbyname({hostname!r}, returns=...)"
         elif operation == "resolve":
             rdtype = interaction.details.get("rdtype", "A")
-            return f"    bigfoot.dns_mock.mock_resolve({hostname!r}, {rdtype!r}, returns=...)"
-        return f"    bigfoot.dns_mock.mock_{operation}({hostname!r}, returns=...)"
+            return f"    bigfoot.dns.mock_resolve({hostname!r}, {rdtype!r}, returns=...)"
+        return f"    bigfoot.dns.mock_{operation}({hostname!r}, returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -445,28 +445,28 @@ class DnsPlugin(BasePlugin):
             return (
                 f"socket.getaddrinfo({hostname!r}, ...) was called but no mock was registered.\n"
                 f"Register a mock with:\n"
-                f"    bigfoot.dns_mock.mock_getaddrinfo({hostname!r}, returns=...)"
+                f"    bigfoot.dns.mock_getaddrinfo({hostname!r}, returns=...)"
             )
         elif operation == "gethostbyname":
             return (
                 f"socket.gethostbyname({hostname!r}) was called but no mock was registered.\n"
                 f"Register a mock with:\n"
-                f"    bigfoot.dns_mock.mock_gethostbyname({hostname!r}, returns=...)"
+                f"    bigfoot.dns.mock_gethostbyname({hostname!r}, returns=...)"
             )
         elif operation == "resolve":
             return (
                 f"dns.resolver.resolve({hostname!r}, ...) was called but no mock was registered.\n"
                 f"Register a mock with:\n"
-                f"    bigfoot.dns_mock.mock_resolve({hostname!r}, 'A', returns=...)"
+                f"    bigfoot.dns.mock_resolve({hostname!r}, 'A', returns=...)"
             )
         return (
             f"dns.{operation}({hostname!r}) was called but no mock was registered.\n"
             f"Register a mock with:\n"
-            f"    bigfoot.dns_mock.mock_{operation}({hostname!r}, returns=...)"
+            f"    bigfoot.dns.mock_{operation}({hostname!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
-        sm = "bigfoot.dns_mock"
+        sm = "bigfoot.dns"
         source_id = interaction.source_id
         parts = source_id.split(":", 2)
         operation = parts[1] if len(parts) > 1 else "?"

--- a/src/bigfoot/plugins/elasticsearch_plugin.py
+++ b/src/bigfoot/plugins/elasticsearch_plugin.py
@@ -323,7 +323,7 @@ class ElasticsearchPlugin(BasePlugin):
     def format_mock_hint(self, interaction: Interaction) -> str:
         source_id = interaction.source_id
         operation = source_id.split(":", 1)[-1] if ":" in source_id else "?"
-        return f"    bigfoot.elasticsearch_mock.mock_operation({operation!r}, returns=...)"
+        return f"    bigfoot.elasticsearch.mock_operation({operation!r}, returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -335,7 +335,7 @@ class ElasticsearchPlugin(BasePlugin):
         return (
             f"elasticsearch.{operation}(...) was called but no mock was registered.\n"
             f"Register a mock with:\n"
-            f"    bigfoot.elasticsearch_mock.mock_operation({operation!r}, returns=...)"
+            f"    bigfoot.elasticsearch.mock_operation({operation!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
@@ -345,7 +345,7 @@ class ElasticsearchPlugin(BasePlugin):
         parts = [f"        {k}={v!r}," for k, v in details.items() if v is not None]
         lines = "\n".join(parts)
         return (
-            f"    bigfoot.elasticsearch_mock.assert_{operation}(\n"
+            f"    bigfoot.elasticsearch.assert_{operation}(\n"
             f"{lines}\n"
             f"    )"
         )

--- a/src/bigfoot/plugins/file_io_plugin.py
+++ b/src/bigfoot/plugins/file_io_plugin.py
@@ -708,7 +708,7 @@ class FileIoPlugin(BasePlugin):
         source_id = interaction.source_id
         operation = source_id.split(":", 1)[-1] if ":" in source_id else source_id
         path = interaction.details.get("path", interaction.details.get("src", "?"))
-        return f"    bigfoot.file_io_mock.mock_operation('{operation}', '{path}', returns=...)"
+        return f"    bigfoot.file_io.mock_operation('{operation}', '{path}', returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -722,7 +722,7 @@ class FileIoPlugin(BasePlugin):
         return (
             f"{display}('{path}', ...) was called but no mock was registered.\n"
             f"Register a mock with:\n"
-            f"    bigfoot.file_io_mock.mock_operation('{operation}', '{path}', returns=...)"
+            f"    bigfoot.file_io.mock_operation('{operation}', '{path}', returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
@@ -730,7 +730,7 @@ class FileIoPlugin(BasePlugin):
         operation = source_id.split(":", 1)[-1] if ":" in source_id else source_id
         helper = _OP_ASSERT_HELPER.get(operation, f"assert_{operation}")
 
-        lines = [f"    bigfoot.file_io_mock.{helper}("]
+        lines = [f"    bigfoot.file_io.{helper}("]
         for key, val in interaction.details.items():
             lines.append(f"        {key}={val!r},")
         lines.append("    )")

--- a/src/bigfoot/plugins/grpc_plugin.py
+++ b/src/bigfoot/plugins/grpc_plugin.py
@@ -445,7 +445,7 @@ class GrpcPlugin(BasePlugin):
     def format_mock_hint(self, interaction: Interaction) -> str:
         call_type = interaction.details.get("call_type", "?")
         method = interaction.details.get("method", "?")
-        return f"    bigfoot.grpc_mock.mock_{call_type}({method!r}, returns=...)"
+        return f"    bigfoot.grpc.mock_{call_type}({method!r}, returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -460,11 +460,11 @@ class GrpcPlugin(BasePlugin):
         return (
             f"grpc.{call_type}({method!r}) was called but no mock was registered.\n"
             f"Register a mock with:\n"
-            f"    bigfoot.grpc_mock.mock_{call_type}({method!r}, returns=...)"
+            f"    bigfoot.grpc.mock_{call_type}({method!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
-        sm = "bigfoot.grpc_mock"
+        sm = "bigfoot.grpc"
         call_type = interaction.details.get("call_type", "?")
         method = interaction.details.get("method", "?")
         request = interaction.details.get("request")

--- a/src/bigfoot/plugins/jwt_plugin.py
+++ b/src/bigfoot/plugins/jwt_plugin.py
@@ -279,7 +279,7 @@ class JwtPlugin(BasePlugin):
     def format_mock_hint(self, interaction: Interaction) -> str:
         source_id = interaction.source_id
         operation = source_id.split(":", 1)[-1] if ":" in source_id else "?"
-        return f"    bigfoot.jwt_mock.mock_{operation}(returns=...)"
+        return f"    bigfoot.jwt.mock_{operation}(returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -291,7 +291,7 @@ class JwtPlugin(BasePlugin):
         return (
             f"jwt.{operation}(...) was called but no mock was registered.\n"
             f"Register a mock with:\n"
-            f"    bigfoot.jwt_mock.mock_{operation}(returns=...)"
+            f"    bigfoot.jwt.mock_{operation}(returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
@@ -301,7 +301,7 @@ class JwtPlugin(BasePlugin):
         parts = [f"        {k}={v!r}," for k, v in details.items()]
         lines = "\n".join(parts)
         return (
-            f"    bigfoot.jwt_mock.assert_{operation}(\n"
+            f"    bigfoot.jwt.assert_{operation}(\n"
             f"{lines}\n"
             f"    )"
         )

--- a/src/bigfoot/plugins/logging_plugin.py
+++ b/src/bigfoot/plugins/logging_plugin.py
@@ -133,7 +133,7 @@ class LoggingPlugin(BasePlugin):
     def install(self) -> None:
         """No-op. Called to ensure plugin is registered before sandbox entry.
 
-        Access to any attribute of log_mock triggers plugin creation via
+        Access to any attribute of log triggers plugin creation via
         _LoggingProxy.__getattr__. This method exists as a named no-op so
         tests that want the interceptor active without any mocks have an
         explicit API to call.
@@ -339,7 +339,7 @@ class LoggingPlugin(BasePlugin):
         message = interaction.details.get("message", "")
         logger_name = interaction.details.get("logger_name", "root")
         return (
-            f"    bigfoot.log_mock.mock_log("
+            f"    bigfoot.log.mock_log("
             f"{level!r}, {message!r}, logger_name={logger_name!r})"
         )
 
@@ -356,11 +356,11 @@ class LoggingPlugin(BasePlugin):
         return (
             f"logging.{level.lower()}({message!r}) was called.\n"
             f"Register it with:\n"
-            f"    bigfoot.log_mock.mock_log({level!r}, {message!r})"
+            f"    bigfoot.log.mock_log({level!r}, {message!r})"
         )
 
     def format_assert_hint(self, interaction: "Interaction") -> str:
-        lm = "bigfoot.log_mock"
+        lm = "bigfoot.log"
         level = interaction.details.get("level", "INFO")
         message = interaction.details.get("message", "")
         logger_name = interaction.details.get("logger_name", "root")

--- a/src/bigfoot/plugins/mcp_plugin.py
+++ b/src/bigfoot/plugins/mcp_plugin.py
@@ -584,7 +584,7 @@ class McpPlugin(BasePlugin):
     def format_mock_hint(self, interaction: Interaction) -> str:
         direction = interaction.details.get("direction", "?")
         method = interaction.details.get("method", "?")
-        prefix = "bigfoot.mcp_mock"
+        prefix = "bigfoot.mcp"
         if direction == "server":
             if method == "call_tool":
                 tool_name = interaction.details.get("tool_name", "?")
@@ -618,7 +618,7 @@ class McpPlugin(BasePlugin):
         direction = parts[1] if len(parts) > 1 else "?"
         method = parts[2] if len(parts) > 2 else "?"
         key = parts[3] if len(parts) > 3 else "?"
-        prefix = "bigfoot.mcp_mock"
+        prefix = "bigfoot.mcp"
 
         if direction == "server":
             mock_fn = f"mock_server_{method}"
@@ -632,7 +632,7 @@ class McpPlugin(BasePlugin):
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
-        sm = "bigfoot.mcp_mock"
+        sm = "bigfoot.mcp"
         direction = interaction.details.get("direction", "?")
         method = interaction.details.get("method", "?")
 

--- a/src/bigfoot/plugins/memcache_plugin.py
+++ b/src/bigfoot/plugins/memcache_plugin.py
@@ -296,7 +296,7 @@ class MemcachePlugin(BasePlugin):
 
     def format_mock_hint(self, interaction: Interaction) -> str:
         command = interaction.details.get("command", "?")
-        return f"    bigfoot.memcache_mock.mock_command({command!r}, returns=...)"
+        return f"    bigfoot.memcache.mock_command({command!r}, returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -308,11 +308,11 @@ class MemcachePlugin(BasePlugin):
         return (
             f"memcache.{cmd}(...) was called but no mock was registered.\n"
             f"Register a mock with:\n"
-            f"    bigfoot.memcache_mock.mock_command({cmd!r}, returns=...)"
+            f"    bigfoot.memcache.mock_command({cmd!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
-        sm = "bigfoot.memcache_mock"
+        sm = "bigfoot.memcache"
         command = interaction.details.get("command", "?")
         # Determine which helper to suggest
         helper = f"assert_{command.lower()}"

--- a/src/bigfoot/plugins/mongo_plugin.py
+++ b/src/bigfoot/plugins/mongo_plugin.py
@@ -401,7 +401,7 @@ class MongoPlugin(BasePlugin):
 
     def format_mock_hint(self, interaction: Interaction) -> str:
         operation = interaction.details.get("operation", "?")
-        return f"    bigfoot.mongo_mock.mock_operation({operation!r}, returns=...)"
+        return f"    bigfoot.mongo.mock_operation({operation!r}, returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -413,11 +413,11 @@ class MongoPlugin(BasePlugin):
         return (
             f"mongo.{op}(...) was called but no mock was registered.\n"
             f"Register a mock with:\n"
-            f"    bigfoot.mongo_mock.mock_operation({op!r}, returns=...)"
+            f"    bigfoot.mongo.mock_operation({op!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
-        sm = "bigfoot.mongo_mock"
+        sm = "bigfoot.mongo"
         operation = interaction.details.get("operation", "?")
         helper_name = _ASSERT_HELPER_NAMES.get(operation, f"assert_{operation}")
 

--- a/src/bigfoot/plugins/native_plugin.py
+++ b/src/bigfoot/plugins/native_plugin.py
@@ -376,7 +376,7 @@ class NativePlugin(BasePlugin):
     def format_mock_hint(self, interaction: Interaction) -> str:
         library = interaction.details.get("library", "?")
         function = interaction.details.get("function", "?")
-        return f"    bigfoot.native_mock.mock_call({library!r}, {function!r}, returns=...)"
+        return f"    bigfoot.native.mock_call({library!r}, {function!r}, returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -391,11 +391,11 @@ class NativePlugin(BasePlugin):
         return (
             f"{library}.{function}(...) was called but no mock was registered.\n"
             f"Register a mock with:\n"
-            f"    bigfoot.native_mock.mock_call({library!r}, {function!r}, returns=...)"
+            f"    bigfoot.native.mock_call({library!r}, {function!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
-        sm = "bigfoot.native_mock"
+        sm = "bigfoot.native"
         library = interaction.details.get("library", "?")
         function = interaction.details.get("function", "?")
         args = interaction.details.get("args", ())

--- a/src/bigfoot/plugins/pika_plugin.py
+++ b/src/bigfoot/plugins/pika_plugin.py
@@ -342,7 +342,7 @@ class PikaPlugin(StateMachinePlugin):
     def format_mock_hint(self, interaction: Interaction) -> str:
         sid = interaction.source_id
         method = sid.split(":")[-1] if ":" in sid else sid
-        return f"    bigfoot.pika_mock.new_session().expect({method!r}, returns=...)"
+        return f"    bigfoot.pika.new_session().expect({method!r}, returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -354,11 +354,11 @@ class PikaPlugin(StateMachinePlugin):
         return (
             f"pika.BlockingConnection.{method}(...) was called but no session was queued.\n"
             f"Register a session with:\n"
-            f"    bigfoot.pika_mock.new_session().expect({method!r}, returns=...)"
+            f"    bigfoot.pika.new_session().expect({method!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
-        sm = "bigfoot.pika_mock"
+        sm = "bigfoot.pika"
         sid = interaction.source_id
         if sid == _SOURCE_CONNECT:
             host = interaction.details.get("host", "?")

--- a/src/bigfoot/plugins/popen_plugin.py
+++ b/src/bigfoot/plugins/popen_plugin.py
@@ -287,15 +287,15 @@ class PopenPlugin(StateMachinePlugin):
 
     def format_mock_hint(self, interaction: Interaction) -> str:
         if interaction.source_id == _SOURCE_SPAWN:
-            return "    bigfoot.popen_mock.new_session().expect('spawn', returns=None)"
+            return "    bigfoot.popen.new_session().expect('spawn', returns=None)"
         if interaction.source_id == _SOURCE_COMMUNICATE:
             return (
-                "    bigfoot.popen_mock.new_session()"
+                "    bigfoot.popen.new_session()"
                 ".expect('communicate', returns=(b'', b'', 0))"
             )
         if interaction.source_id == _SOURCE_WAIT:
-            return "    bigfoot.popen_mock.new_session().expect('wait', returns=0)"
-        return "    bigfoot.popen_mock.new_session().expect('?', returns=...)"
+            return "    bigfoot.popen.new_session().expect('wait', returns=0)"
+        return "    bigfoot.popen.new_session().expect('?', returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -307,11 +307,11 @@ class PopenPlugin(StateMachinePlugin):
         return (
             f"subprocess.Popen.{method}(...) was called but no session was queued.\n"
             f"Register a session with:\n"
-            f"    bigfoot.popen_mock.new_session().expect({method!r}, returns=...)"
+            f"    bigfoot.popen.new_session().expect({method!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
-        pm = "bigfoot.popen_mock"
+        pm = "bigfoot.popen"
         sid = interaction.source_id
         if sid == _SOURCE_SPAWN:
             command = interaction.details.get("command", [])

--- a/src/bigfoot/plugins/psycopg2_plugin.py
+++ b/src/bigfoot/plugins/psycopg2_plugin.py
@@ -291,7 +291,7 @@ class Psycopg2Plugin(StateMachinePlugin):
 
     def format_mock_hint(self, interaction: Interaction) -> str:
         method = interaction.details.get("method", "?")
-        return f"    bigfoot.psycopg2_mock.new_session().expect({method!r}, returns=...)"
+        return f"    bigfoot.psycopg2.new_session().expect({method!r}, returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -303,11 +303,11 @@ class Psycopg2Plugin(StateMachinePlugin):
         return (
             f"psycopg2.{method}(...) was called but no session was queued.\n"
             f"Register a session with:\n"
-            f"    bigfoot.psycopg2_mock.new_session().expect({method!r}, returns=...)"
+            f"    bigfoot.psycopg2.new_session().expect({method!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
-        sm = "bigfoot.psycopg2_mock"
+        sm = "bigfoot.psycopg2"
         sid = interaction.source_id
         if sid == _SOURCE_CONNECT:
             # Show whichever connect fields were recorded

--- a/src/bigfoot/plugins/redis_plugin.py
+++ b/src/bigfoot/plugins/redis_plugin.py
@@ -265,7 +265,7 @@ class RedisPlugin(BasePlugin):
 
     def format_mock_hint(self, interaction: Interaction) -> str:
         command = interaction.details.get("command", "?")
-        return f"    bigfoot.redis_mock.mock_command({command!r}, returns=...)"
+        return f"    bigfoot.redis.mock_command({command!r}, returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -278,11 +278,11 @@ class RedisPlugin(BasePlugin):
         return (
             f"redis.{cmd}(...) was called but no mock was registered.\n"
             f"Register a mock with:\n"
-            f"    bigfoot.redis_mock.mock_command({cmd!r}, returns=...)"
+            f"    bigfoot.redis.mock_command({cmd!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
-        sm = "bigfoot.redis_mock"
+        sm = "bigfoot.redis"
         command = interaction.details.get("command", "?")
         args = interaction.details.get("args", ())
         kwargs = interaction.details.get("kwargs", {})

--- a/src/bigfoot/plugins/smtp_plugin.py
+++ b/src/bigfoot/plugins/smtp_plugin.py
@@ -311,7 +311,7 @@ class SmtpPlugin(StateMachinePlugin):
     def format_mock_hint(self, interaction: Interaction) -> str:
         sid = interaction.source_id
         method = sid.split(":")[-1] if ":" in sid else sid
-        return f"    bigfoot.smtp_mock.new_session().expect({method!r}, returns=...)"
+        return f"    bigfoot.smtp.new_session().expect({method!r}, returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -323,11 +323,11 @@ class SmtpPlugin(StateMachinePlugin):
         return (
             f"smtplib.SMTP.{method}(...) was called but no session was queued.\n"
             f"Register a session with:\n"
-            f"    bigfoot.smtp_mock.new_session().expect({method!r}, returns=...)"
+            f"    bigfoot.smtp.new_session().expect({method!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
-        sm = "bigfoot.smtp_mock"
+        sm = "bigfoot.smtp"
         sid = interaction.source_id
         if sid == _SOURCE_CONNECT:
             host = interaction.details.get("host", "?")

--- a/src/bigfoot/plugins/socket_plugin.py
+++ b/src/bigfoot/plugins/socket_plugin.py
@@ -281,7 +281,7 @@ class SocketPlugin(StateMachinePlugin):
     def format_mock_hint(self, interaction: Interaction) -> str:
         sid = interaction.source_id
         method = sid.split(":", 1)[-1] if ":" in sid else sid
-        return f"    bigfoot.socket_mock.new_session().expect({method!r}, returns=...)"
+        return f"    bigfoot.socket.new_session().expect({method!r}, returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -293,11 +293,11 @@ class SocketPlugin(StateMachinePlugin):
         return (
             f"socket.socket.{method}(...) was called but no session was queued.\n"
             f"Register a session with:\n"
-            f"    bigfoot.socket_mock.new_session().expect({method!r}, returns=...)"
+            f"    bigfoot.socket.new_session().expect({method!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
-        sm = "bigfoot.socket_mock"
+        sm = "bigfoot.socket"
         sid = interaction.source_id
         if sid == _SOURCE_CONNECT:
             host = interaction.details.get("host", "?")

--- a/src/bigfoot/plugins/ssh_plugin.py
+++ b/src/bigfoot/plugins/ssh_plugin.py
@@ -412,7 +412,7 @@ class SshPlugin(StateMachinePlugin):
     def format_mock_hint(self, interaction: Interaction) -> str:
         sid = interaction.source_id
         method = sid.split(":")[-1] if ":" in sid else sid
-        return f"    bigfoot.ssh_mock.new_session().expect({method!r}, returns=...)"
+        return f"    bigfoot.ssh.new_session().expect({method!r}, returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -424,11 +424,11 @@ class SshPlugin(StateMachinePlugin):
         return (
             f"paramiko.SSHClient.{method}(...) was called but no session was queued.\n"
             f"Register a session with:\n"
-            f"    bigfoot.ssh_mock.new_session().expect({method!r}, returns=...)"
+            f"    bigfoot.ssh.new_session().expect({method!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
-        sm = "bigfoot.ssh_mock"
+        sm = "bigfoot.ssh"
         sid = interaction.source_id
         if sid == _SOURCE_CONNECT:
             hostname = interaction.details.get("hostname", "?")

--- a/src/bigfoot/plugins/subprocess.py
+++ b/src/bigfoot/plugins/subprocess.py
@@ -162,7 +162,7 @@ class SubprocessPlugin(BasePlugin):
     def install(self) -> None:
         """No-op. Called to ensure plugin is registered before sandbox entry.
 
-        Access to any attribute of subprocess_mock triggers plugin creation via
+        Access to any attribute of subprocess triggers plugin creation via
         _SubprocessProxy.__getattr__. This method exists as a named no-op so
         tests that want the bouncer active without any mocks have an explicit
         API to call.
@@ -469,7 +469,7 @@ class SubprocessPlugin(BasePlugin):
             rc = interaction.details.get("returncode", 0)
             stdout = interaction.details.get("stdout", "")
             stderr = interaction.details.get("stderr", "")
-            parts = [f"    bigfoot.subprocess_mock.mock_run({cmd!r}"]
+            parts = [f"    bigfoot.subprocess.mock_run({cmd!r}"]
             if rc != 0:
                 parts.append(f", returncode={rc!r}")
             if stdout:
@@ -481,7 +481,7 @@ class SubprocessPlugin(BasePlugin):
         if interaction.source_id == _SOURCE_WHICH:
             name = interaction.details.get("name", "?")
             returns = interaction.details.get("returns")
-            return f"    bigfoot.subprocess_mock.mock_which({name!r}, returns={returns!r})"
+            return f"    bigfoot.subprocess.mock_which({name!r}, returns={returns!r})"
         return f"    # unknown source_id={interaction.source_id!r}"
 
     def format_unmocked_hint(
@@ -495,19 +495,19 @@ class SubprocessPlugin(BasePlugin):
             return (
                 f"subprocess.run({list(cmd)!r}) was called but no mock was registered.\n"
                 f"Register it with:\n"
-                f"    bigfoot.subprocess_mock.mock_run({list(cmd)!r})"
+                f"    bigfoot.subprocess.mock_run({list(cmd)!r})"
             )
         if source_id == _SOURCE_WHICH:
             name = args[0] if args else kwargs.get("name", "?")
             return (
                 f"shutil.which({name!r}) was called but no mock was registered.\n"
                 f"Register it with:\n"
-                f"    bigfoot.subprocess_mock.mock_which({name!r}, returns='/path/to/{name}')"
+                f"    bigfoot.subprocess.mock_which({name!r}, returns='/path/to/{name}')"
             )
         return f"Unmocked call to source_id={source_id!r}"
 
     def format_assert_hint(self, interaction: "Interaction") -> str:
-        sm = "bigfoot.subprocess_mock"
+        sm = "bigfoot.subprocess"
         if interaction.source_id == _SOURCE_RUN:
             cmd = interaction.details.get("command", [])
             rc = interaction.details.get("returncode", 0)

--- a/src/bigfoot/plugins/websocket_plugin.py
+++ b/src/bigfoot/plugins/websocket_plugin.py
@@ -286,7 +286,7 @@ class AsyncWebSocketPlugin(StateMachinePlugin):
     def format_mock_hint(self, interaction: Interaction) -> str:
         sid = interaction.source_id
         step = sid.split(":")[-1] if ":" in sid else sid
-        return f"    bigfoot.async_websocket_mock.new_session().expect({step!r}, returns=...)"
+        return f"    bigfoot.async_websocket.new_session().expect({step!r}, returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -298,11 +298,11 @@ class AsyncWebSocketPlugin(StateMachinePlugin):
         return (
             f"websockets.{method}(...) was called but no session was queued.\n"
             f"Register a session with:\n"
-            f"    bigfoot.async_websocket_mock.new_session().expect({method!r}, returns=...)"
+            f"    bigfoot.async_websocket.new_session().expect({method!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
-        sm = "bigfoot.async_websocket_mock"
+        sm = "bigfoot.async_websocket"
         sid = interaction.source_id
         if sid == _ASYNC_SOURCE_CONNECT:
             uri = interaction.details.get("uri", "?")
@@ -542,7 +542,7 @@ class SyncWebSocketPlugin(StateMachinePlugin):
     def format_mock_hint(self, interaction: Interaction) -> str:
         sid = interaction.source_id
         step = sid.split(":")[-1] if ":" in sid else sid
-        return f"    bigfoot.sync_websocket_mock.new_session().expect({step!r}, returns=...)"
+        return f"    bigfoot.sync_websocket.new_session().expect({step!r}, returns=...)"
 
     def format_unmocked_hint(
         self,
@@ -554,11 +554,11 @@ class SyncWebSocketPlugin(StateMachinePlugin):
         return (
             f"websocket.{method}(...) was called but no session was queued.\n"
             f"Register a session with:\n"
-            f"    bigfoot.sync_websocket_mock.new_session().expect({method!r}, returns=...)"
+            f"    bigfoot.sync_websocket.new_session().expect({method!r}, returns=...)"
         )
 
     def format_assert_hint(self, interaction: Interaction) -> str:
-        sm = "bigfoot.sync_websocket_mock"
+        sm = "bigfoot.sync_websocket"
         sid = interaction.source_id
         if sid == _SYNC_SOURCE_CONNECT:
             uri = interaction.details.get("uri", "?")

--- a/tests/unit/test_async_subprocess_plugin.py
+++ b/tests/unit/test_async_subprocess_plugin.py
@@ -478,7 +478,7 @@ async def test_format_assert_hint() -> None:
 
     interactions = v._timeline._interactions
     hint = p.format_assert_hint(interactions[0])
-    assert "async_subprocess_mock" in hint
+    assert "bigfoot.async_subprocess" in hint
     assert "assert_spawn" in hint
 
     v.assert_interaction(p.spawn, command=["cmd"], stdin=None)
@@ -494,7 +494,7 @@ async def test_format_mock_hint() -> None:
 
     interactions = v._timeline._interactions
     hint = p.format_mock_hint(interactions[0])
-    assert "async_subprocess_mock" in hint
+    assert "bigfoot.async_subprocess" in hint
     assert "spawn" in hint
 
     v.assert_interaction(p.spawn, command=["cmd"], stdin=None)
@@ -509,7 +509,7 @@ def test_format_unmocked_hint() -> None:
     v, p = _make_verifier_with_plugin()
     hint = p.format_unmocked_hint("asyncio:subprocess:spawn", (), {})
     assert "asyncio.create_subprocess" in hint
-    assert "async_subprocess_mock" in hint
+    assert "bigfoot.async_subprocess" in hint
 
 
 # ---------------------------------------------------------------------------
@@ -529,14 +529,14 @@ def test_format_unused_mock_hint() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.async_subprocess_mock
+# Module-level proxy: bigfoot.async_subprocess
 # ---------------------------------------------------------------------------
 
 
 def test_async_subprocess_mock_proxy_new_session(bigfoot_verifier: StrictVerifier) -> None:
     from bigfoot._state_machine_plugin import SessionHandle
 
-    session = bigfoot.async_subprocess_mock.new_session()
+    session = bigfoot.async_subprocess.new_session()
     assert isinstance(session, SessionHandle)
     result = session.expect("spawn", returns=None, required=False)
     assert result is session
@@ -548,7 +548,7 @@ def test_async_subprocess_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.async_subprocess_mock.new_session
+            _ = bigfoot.async_subprocess.new_session
     finally:
         _current_test_verifier.reset(token)
 
@@ -598,7 +598,7 @@ def test_conflict_error_shell_already_patched() -> None:
 
 
 async def test_assertion_helpers_via_proxy(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.async_subprocess_mock.new_session()
+    session = bigfoot.async_subprocess.new_session()
     session.expect("spawn", returns=None)
     session.expect("communicate", returns=(b"output", b"", 0))
 
@@ -606,8 +606,8 @@ async def test_assertion_helpers_via_proxy(bigfoot_verifier: StrictVerifier) -> 
         proc = await asyncio.create_subprocess_exec("make", "all")
         stdout, stderr = await proc.communicate()
 
-    bigfoot.async_subprocess_mock.assert_spawn(command=["make", "all"], stdin=None)
-    bigfoot.async_subprocess_mock.assert_communicate(input=None)
+    bigfoot.async_subprocess.assert_spawn(command=["make", "all"], stdin=None)
+    bigfoot.async_subprocess.assert_communicate(input=None)
 
     assert stdout == b"output"
     assert stderr == b""
@@ -615,7 +615,7 @@ async def test_assertion_helpers_via_proxy(bigfoot_verifier: StrictVerifier) -> 
 
 
 async def test_assertion_helpers_wait_via_proxy(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.async_subprocess_mock.new_session()
+    session = bigfoot.async_subprocess.new_session()
     session.expect("spawn", returns=None)
     session.expect("wait", returns=0)
 
@@ -623,8 +623,8 @@ async def test_assertion_helpers_wait_via_proxy(bigfoot_verifier: StrictVerifier
         proc = await asyncio.create_subprocess_exec("cmd")
         await proc.wait()
 
-    bigfoot.async_subprocess_mock.assert_spawn(command=["cmd"], stdin=None)
-    bigfoot.async_subprocess_mock.assert_wait()
+    bigfoot.async_subprocess.assert_spawn(command=["cmd"], stdin=None)
+    bigfoot.async_subprocess.assert_wait()
 
 
 # ---------------------------------------------------------------------------
@@ -633,7 +633,7 @@ async def test_assertion_helpers_wait_via_proxy(bigfoot_verifier: StrictVerifier
 
 
 async def test_full_session_via_sandbox(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.async_subprocess_mock.new_session()
+    session = bigfoot.async_subprocess.new_session()
     session.expect("spawn", returns=None)
     session.expect("communicate", returns=(b"build output", b"", 0))
 
@@ -641,8 +641,8 @@ async def test_full_session_via_sandbox(bigfoot_verifier: StrictVerifier) -> Non
         proc = await asyncio.create_subprocess_exec("make", "all")
         stdout, stderr = await proc.communicate()
 
-    bigfoot.async_subprocess_mock.assert_spawn(command=["make", "all"], stdin=None)
-    bigfoot.async_subprocess_mock.assert_communicate(input=None)
+    bigfoot.async_subprocess.assert_spawn(command=["make", "all"], stdin=None)
+    bigfoot.async_subprocess.assert_communicate(input=None)
 
     assert stdout == b"build output"
     assert stderr == b""
@@ -650,7 +650,7 @@ async def test_full_session_via_sandbox(bigfoot_verifier: StrictVerifier) -> Non
 
 
 async def test_full_shell_session_via_sandbox(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.async_subprocess_mock.new_session()
+    session = bigfoot.async_subprocess.new_session()
     session.expect("spawn", returns=None)
     session.expect("communicate", returns=(b"shell output", b"", 0))
 
@@ -658,10 +658,10 @@ async def test_full_shell_session_via_sandbox(bigfoot_verifier: StrictVerifier) 
         proc = await asyncio.create_subprocess_shell("echo hello | tr a-z A-Z")
         stdout, stderr = await proc.communicate()
 
-    bigfoot.async_subprocess_mock.assert_spawn(
+    bigfoot.async_subprocess.assert_spawn(
         command="echo hello | tr a-z A-Z", stdin=None
     )
-    bigfoot.async_subprocess_mock.assert_communicate(input=None)
+    bigfoot.async_subprocess.assert_communicate(input=None)
 
     assert stdout == b"shell output"
     assert stderr == b""

--- a/tests/unit/test_asyncpg_plugin.py
+++ b/tests/unit/test_asyncpg_plugin.py
@@ -327,14 +327,14 @@ async def test_connect_with_empty_queue_raises_unmocked() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.asyncpg_mock
+# Module-level proxy: bigfoot.asyncpg
 # ---------------------------------------------------------------------------
 
 
 def test_asyncpg_mock_proxy_new_session(bigfoot_verifier: StrictVerifier) -> None:
     from bigfoot._state_machine_plugin import SessionHandle
 
-    session = bigfoot.asyncpg_mock.new_session()
+    session = bigfoot.asyncpg.new_session()
     assert isinstance(session, SessionHandle)
     result = session.expect("execute", returns="", required=False)
     assert result is session
@@ -346,7 +346,7 @@ def test_asyncpg_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.asyncpg_mock.new_session
+            _ = bigfoot.asyncpg.new_session
     finally:
         _current_test_verifier.reset(token)
 

--- a/tests/unit/test_boto3_plugin.py
+++ b/tests/unit/test_boto3_plugin.py
@@ -337,7 +337,7 @@ def test_format_mock_hint() -> None:
         plugin=p,
     )
     result = p.format_mock_hint(interaction)
-    assert result == "    bigfoot.boto3_mock.mock_call('s3', 'GetObject', returns=...)"
+    assert result == "    bigfoot.boto3.mock_call('s3', 'GetObject', returns=...)"
 
 
 def test_format_unmocked_hint() -> None:
@@ -346,7 +346,7 @@ def test_format_unmocked_hint() -> None:
     assert result == (
         "s3.GetObject(...) was called but no mock was registered.\n"
         "Register a mock with:\n"
-        "    bigfoot.boto3_mock.mock_call('s3', 'GetObject', returns=...)"
+        "    bigfoot.boto3.mock_call('s3', 'GetObject', returns=...)"
     )
 
 
@@ -360,7 +360,7 @@ def test_format_assert_hint() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        "    bigfoot.boto3_mock.assert_boto3_call(\n"
+        "    bigfoot.boto3.assert_boto3_call(\n"
         "        service='s3',\n"
         "        operation='GetObject',\n"
         "        params={'Bucket': 'b'},\n"
@@ -398,21 +398,21 @@ def test_dynamic_sentinel_different_services() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.boto3_mock
+# Module-level proxy: bigfoot.boto3
 # ---------------------------------------------------------------------------
 
 
 def test_boto3_mock_proxy_mock_call(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.boto3_mock.mock_call("s3", "GetObject", returns={"Body": b"proxied"})
+    bigfoot.boto3.mock_call("s3", "GetObject", returns={"Body": b"proxied"})
 
     with bigfoot.sandbox():
         client = boto3.client("s3", region_name="us-east-1")
         result = client.get_object(Bucket="b", Key="k")
 
     assert result == {"Body": b"proxied"}
-    bigfoot.boto3_mock.assert_boto3_call(
+    bigfoot.boto3.assert_boto3_call(
         "s3", "GetObject", params={"Bucket": "b", "Key": "k"}
     )
 
@@ -424,7 +424,7 @@ def test_boto3_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.boto3_mock.mock_call
+            _ = bigfoot.boto3.mock_call
     finally:
         _current_test_verifier.reset(token)
 
@@ -439,7 +439,7 @@ def test_boto3_plugin_in_all() -> None:
     from bigfoot.plugins.boto3_plugin import Boto3Plugin as _Boto3Plugin
 
     assert bigfoot.Boto3Plugin is _Boto3Plugin
-    assert type(bigfoot.boto3_mock).__name__ == "_Boto3Proxy"
+    assert type(bigfoot.boto3).__name__ == "_Boto3Proxy"
 
 
 # ---------------------------------------------------------------------------
@@ -451,7 +451,7 @@ def test_boto3_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier) 
     """boto3 interactions are NOT auto-asserted."""
     import bigfoot
 
-    bigfoot.boto3_mock.mock_call("s3", "GetObject", returns={"Body": b"val"})
+    bigfoot.boto3.mock_call("s3", "GetObject", returns={"Body": b"val"})
     with bigfoot.sandbox():
         client = boto3.client("s3", region_name="us-east-1")
         client.get_object(Bucket="b", Key="k")
@@ -460,18 +460,18 @@ def test_boto3_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier) 
     interactions = timeline.all_unasserted()
     assert len(interactions) == 1
     assert interactions[0].source_id == "boto3:s3:GetObject"
-    bigfoot.boto3_mock.assert_boto3_call("s3", "GetObject", params={"Bucket": "b", "Key": "k"})
+    bigfoot.boto3.assert_boto3_call("s3", "GetObject", params={"Bucket": "b", "Key": "k"})
 
 
 def test_assert_boto3_call_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
     """assert_boto3_call() asserts the next boto3 interaction."""
     import bigfoot
 
-    bigfoot.boto3_mock.mock_call("s3", "PutObject", returns={"ETag": '"abc"'})
+    bigfoot.boto3.mock_call("s3", "PutObject", returns={"ETag": '"abc"'})
     with bigfoot.sandbox():
         client = boto3.client("s3", region_name="us-east-1")
         client.put_object(Bucket="b", Key="k", Body=b"data")
-    bigfoot.boto3_mock.assert_boto3_call(
+    bigfoot.boto3.assert_boto3_call(
         "s3", "PutObject", params={"Bucket": "b", "Key": "k", "Body": b"data"}
     )
 
@@ -480,21 +480,21 @@ def test_assert_boto3_call_wrong_params_raises(bigfoot_verifier: StrictVerifier)
     """assert_boto3_call() with wrong params raises InteractionMismatchError."""
     import bigfoot
 
-    bigfoot.boto3_mock.mock_call("s3", "GetObject", returns={"Body": b"val"})
+    bigfoot.boto3.mock_call("s3", "GetObject", returns={"Body": b"val"})
     with bigfoot.sandbox():
         client = boto3.client("s3", region_name="us-east-1")
         client.get_object(Bucket="b", Key="k")
     with pytest.raises(InteractionMismatchError):
-        bigfoot.boto3_mock.assert_boto3_call("s3", "GetObject", params={"Bucket": "wrong"})
+        bigfoot.boto3.assert_boto3_call("s3", "GetObject", params={"Bucket": "wrong"})
     # Assert correctly so teardown passes
-    bigfoot.boto3_mock.assert_boto3_call("s3", "GetObject", params={"Bucket": "b", "Key": "k"})
+    bigfoot.boto3.assert_boto3_call("s3", "GetObject", params={"Bucket": "b", "Key": "k"})
 
 
 def test_missing_assertion_fields_raises(bigfoot_verifier: StrictVerifier) -> None:
     """Incomplete fields in assert_interaction raises MissingAssertionFieldsError."""
     import bigfoot
 
-    bigfoot.boto3_mock.mock_call("s3", "GetObject", returns={"Body": b"val"})
+    bigfoot.boto3.mock_call("s3", "GetObject", returns={"Body": b"val"})
     with bigfoot.sandbox():
         client = boto3.client("s3", region_name="us-east-1")
         client.get_object(Bucket="b", Key="k")
@@ -505,4 +505,4 @@ def test_missing_assertion_fields_raises(bigfoot_verifier: StrictVerifier) -> No
     with pytest.raises(MissingAssertionFieldsError):
         bigfoot.assert_interaction(sentinel, service="s3")
     # Assert correctly so teardown passes
-    bigfoot.boto3_mock.assert_boto3_call("s3", "GetObject", params={"Bucket": "b", "Key": "k"})
+    bigfoot.boto3.assert_boto3_call("s3", "GetObject", params={"Bucket": "b", "Key": "k"})

--- a/tests/unit/test_celery_plugin.py
+++ b/tests/unit/test_celery_plugin.py
@@ -200,12 +200,12 @@ def test_mock_apply_async_returns_value() -> None:
 def test_assert_delay_full_assertion(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.celery_mock.mock_delay("myapp.tasks.add", returns="mock-id")
+    bigfoot.celery.mock_delay("myapp.tasks.add", returns="mock-id")
 
     with bigfoot.sandbox():
         add_task.delay(1, 2)
 
-    bigfoot.celery_mock.assert_delay(
+    bigfoot.celery.assert_delay(
         task_name="myapp.tasks.add",
         args=(1, 2),
         kwargs={},
@@ -216,12 +216,12 @@ def test_assert_delay_full_assertion(bigfoot_verifier: StrictVerifier) -> None:
 def test_assert_apply_async_full_assertion(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.celery_mock.mock_apply_async("myapp.tasks.add", returns="mock-id")
+    bigfoot.celery.mock_apply_async("myapp.tasks.add", returns="mock-id")
 
     with bigfoot.sandbox():
         add_task.apply_async(args=(1, 2), countdown=10)
 
-    bigfoot.celery_mock.assert_apply_async(
+    bigfoot.celery.assert_apply_async(
         task_name="myapp.tasks.add",
         args=(1, 2),
         kwargs={},
@@ -361,7 +361,7 @@ def test_missing_assertion_fields(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
     from bigfoot.plugins.celery_plugin import _CelerySentinel
 
-    bigfoot.celery_mock.mock_delay("myapp.tasks.add", returns="mock-id")
+    bigfoot.celery.mock_delay("myapp.tasks.add", returns="mock-id")
 
     with bigfoot.sandbox():
         add_task.delay(1, 2)
@@ -373,7 +373,7 @@ def test_missing_assertion_fields(bigfoot_verifier: StrictVerifier) -> None:
 
     assert "dispatch_method" in exc_info.value.missing_fields
     # Now assert fully so teardown passes
-    bigfoot.celery_mock.assert_delay(
+    bigfoot.celery.assert_delay(
         task_name="myapp.tasks.add",
         args=(1, 2),
         kwargs={},
@@ -389,7 +389,7 @@ def test_missing_assertion_fields(bigfoot_verifier: StrictVerifier) -> None:
 def test_celery_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.celery_mock.mock_delay("myapp.tasks.add", returns="mock-id")
+    bigfoot.celery.mock_delay("myapp.tasks.add", returns="mock-id")
 
     with bigfoot.sandbox():
         add_task.delay(1, 2)
@@ -399,7 +399,7 @@ def test_celery_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier)
     assert len(interactions) == 1
     assert interactions[0].source_id == "celery:myapp.tasks.add:delay"
     # Assert it so verify_all() at teardown succeeds
-    bigfoot.celery_mock.assert_delay(
+    bigfoot.celery.assert_delay(
         task_name="myapp.tasks.add",
         args=(1, 2),
         kwargs={},
@@ -485,7 +485,7 @@ def test_format_mock_hint() -> None:
         plugin=p,
     )
     result = p.format_mock_hint(interaction)
-    assert result == "    bigfoot.celery_mock.mock_delay('myapp.tasks.add', returns=...)"
+    assert result == "    bigfoot.celery.mock_delay('myapp.tasks.add', returns=...)"
 
 
 def test_format_unmocked_hint() -> None:
@@ -494,7 +494,7 @@ def test_format_unmocked_hint() -> None:
     assert result == (
         "celery.delay('myapp.tasks.add', ...) was called but no mock was registered.\n"
         "Register a mock with:\n"
-        "    bigfoot.celery_mock.mock_delay('myapp.tasks.add', returns=...)"
+        "    bigfoot.celery.mock_delay('myapp.tasks.add', returns=...)"
     )
 
 
@@ -514,7 +514,7 @@ def test_format_assert_hint() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        "    bigfoot.celery_mock.assert_delay(\n"
+        "    bigfoot.celery.assert_delay(\n"
         "        task_name='myapp.tasks.add',\n"
         "        dispatch_method='delay',\n"
         "        args=(1, 2),\n"
@@ -540,20 +540,20 @@ def test_format_unused_mock_hint() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.celery_mock
+# Module-level proxy: bigfoot.celery
 # ---------------------------------------------------------------------------
 
 
 def test_celery_mock_proxy_mock_delay(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.celery_mock.mock_delay("myapp.tasks.add", returns="proxy-result")
+    bigfoot.celery.mock_delay("myapp.tasks.add", returns="proxy-result")
 
     with bigfoot.sandbox():
         result = add_task.delay(1, 2)
 
     assert result == "proxy-result"
-    bigfoot.celery_mock.assert_delay(
+    bigfoot.celery.assert_delay(
         task_name="myapp.tasks.add",
         args=(1, 2),
         kwargs={},
@@ -568,7 +568,7 @@ def test_celery_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.celery_mock.mock_delay
+            _ = bigfoot.celery.mock_delay
     finally:
         _current_test_verifier.reset(token)
 
@@ -582,8 +582,8 @@ def test_celery_plugin_in_all() -> None:
     import bigfoot
 
     assert "CeleryPlugin" in bigfoot.__all__
-    assert "celery_mock" in bigfoot.__all__
-    assert type(bigfoot.celery_mock).__name__ == "_CeleryProxy"
+    assert "celery" in bigfoot.__all__
+    assert type(bigfoot.celery).__name__ == "_CeleryProxy"
 
 
 # ---------------------------------------------------------------------------
@@ -594,20 +594,20 @@ def test_celery_plugin_in_all() -> None:
 def test_assert_delay_wrong_args_raises(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.celery_mock.mock_delay("myapp.tasks.add", returns="mock-id")
+    bigfoot.celery.mock_delay("myapp.tasks.add", returns="mock-id")
 
     with bigfoot.sandbox():
         add_task.delay(1, 2)
 
     with pytest.raises(InteractionMismatchError):
-        bigfoot.celery_mock.assert_delay(
+        bigfoot.celery.assert_delay(
             task_name="myapp.tasks.add",
             args=(99, 99),
             kwargs={},
             options={},
         )
     # Assert correctly so teardown passes
-    bigfoot.celery_mock.assert_delay(
+    bigfoot.celery.assert_delay(
         task_name="myapp.tasks.add",
         args=(1, 2),
         kwargs={},

--- a/tests/unit/test_crypto_plugin.py
+++ b/tests/unit/test_crypto_plugin.py
@@ -408,7 +408,7 @@ def test_format_mock_hint() -> None:
         plugin=p,
     )
     result = p.format_mock_hint(interaction)
-    assert result == "    bigfoot.crypto_mock.mock_encrypt(returns=...)"
+    assert result == "    bigfoot.crypto.mock_encrypt(returns=...)"
 
 
 def test_format_unmocked_hint() -> None:
@@ -417,7 +417,7 @@ def test_format_unmocked_hint() -> None:
     assert result == (
         "crypto.fernet_encrypt(...) was called but no mock was registered.\n"
         "Register a mock with:\n"
-        "    bigfoot.crypto_mock.mock_encrypt(returns=...)"
+        "    bigfoot.crypto.mock_encrypt(returns=...)"
     )
 
 
@@ -432,7 +432,7 @@ def test_format_unused_mock_hint() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.crypto_mock
+# Module-level proxy: bigfoot.crypto
 # ---------------------------------------------------------------------------
 
 
@@ -441,14 +441,14 @@ def test_crypto_mock_proxy_mock_encrypt(bigfoot_verifier: StrictVerifier) -> Non
 
     import bigfoot
 
-    bigfoot.crypto_mock.mock_encrypt(returns=b"proxied_encrypted")
+    bigfoot.crypto.mock_encrypt(returns=b"proxied_encrypted")
 
     with bigfoot.sandbox():
         f = Fernet(Fernet.generate_key())
         result = f.encrypt(b"hello")
 
     assert result == b"proxied_encrypted"
-    bigfoot.crypto_mock.assert_encrypt(plaintext_length=5)
+    bigfoot.crypto.assert_encrypt(plaintext_length=5)
 
 
 def test_crypto_mock_proxy_raises_outside_context() -> None:
@@ -458,7 +458,7 @@ def test_crypto_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.crypto_mock.mock_encrypt
+            _ = bigfoot.crypto.mock_encrypt
     finally:
         _current_test_verifier.reset(token)
 
@@ -473,7 +473,7 @@ def test_crypto_plugin_in_all() -> None:
     from bigfoot.plugins.crypto_plugin import CryptoPlugin as _CryptoPlugin
 
     assert bigfoot.CryptoPlugin is _CryptoPlugin
-    assert type(bigfoot.crypto_mock).__name__ == "_CryptoProxy"
+    assert type(bigfoot.crypto).__name__ == "_CryptoProxy"
 
 
 # ---------------------------------------------------------------------------
@@ -486,7 +486,7 @@ def test_crypto_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier)
 
     import bigfoot
 
-    bigfoot.crypto_mock.mock_encrypt(returns=b"encrypted")
+    bigfoot.crypto.mock_encrypt(returns=b"encrypted")
     with bigfoot.sandbox():
         f = Fernet(Fernet.generate_key())
         f.encrypt(b"data")
@@ -495,7 +495,7 @@ def test_crypto_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier)
     interactions = timeline.all_unasserted()
     assert len(interactions) == 1
     assert interactions[0].source_id == "crypto:fernet_encrypt"
-    bigfoot.crypto_mock.assert_encrypt(plaintext_length=4)
+    bigfoot.crypto.assert_encrypt(plaintext_length=4)
 
 
 def test_assert_encrypt_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
@@ -503,11 +503,11 @@ def test_assert_encrypt_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
 
     import bigfoot
 
-    bigfoot.crypto_mock.mock_encrypt(returns=b"encrypted")
+    bigfoot.crypto.mock_encrypt(returns=b"encrypted")
     with bigfoot.sandbox():
         f = Fernet(Fernet.generate_key())
         f.encrypt(b"hello")
-    bigfoot.crypto_mock.assert_encrypt(plaintext_length=5)
+    bigfoot.crypto.assert_encrypt(plaintext_length=5)
 
 
 def test_assert_decrypt_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
@@ -515,23 +515,23 @@ def test_assert_decrypt_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
 
     import bigfoot
 
-    bigfoot.crypto_mock.mock_decrypt(returns=b"decrypted")
+    bigfoot.crypto.mock_decrypt(returns=b"decrypted")
     with bigfoot.sandbox():
         f = Fernet(Fernet.generate_key())
         f.decrypt(b"gAAAAABtoken")
-    bigfoot.crypto_mock.assert_decrypt(token=b"gAAAAABtoken", ttl=None)
+    bigfoot.crypto.assert_decrypt(token=b"gAAAAABtoken", ttl=None)
 
 
 def test_assert_generate_key_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
     mock_key = object()
-    bigfoot.crypto_mock.mock_generate_key(returns=mock_key)
+    bigfoot.crypto.mock_generate_key(returns=mock_key)
     with bigfoot.sandbox():
         from cryptography.hazmat.primitives.asymmetric import rsa
 
         rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    bigfoot.crypto_mock.assert_generate_key(algorithm="RSA", key_size=2048)
+    bigfoot.crypto.assert_generate_key(algorithm="RSA", key_size=2048)
 
 
 def test_assert_encrypt_wrong_params_raises(bigfoot_verifier: StrictVerifier) -> None:
@@ -539,20 +539,20 @@ def test_assert_encrypt_wrong_params_raises(bigfoot_verifier: StrictVerifier) ->
 
     import bigfoot
 
-    bigfoot.crypto_mock.mock_encrypt(returns=b"encrypted")
+    bigfoot.crypto.mock_encrypt(returns=b"encrypted")
     with bigfoot.sandbox():
         f = Fernet(Fernet.generate_key())
         f.encrypt(b"hello")
     with pytest.raises(InteractionMismatchError):
-        bigfoot.crypto_mock.assert_encrypt(plaintext_length=999)
-    bigfoot.crypto_mock.assert_encrypt(plaintext_length=5)
+        bigfoot.crypto.assert_encrypt(plaintext_length=999)
+    bigfoot.crypto.assert_encrypt(plaintext_length=5)
 
 
 def test_missing_assertion_fields_raises(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
     mock_key = object()
-    bigfoot.crypto_mock.mock_generate_key(returns=mock_key)
+    bigfoot.crypto.mock_generate_key(returns=mock_key)
     with bigfoot.sandbox():
         from cryptography.hazmat.primitives.asymmetric import rsa
 
@@ -563,4 +563,4 @@ def test_missing_assertion_fields_raises(bigfoot_verifier: StrictVerifier) -> No
     sentinel = _CryptoSentinel("generate_key")
     with pytest.raises(MissingAssertionFieldsError):
         bigfoot.assert_interaction(sentinel, algorithm="RSA")
-    bigfoot.crypto_mock.assert_generate_key(algorithm="RSA", key_size=2048)
+    bigfoot.crypto.assert_generate_key(algorithm="RSA", key_size=2048)

--- a/tests/unit/test_database_plugin.py
+++ b/tests/unit/test_database_plugin.py
@@ -483,12 +483,12 @@ def test_connect_with_empty_queue_raises_unmocked() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.db_mock
+# Module-level proxy: bigfoot.db
 # ---------------------------------------------------------------------------
 
 
 # ESCAPE: test_db_mock_proxy_new_session
-#   CLAIM: bigfoot.db_mock.new_session() returns a SessionHandle that can
+#   CLAIM: bigfoot.db.new_session() returns a SessionHandle that can
 #          be used to configure a session without importing DatabasePlugin directly.
 #   PATH:  _DatabaseProxy.__getattr__("new_session") -> get verifier -> find/create DatabasePlugin ->
 #          return plugin.new_session.
@@ -499,7 +499,7 @@ def test_connect_with_empty_queue_raises_unmocked() -> None:
 def test_db_mock_proxy_new_session(bigfoot_verifier: StrictVerifier) -> None:
     from bigfoot._state_machine_plugin import SessionHandle
 
-    session = bigfoot.db_mock.new_session()
+    session = bigfoot.db.new_session()
     assert isinstance(session, SessionHandle)
     # Chaining expect() with required=False so it doesn't trigger UnusedMocksError at teardown.
     result = session.expect("execute", returns=[], required=False)
@@ -507,7 +507,7 @@ def test_db_mock_proxy_new_session(bigfoot_verifier: StrictVerifier) -> None:
 
 
 # ESCAPE: test_db_mock_proxy_raises_outside_context
-#   CLAIM: Accessing bigfoot.db_mock outside a test context raises NoActiveVerifierError.
+#   CLAIM: Accessing bigfoot.db outside a test context raises NoActiveVerifierError.
 #   PATH:  _DatabaseProxy.__getattr__ -> _get_test_verifier_or_raise -> NoActiveVerifierError.
 #   CHECK: NoActiveVerifierError raised.
 #   MUTATION: Silently returning None would not raise and hide context failures.
@@ -518,7 +518,7 @@ def test_db_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.db_mock.new_session
+            _ = bigfoot.db.new_session
     finally:
         _current_test_verifier.reset(token)
 

--- a/tests/unit/test_dns_plugin.py
+++ b/tests/unit/test_dns_plugin.py
@@ -158,12 +158,12 @@ def test_mock_getaddrinfo_full_assertion(bigfoot_verifier: StrictVerifier) -> No
     expected_result = [
         (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80))
     ]
-    bigfoot.dns_mock.mock_getaddrinfo("example.com", returns=expected_result)
+    bigfoot.dns.mock_getaddrinfo("example.com", returns=expected_result)
 
     with bigfoot.sandbox():
         socket.getaddrinfo("example.com", 80, socket.AF_INET, socket.SOCK_STREAM, 6)
 
-    bigfoot.dns_mock.assert_getaddrinfo(
+    bigfoot.dns.assert_getaddrinfo(
         host="example.com",
         port=80,
         family=socket.AF_INET,
@@ -179,12 +179,12 @@ def test_mock_getaddrinfo_default_args(bigfoot_verifier: StrictVerifier) -> None
     expected_result = [
         (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80))
     ]
-    bigfoot.dns_mock.mock_getaddrinfo("example.com", returns=expected_result)
+    bigfoot.dns.mock_getaddrinfo("example.com", returns=expected_result)
 
     with bigfoot.sandbox():
         socket.getaddrinfo("example.com", 80)
 
-    bigfoot.dns_mock.assert_getaddrinfo(
+    bigfoot.dns.assert_getaddrinfo(
         host="example.com",
         port=80,
         family=0,
@@ -213,12 +213,12 @@ def test_mock_gethostbyname_full_assertion(bigfoot_verifier: StrictVerifier) -> 
     """assert_gethostbyname asserts hostname field."""
     import bigfoot
 
-    bigfoot.dns_mock.mock_gethostbyname("example.com", returns="93.184.216.34")
+    bigfoot.dns.mock_gethostbyname("example.com", returns="93.184.216.34")
 
     with bigfoot.sandbox():
         socket.gethostbyname("example.com")
 
-    bigfoot.dns_mock.assert_gethostbyname(hostname="example.com")
+    bigfoot.dns.assert_gethostbyname(hostname="example.com")
 
 
 # ---------------------------------------------------------------------------
@@ -286,7 +286,7 @@ def test_missing_assertion_fields_getaddrinfo(bigfoot_verifier: StrictVerifier) 
     import bigfoot
     from bigfoot.plugins.dns_plugin import _DnsSentinel
 
-    bigfoot.dns_mock.mock_getaddrinfo("example.com", returns=[])
+    bigfoot.dns.mock_getaddrinfo("example.com", returns=[])
 
     with bigfoot.sandbox():
         socket.getaddrinfo("example.com", 80)
@@ -298,7 +298,7 @@ def test_missing_assertion_fields_getaddrinfo(bigfoot_verifier: StrictVerifier) 
 
     assert "port" in exc_info.value.missing_fields
     # Now assert fully so teardown passes
-    bigfoot.dns_mock.assert_getaddrinfo(
+    bigfoot.dns.assert_getaddrinfo(
         host="example.com", port=80, family=0, type=0, proto=0,
     )
 
@@ -362,7 +362,7 @@ def test_dns_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier) ->
     """DNS interactions are NOT auto-asserted -- they land on the timeline unasserted."""
     import bigfoot
 
-    bigfoot.dns_mock.mock_gethostbyname("example.com", returns="1.2.3.4")
+    bigfoot.dns.mock_gethostbyname("example.com", returns="1.2.3.4")
     with bigfoot.sandbox():
         socket.gethostbyname("example.com")
 
@@ -371,7 +371,7 @@ def test_dns_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier) ->
     assert len(interactions) == 1
     assert interactions[0].source_id == "dns:gethostbyname:example.com"
     # Assert it so verify_all() at teardown succeeds
-    bigfoot.dns_mock.assert_gethostbyname(hostname="example.com")
+    bigfoot.dns.assert_gethostbyname(hostname="example.com")
 
 
 # ---------------------------------------------------------------------------
@@ -443,7 +443,7 @@ def test_format_mock_hint_getaddrinfo() -> None:
         plugin=p,
     )
     result = p.format_mock_hint(interaction)
-    assert result == "    bigfoot.dns_mock.mock_getaddrinfo('example.com', returns=...)"
+    assert result == "    bigfoot.dns.mock_getaddrinfo('example.com', returns=...)"
 
 
 def test_format_unmocked_hint() -> None:
@@ -452,7 +452,7 @@ def test_format_unmocked_hint() -> None:
     assert result == (
         "socket.getaddrinfo('example.com', ...) was called but no mock was registered.\n"
         "Register a mock with:\n"
-        "    bigfoot.dns_mock.mock_getaddrinfo('example.com', returns=...)"
+        "    bigfoot.dns.mock_getaddrinfo('example.com', returns=...)"
     )
 
 
@@ -466,7 +466,7 @@ def test_format_assert_hint_getaddrinfo() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        "    bigfoot.dns_mock.assert_getaddrinfo(\n"
+        "    bigfoot.dns.assert_getaddrinfo(\n"
         "        host='example.com',\n"
         "        port=80,\n"
         "        family=0,\n"
@@ -488,24 +488,24 @@ def test_format_unused_mock_hint() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.dns_mock
+# Module-level proxy: bigfoot.dns
 # ---------------------------------------------------------------------------
 
 
 def test_dns_mock_proxy_mock_getaddrinfo(bigfoot_verifier: StrictVerifier) -> None:
-    """bigfoot.dns_mock.mock_getaddrinfo works via the proxy."""
+    """bigfoot.dns.mock_getaddrinfo works via the proxy."""
     import bigfoot
 
     expected_result = [
         (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80))
     ]
-    bigfoot.dns_mock.mock_getaddrinfo("example.com", returns=expected_result)
+    bigfoot.dns.mock_getaddrinfo("example.com", returns=expected_result)
 
     with bigfoot.sandbox():
         result = socket.getaddrinfo("example.com", 80)
 
     assert result == expected_result
-    bigfoot.dns_mock.assert_getaddrinfo(
+    bigfoot.dns.assert_getaddrinfo(
         host="example.com",
         port=80,
         family=0,
@@ -515,14 +515,14 @@ def test_dns_mock_proxy_mock_getaddrinfo(bigfoot_verifier: StrictVerifier) -> No
 
 
 def test_dns_mock_proxy_raises_outside_context() -> None:
-    """Accessing bigfoot.dns_mock outside a test context raises NoActiveVerifierError."""
+    """Accessing bigfoot.dns outside a test context raises NoActiveVerifierError."""
     import bigfoot
     from bigfoot._errors import NoActiveVerifierError
 
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.dns_mock.mock_getaddrinfo
+            _ = bigfoot.dns.mock_getaddrinfo
     finally:
         _current_test_verifier.reset(token)
 
@@ -533,12 +533,12 @@ def test_dns_mock_proxy_raises_outside_context() -> None:
 
 
 def test_dns_plugin_in_all() -> None:
-    """DnsPlugin and dns_mock are exported from bigfoot."""
+    """DnsPlugin and dns are exported from bigfoot."""
     import bigfoot
 
     assert "DnsPlugin" in bigfoot.__all__
-    assert "dns_mock" in bigfoot.__all__
-    assert type(bigfoot.dns_mock).__name__ == "_DnsProxy"
+    assert "dns" in bigfoot.__all__
+    assert type(bigfoot.dns).__name__ == "_DnsProxy"
 
 
 # ---------------------------------------------------------------------------
@@ -550,13 +550,13 @@ def test_assert_getaddrinfo_wrong_args_raises(bigfoot_verifier: StrictVerifier) 
     """assert_getaddrinfo with wrong values raises InteractionMismatchError."""
     import bigfoot
 
-    bigfoot.dns_mock.mock_getaddrinfo("example.com", returns=[])
+    bigfoot.dns.mock_getaddrinfo("example.com", returns=[])
 
     with bigfoot.sandbox():
         socket.getaddrinfo("example.com", 80)
 
     with pytest.raises(InteractionMismatchError):
-        bigfoot.dns_mock.assert_getaddrinfo(
+        bigfoot.dns.assert_getaddrinfo(
             host="wrong.com",
             port=80,
             family=0,
@@ -564,7 +564,7 @@ def test_assert_getaddrinfo_wrong_args_raises(bigfoot_verifier: StrictVerifier) 
             proto=0,
         )
     # Assert correctly so teardown passes
-    bigfoot.dns_mock.assert_getaddrinfo(
+    bigfoot.dns.assert_getaddrinfo(
         host="example.com",
         port=80,
         family=0,
@@ -601,14 +601,14 @@ class TestDnsResolve:
         """assert_resolve asserts qname and rdtype fields."""
         import bigfoot
 
-        bigfoot.dns_mock.mock_resolve("example.com", "A", returns=["93.184.216.34"])
+        bigfoot.dns.mock_resolve("example.com", "A", returns=["93.184.216.34"])
 
         with bigfoot.sandbox():
             import dns.resolver
 
             dns.resolver.resolve("example.com", "A")
 
-        bigfoot.dns_mock.assert_resolve(qname="example.com", rdtype="A")
+        bigfoot.dns.assert_resolve(qname="example.com", rdtype="A")
 
     def test_unmocked_resolve_raises(self) -> None:
         """resolve without mock raises UnmockedInteractionError."""

--- a/tests/unit/test_elasticsearch_plugin.py
+++ b/tests/unit/test_elasticsearch_plugin.py
@@ -339,7 +339,7 @@ def test_format_mock_hint() -> None:
         plugin=p,
     )
     result = p.format_mock_hint(interaction)
-    assert result == "    bigfoot.elasticsearch_mock.mock_operation('search', returns=...)"
+    assert result == "    bigfoot.elasticsearch.mock_operation('search', returns=...)"
 
 
 def test_format_unmocked_hint() -> None:
@@ -348,7 +348,7 @@ def test_format_unmocked_hint() -> None:
     assert result == (
         "elasticsearch.index(...) was called but no mock was registered.\n"
         "Register a mock with:\n"
-        "    bigfoot.elasticsearch_mock.mock_operation('index', returns=...)"
+        "    bigfoot.elasticsearch.mock_operation('index', returns=...)"
     )
 
 
@@ -362,7 +362,7 @@ def test_format_assert_hint() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        "    bigfoot.elasticsearch_mock.assert_index(\n"
+        "    bigfoot.elasticsearch.assert_index(\n"
         "        index='my-index',\n"
         "        document={'a': 1},\n"
         "    )"
@@ -380,21 +380,21 @@ def test_format_unused_mock_hint() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.elasticsearch_mock
+# Module-level proxy: bigfoot.elasticsearch
 # ---------------------------------------------------------------------------
 
 
 def test_elasticsearch_mock_proxy_mock_operation(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.elasticsearch_mock.mock_operation("index", returns={"_id": "1"})
+    bigfoot.elasticsearch.mock_operation("index", returns={"_id": "1"})
 
     with bigfoot.sandbox():
         es = elasticsearch.Elasticsearch("http://localhost:9200")
         result = es.index(index="my-index", document={"field": "val"})
 
     assert result == {"_id": "1"}
-    bigfoot.elasticsearch_mock.assert_index(index="my-index", document={"field": "val"})
+    bigfoot.elasticsearch.assert_index(index="my-index", document={"field": "val"})
 
 
 def test_elasticsearch_mock_proxy_raises_outside_context() -> None:
@@ -404,7 +404,7 @@ def test_elasticsearch_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.elasticsearch_mock.mock_operation
+            _ = bigfoot.elasticsearch.mock_operation
     finally:
         _current_test_verifier.reset(token)
 
@@ -421,7 +421,7 @@ def test_elasticsearch_plugin_in_all() -> None:
     )
 
     assert bigfoot.ElasticsearchPlugin is _ElasticsearchPlugin
-    assert type(bigfoot.elasticsearch_mock).__name__ == "_ElasticsearchProxy"
+    assert type(bigfoot.elasticsearch).__name__ == "_ElasticsearchProxy"
 
 
 # ---------------------------------------------------------------------------
@@ -432,7 +432,7 @@ def test_elasticsearch_plugin_in_all() -> None:
 def test_elasticsearch_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.elasticsearch_mock.mock_operation("index", returns={"_id": "1"})
+    bigfoot.elasticsearch.mock_operation("index", returns={"_id": "1"})
     with bigfoot.sandbox():
         es = elasticsearch.Elasticsearch("http://localhost:9200")
         es.index(index="idx", document={"a": 1})
@@ -441,78 +441,78 @@ def test_elasticsearch_interactions_not_auto_asserted(bigfoot_verifier: StrictVe
     interactions = timeline.all_unasserted()
     assert len(interactions) == 1
     assert interactions[0].source_id == "elasticsearch:index"
-    bigfoot.elasticsearch_mock.assert_index(index="idx", document={"a": 1})
+    bigfoot.elasticsearch.assert_index(index="idx", document={"a": 1})
 
 
 def test_assert_index_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.elasticsearch_mock.mock_operation("index", returns={"_id": "1"})
+    bigfoot.elasticsearch.mock_operation("index", returns={"_id": "1"})
     with bigfoot.sandbox():
         es = elasticsearch.Elasticsearch("http://localhost:9200")
         es.index(index="idx", document={"a": 1})
-    bigfoot.elasticsearch_mock.assert_index(index="idx", document={"a": 1})
+    bigfoot.elasticsearch.assert_index(index="idx", document={"a": 1})
 
 
 def test_assert_search_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.elasticsearch_mock.mock_operation("search", returns={"hits": {"hits": []}})
+    bigfoot.elasticsearch.mock_operation("search", returns={"hits": {"hits": []}})
     with bigfoot.sandbox():
         es = elasticsearch.Elasticsearch("http://localhost:9200")
         es.search(index="idx", query={"match_all": {}})
-    bigfoot.elasticsearch_mock.assert_search(index="idx", query={"match_all": {}})
+    bigfoot.elasticsearch.assert_search(index="idx", query={"match_all": {}})
 
 
 def test_assert_get_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.elasticsearch_mock.mock_operation("get", returns={"_source": {"a": 1}})
+    bigfoot.elasticsearch.mock_operation("get", returns={"_source": {"a": 1}})
     with bigfoot.sandbox():
         es = elasticsearch.Elasticsearch("http://localhost:9200")
         es.get(index="idx", id="1")
-    bigfoot.elasticsearch_mock.assert_get(index="idx", id="1")
+    bigfoot.elasticsearch.assert_get(index="idx", id="1")
 
 
 def test_assert_delete_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.elasticsearch_mock.mock_operation("delete", returns={"result": "deleted"})
+    bigfoot.elasticsearch.mock_operation("delete", returns={"result": "deleted"})
     with bigfoot.sandbox():
         es = elasticsearch.Elasticsearch("http://localhost:9200")
         es.delete(index="idx", id="1")
-    bigfoot.elasticsearch_mock.assert_delete(index="idx", id="1")
+    bigfoot.elasticsearch.assert_delete(index="idx", id="1")
 
 
 def test_assert_bulk_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
     ops = [{"index": {"_index": "idx", "_id": "1"}}, {"field": "val"}]
-    bigfoot.elasticsearch_mock.mock_operation("bulk", returns={"items": []})
+    bigfoot.elasticsearch.mock_operation("bulk", returns={"items": []})
     with bigfoot.sandbox():
         es = elasticsearch.Elasticsearch("http://localhost:9200")
         es.bulk(operations=ops)
-    bigfoot.elasticsearch_mock.assert_bulk(operations=ops)
+    bigfoot.elasticsearch.assert_bulk(operations=ops)
 
 
 def test_assert_index_wrong_params_raises(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.elasticsearch_mock.mock_operation("index", returns={"_id": "1"})
+    bigfoot.elasticsearch.mock_operation("index", returns={"_id": "1"})
     with bigfoot.sandbox():
         es = elasticsearch.Elasticsearch("http://localhost:9200")
         es.index(index="idx", document={"a": 1})
     with pytest.raises(InteractionMismatchError):
-        bigfoot.elasticsearch_mock.assert_index(index="wrong", document={"a": 1})
+        bigfoot.elasticsearch.assert_index(index="wrong", document={"a": 1})
     # Assert correctly so teardown passes
-    bigfoot.elasticsearch_mock.assert_index(index="idx", document={"a": 1})
+    bigfoot.elasticsearch.assert_index(index="idx", document={"a": 1})
 
 
 def test_missing_assertion_fields_raises(bigfoot_verifier: StrictVerifier) -> None:
     """Incomplete fields in assert_interaction raises MissingAssertionFieldsError."""
     import bigfoot
 
-    bigfoot.elasticsearch_mock.mock_operation("get", returns={"_source": {"a": 1}})
+    bigfoot.elasticsearch.mock_operation("get", returns={"_source": {"a": 1}})
     with bigfoot.sandbox():
         es = elasticsearch.Elasticsearch("http://localhost:9200")
         es.get(index="idx", id="1")
@@ -524,4 +524,4 @@ def test_missing_assertion_fields_raises(bigfoot_verifier: StrictVerifier) -> No
         # Only providing index, missing id
         bigfoot.assert_interaction(sentinel, index="idx")
     # Assert correctly so teardown passes
-    bigfoot.elasticsearch_mock.assert_get(index="idx", id="1")
+    bigfoot.elasticsearch.assert_get(index="idx", id="1")

--- a/tests/unit/test_file_io_plugin.py
+++ b/tests/unit/test_file_io_plugin.py
@@ -970,7 +970,7 @@ def test_format_mock_hint() -> None:
         plugin=p,
     )
     result = p.format_mock_hint(interaction)
-    assert result == f"    bigfoot.file_io_mock.mock_operation('open', '{os.path.normpath('/tmp/f.txt')}', returns=...)"
+    assert result == f"    bigfoot.file_io.mock_operation('open', '{os.path.normpath('/tmp/f.txt')}', returns=...)"
 
 
 # ESCAPE: test_format_unmocked_hint
@@ -986,7 +986,7 @@ def test_format_unmocked_hint() -> None:
     assert result == (
         f"open('{np('/tmp/f.txt')}', ...) was called but no mock was registered.\n"
         "Register a mock with:\n"
-        f"    bigfoot.file_io_mock.mock_operation('open', '{np('/tmp/f.txt')}', returns=...)"
+        f"    bigfoot.file_io.mock_operation('open', '{np('/tmp/f.txt')}', returns=...)"
     )
 
 
@@ -1007,7 +1007,7 @@ def test_format_assert_hint() -> None:
     result = p.format_assert_hint(interaction)
     npath = os.path.normpath("/tmp/f.txt")
     assert result == (
-        "    bigfoot.file_io_mock.assert_open(\n"
+        "    bigfoot.file_io.assert_open(\n"
         f"        path={npath!r},\n"
         "        mode='r',\n"
         "        encoding='utf-8',\n"
@@ -1032,7 +1032,7 @@ def test_format_assert_hint_remove() -> None:
     result = p.format_assert_hint(interaction)
     npath = os.path.normpath("/tmp/del.txt")
     assert result == (
-        "    bigfoot.file_io_mock.assert_remove(\n"
+        "    bigfoot.file_io.assert_remove(\n"
         f"        path={npath!r},\n"
         "    )"
     )
@@ -1191,8 +1191,8 @@ def test_reference_counting_nested() -> None:
 
 
 # ESCAPE: test_file_io_plugin_in_all
-#   CLAIM: FileIoPlugin and file_io_mock are exported from bigfoot.__all__.
-#   PATH:  bigfoot.__all__ contains "FileIoPlugin" and "file_io_mock".
+#   CLAIM: FileIoPlugin and file_io are exported from bigfoot.__all__.
+#   PATH:  bigfoot.__all__ contains "FileIoPlugin" and "file_io".
 #   CHECK: Both names in __all__; bigfoot.FileIoPlugin is the real class.
 #   MUTATION: Omitting either from __all__ fails membership check.
 #   ESCAPE: Nothing reasonable -- exact membership check.
@@ -1200,12 +1200,12 @@ def test_file_io_plugin_in_all() -> None:
     import bigfoot
 
     assert "FileIoPlugin" in bigfoot.__all__
-    assert "file_io_mock" in bigfoot.__all__
+    assert "file_io" in bigfoot.__all__
     assert bigfoot.FileIoPlugin is FileIoPlugin
 
 
 # ESCAPE: test_file_io_mock_proxy
-#   CLAIM: bigfoot.file_io_mock proxies to FileIoPlugin on the active verifier.
+#   CLAIM: bigfoot.file_io proxies to FileIoPlugin on the active verifier.
 #   PATH:  _FileIoProxy.__getattr__ -> get verifier -> find/create FileIoPlugin.
 #   CHECK: Proxy attribute access does not raise when verifier is active.
 #   MUTATION: Wrong proxy class or missing registration fails with AttributeError.
@@ -1214,12 +1214,12 @@ def test_file_io_mock_proxy(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
     # End-to-end: register mock through proxy, trigger it, verify interaction
-    bigfoot.file_io_mock.mock_operation("open", "/tmp/proxy-test.txt", returns="proxied")
+    bigfoot.file_io.mock_operation("open", "/tmp/proxy-test.txt", returns="proxied")
     with bigfoot.sandbox():
         f = builtins.open("/tmp/proxy-test.txt")
         result = f.read()
     assert result == "proxied"
-    bigfoot.file_io_mock.assert_open(path="/tmp/proxy-test.txt", mode="r", encoding="utf-8")
+    bigfoot.file_io.assert_open(path="/tmp/proxy-test.txt", mode="r", encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_grpc_plugin.py
+++ b/tests/unit/test_grpc_plugin.py
@@ -207,14 +207,14 @@ def test_reference_counting_nested() -> None:
 def test_unary_unary_basic_interception(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/Do", returns=b"response-data")
+    bigfoot.grpc.mock_unary_unary("/pkg.Svc/Do", returns=b"response-data")
     with bigfoot.sandbox():
         channel = grpc.insecure_channel("localhost:50051")
         stub = channel.unary_unary("/pkg.Svc/Do")
         result = stub(b"request-data")
 
     assert result == b"response-data"
-    bigfoot.grpc_mock.assert_unary_unary(
+    bigfoot.grpc.assert_unary_unary(
         method="/pkg.Svc/Do",
         request=b"request-data",
         metadata=None,
@@ -323,7 +323,7 @@ def test_get_unused_mocks_excludes_required_false() -> None:
 def test_missing_fields_raises_error(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/Do", returns=b"val")
+    bigfoot.grpc.mock_unary_unary("/pkg.Svc/Do", returns=b"val")
     with bigfoot.sandbox():
         channel = grpc.insecure_channel("localhost:50051")
         stub = channel.unary_unary("/pkg.Svc/Do")
@@ -340,7 +340,7 @@ def test_missing_fields_raises_error(bigfoot_verifier: StrictVerifier) -> None:
         )
 
     # Now assert correctly so teardown passes
-    bigfoot.grpc_mock.assert_unary_unary(
+    bigfoot.grpc.assert_unary_unary(
         method="/pkg.Svc/Do",
         request=b"req",
         metadata=None,
@@ -361,13 +361,13 @@ def test_missing_fields_raises_error(bigfoot_verifier: StrictVerifier) -> None:
 def test_assert_unary_unary_helper(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/Do", returns=b"ok")
+    bigfoot.grpc.mock_unary_unary("/pkg.Svc/Do", returns=b"ok")
     with bigfoot.sandbox():
         channel = grpc.insecure_channel("localhost:50051")
         stub = channel.unary_unary("/pkg.Svc/Do")
         stub(b"req")
 
-    bigfoot.grpc_mock.assert_unary_unary(
+    bigfoot.grpc.assert_unary_unary(
         method="/pkg.Svc/Do",
         request=b"req",
         metadata=None,
@@ -383,7 +383,7 @@ def test_assert_unary_unary_helper(bigfoot_verifier: StrictVerifier) -> None:
 def test_assert_unary_stream_helper(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.grpc_mock.mock_unary_stream("/pkg.Svc/ServerStream", returns=[b"r1", b"r2"])
+    bigfoot.grpc.mock_unary_stream("/pkg.Svc/ServerStream", returns=[b"r1", b"r2"])
     with bigfoot.sandbox():
         channel = grpc.insecure_channel("localhost:50051")
         stub = channel.unary_stream("/pkg.Svc/ServerStream")
@@ -391,7 +391,7 @@ def test_assert_unary_stream_helper(bigfoot_verifier: StrictVerifier) -> None:
         responses = list(response_iter)
 
     assert responses == [b"r1", b"r2"]
-    bigfoot.grpc_mock.assert_unary_stream(
+    bigfoot.grpc.assert_unary_stream(
         method="/pkg.Svc/ServerStream",
         request=b"req",
         metadata=None,
@@ -407,14 +407,14 @@ def test_assert_unary_stream_helper(bigfoot_verifier: StrictVerifier) -> None:
 def test_assert_stream_unary_helper(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.grpc_mock.mock_stream_unary("/pkg.Svc/ClientStream", returns=b"merged")
+    bigfoot.grpc.mock_stream_unary("/pkg.Svc/ClientStream", returns=b"merged")
     with bigfoot.sandbox():
         channel = grpc.insecure_channel("localhost:50051")
         stub = channel.stream_unary("/pkg.Svc/ClientStream")
         result = stub(iter([b"c1", b"c2"]))
 
     assert result == b"merged"
-    bigfoot.grpc_mock.assert_stream_unary(
+    bigfoot.grpc.assert_stream_unary(
         method="/pkg.Svc/ClientStream",
         request=[b"c1", b"c2"],
         metadata=None,
@@ -430,7 +430,7 @@ def test_assert_stream_unary_helper(bigfoot_verifier: StrictVerifier) -> None:
 def test_assert_stream_stream_helper(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.grpc_mock.mock_stream_stream("/pkg.Svc/Bidi", returns=[b"s1", b"s2"])
+    bigfoot.grpc.mock_stream_stream("/pkg.Svc/Bidi", returns=[b"s1", b"s2"])
     with bigfoot.sandbox():
         channel = grpc.insecure_channel("localhost:50051")
         stub = channel.stream_stream("/pkg.Svc/Bidi")
@@ -438,7 +438,7 @@ def test_assert_stream_stream_helper(bigfoot_verifier: StrictVerifier) -> None:
         responses = list(response_iter)
 
     assert responses == [b"s1", b"s2"]
-    bigfoot.grpc_mock.assert_stream_stream(
+    bigfoot.grpc.assert_stream_stream(
         method="/pkg.Svc/Bidi",
         request=[b"c1"],
         metadata=None,
@@ -459,20 +459,20 @@ def test_assert_stream_stream_helper(bigfoot_verifier: StrictVerifier) -> None:
 def test_assert_unary_unary_wrong_request_raises(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/Do", returns=b"ok")
+    bigfoot.grpc.mock_unary_unary("/pkg.Svc/Do", returns=b"ok")
     with bigfoot.sandbox():
         channel = grpc.insecure_channel("localhost:50051")
         stub = channel.unary_unary("/pkg.Svc/Do")
         stub(b"actual-request")
 
     with pytest.raises(InteractionMismatchError):
-        bigfoot.grpc_mock.assert_unary_unary(
+        bigfoot.grpc.assert_unary_unary(
             method="/pkg.Svc/Do",
             request=b"WRONG-request",
             metadata=None,
         )
     # Assert correctly so teardown passes
-    bigfoot.grpc_mock.assert_unary_unary(
+    bigfoot.grpc.assert_unary_unary(
         method="/pkg.Svc/Do",
         request=b"actual-request",
         metadata=None,
@@ -488,20 +488,20 @@ def test_assert_unary_unary_wrong_request_raises(bigfoot_verifier: StrictVerifie
 def test_assert_unary_unary_wrong_method_raises(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/Do", returns=b"ok")
+    bigfoot.grpc.mock_unary_unary("/pkg.Svc/Do", returns=b"ok")
     with bigfoot.sandbox():
         channel = grpc.insecure_channel("localhost:50051")
         stub = channel.unary_unary("/pkg.Svc/Do")
         stub(b"req")
 
     with pytest.raises(InteractionMismatchError):
-        bigfoot.grpc_mock.assert_unary_unary(
+        bigfoot.grpc.assert_unary_unary(
             method="/pkg.Svc/WRONG",
             request=b"req",
             metadata=None,
         )
     # Assert correctly
-    bigfoot.grpc_mock.assert_unary_unary(
+    bigfoot.grpc.assert_unary_unary(
         method="/pkg.Svc/Do",
         request=b"req",
         metadata=None,
@@ -544,7 +544,7 @@ def test_exception_propagation(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
     err = grpc.RpcError()
-    bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/Fail", returns=None, raises=err)
+    bigfoot.grpc.mock_unary_unary("/pkg.Svc/Fail", returns=None, raises=err)
     with bigfoot.sandbox():
         channel = grpc.insecure_channel("localhost:50051")
         stub = channel.unary_unary("/pkg.Svc/Fail")
@@ -552,7 +552,7 @@ def test_exception_propagation(bigfoot_verifier: StrictVerifier) -> None:
             stub(b"req")
 
     assert exc_info.value is err
-    bigfoot.grpc_mock.assert_unary_unary(
+    bigfoot.grpc.assert_unary_unary(
         method="/pkg.Svc/Fail",
         request=b"req",
         metadata=None,
@@ -574,7 +574,7 @@ def test_exception_propagation(bigfoot_verifier: StrictVerifier) -> None:
 def test_server_streaming_returns_iterator(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.grpc_mock.mock_unary_stream("/pkg.Svc/Stream", returns=[b"a", b"b", b"c"])
+    bigfoot.grpc.mock_unary_stream("/pkg.Svc/Stream", returns=[b"a", b"b", b"c"])
     with bigfoot.sandbox():
         channel = grpc.insecure_channel("localhost:50051")
         stub = channel.unary_stream("/pkg.Svc/Stream")
@@ -582,7 +582,7 @@ def test_server_streaming_returns_iterator(bigfoot_verifier: StrictVerifier) -> 
         responses = list(response_iter)
 
     assert responses == [b"a", b"b", b"c"]
-    bigfoot.grpc_mock.assert_unary_stream(
+    bigfoot.grpc.assert_unary_stream(
         method="/pkg.Svc/Stream",
         request=b"req",
         metadata=None,
@@ -603,14 +603,14 @@ def test_server_streaming_returns_iterator(bigfoot_verifier: StrictVerifier) -> 
 def test_client_streaming_materializes_request(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.grpc_mock.mock_stream_unary("/pkg.Svc/Upload", returns=b"done")
+    bigfoot.grpc.mock_stream_unary("/pkg.Svc/Upload", returns=b"done")
     with bigfoot.sandbox():
         channel = grpc.insecure_channel("localhost:50051")
         stub = channel.stream_unary("/pkg.Svc/Upload")
         result = stub(iter([b"chunk1", b"chunk2", b"chunk3"]))
 
     assert result == b"done"
-    bigfoot.grpc_mock.assert_stream_unary(
+    bigfoot.grpc.assert_stream_unary(
         method="/pkg.Svc/Upload",
         request=[b"chunk1", b"chunk2", b"chunk3"],
         metadata=None,
@@ -631,7 +631,7 @@ def test_client_streaming_materializes_request(bigfoot_verifier: StrictVerifier)
 def test_bidi_streaming(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.grpc_mock.mock_stream_stream("/pkg.Svc/Chat", returns=[b"r1", b"r2"])
+    bigfoot.grpc.mock_stream_stream("/pkg.Svc/Chat", returns=[b"r1", b"r2"])
     with bigfoot.sandbox():
         channel = grpc.insecure_channel("localhost:50051")
         stub = channel.stream_stream("/pkg.Svc/Chat")
@@ -639,7 +639,7 @@ def test_bidi_streaming(bigfoot_verifier: StrictVerifier) -> None:
         responses = list(response_iter)
 
     assert responses == [b"r1", b"r2"]
-    bigfoot.grpc_mock.assert_stream_stream(
+    bigfoot.grpc.assert_stream_stream(
         method="/pkg.Svc/Chat",
         request=[b"c1", b"c2"],
         metadata=None,
@@ -660,7 +660,7 @@ def test_bidi_streaming(bigfoot_verifier: StrictVerifier) -> None:
 def test_empty_streams(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.grpc_mock.mock_stream_stream("/pkg.Svc/Empty", returns=[])
+    bigfoot.grpc.mock_stream_stream("/pkg.Svc/Empty", returns=[])
     with bigfoot.sandbox():
         channel = grpc.insecure_channel("localhost:50051")
         stub = channel.stream_stream("/pkg.Svc/Empty")
@@ -668,7 +668,7 @@ def test_empty_streams(bigfoot_verifier: StrictVerifier) -> None:
         responses = list(response_iter)
 
     assert responses == []
-    bigfoot.grpc_mock.assert_stream_stream(
+    bigfoot.grpc.assert_stream_stream(
         method="/pkg.Svc/Empty",
         request=[],
         metadata=None,
@@ -690,7 +690,7 @@ def test_mid_stream_error(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
     err = grpc.RpcError()
-    bigfoot.grpc_mock.mock_unary_stream("/pkg.Svc/PartialFail", returns=[b"p1", b"p2"], raises=err)
+    bigfoot.grpc.mock_unary_stream("/pkg.Svc/PartialFail", returns=[b"p1", b"p2"], raises=err)
     with bigfoot.sandbox():
         channel = grpc.insecure_channel("localhost:50051")
         stub = channel.unary_stream("/pkg.Svc/PartialFail")
@@ -702,7 +702,7 @@ def test_mid_stream_error(bigfoot_verifier: StrictVerifier) -> None:
 
     assert collected == [b"p1", b"p2"]
     assert exc_info.value is err
-    bigfoot.grpc_mock.assert_unary_stream(
+    bigfoot.grpc.assert_unary_stream(
         method="/pkg.Svc/PartialFail",
         request=b"req",
         metadata=None,
@@ -782,7 +782,7 @@ def test_mock_stream_iterator_empty_with_error() -> None:
 def test_grpc_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/Do", returns=b"ok")
+    bigfoot.grpc.mock_unary_unary("/pkg.Svc/Do", returns=b"ok")
     with bigfoot.sandbox():
         channel = grpc.insecure_channel("localhost:50051")
         stub = channel.unary_unary("/pkg.Svc/Do")
@@ -799,7 +799,7 @@ def test_grpc_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier) -
         "metadata": None,
     }
     # Assert it so verify_all() at teardown succeeds
-    bigfoot.grpc_mock.assert_unary_unary(
+    bigfoot.grpc.assert_unary_unary(
         method="/pkg.Svc/Do",
         request=b"req",
         metadata=None,
@@ -820,8 +820,8 @@ def test_grpc_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier) -
 def test_fifo_queue_ordering(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/Do", returns=b"first")
-    bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/Do", returns=b"second")
+    bigfoot.grpc.mock_unary_unary("/pkg.Svc/Do", returns=b"first")
+    bigfoot.grpc.mock_unary_unary("/pkg.Svc/Do", returns=b"second")
     with bigfoot.sandbox():
         channel = grpc.insecure_channel("localhost:50051")
         stub = channel.unary_unary("/pkg.Svc/Do")
@@ -830,12 +830,12 @@ def test_fifo_queue_ordering(bigfoot_verifier: StrictVerifier) -> None:
 
     assert r1 == b"first"
     assert r2 == b"second"
-    bigfoot.grpc_mock.assert_unary_unary(
+    bigfoot.grpc.assert_unary_unary(
         method="/pkg.Svc/Do",
         request=b"req1",
         metadata=None,
     )
-    bigfoot.grpc_mock.assert_unary_unary(
+    bigfoot.grpc.assert_unary_unary(
         method="/pkg.Svc/Do",
         request=b"req2",
         metadata=None,
@@ -851,7 +851,7 @@ def test_fifo_queue_ordering(bigfoot_verifier: StrictVerifier) -> None:
 def test_unmocked_after_queue_exhausted(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/Do", returns=b"only-one")
+    bigfoot.grpc.mock_unary_unary("/pkg.Svc/Do", returns=b"only-one")
     with bigfoot.sandbox():
         channel = grpc.insecure_channel("localhost:50051")
         stub = channel.unary_unary("/pkg.Svc/Do")
@@ -859,7 +859,7 @@ def test_unmocked_after_queue_exhausted(bigfoot_verifier: StrictVerifier) -> Non
         with pytest.raises(UnmockedInteractionError):
             stub(b"req2")
 
-    bigfoot.grpc_mock.assert_unary_unary(
+    bigfoot.grpc.assert_unary_unary(
         method="/pkg.Svc/Do",
         request=b"req1",
         metadata=None,
@@ -881,13 +881,13 @@ def test_metadata_passed_through(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
     meta = (("authorization", "Bearer token"),)
-    bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/Auth", returns=b"ok")
+    bigfoot.grpc.mock_unary_unary("/pkg.Svc/Auth", returns=b"ok")
     with bigfoot.sandbox():
         channel = grpc.insecure_channel("localhost:50051")
         stub = channel.unary_unary("/pkg.Svc/Auth")
         stub(b"req", metadata=meta)
 
-    bigfoot.grpc_mock.assert_unary_unary(
+    bigfoot.grpc.assert_unary_unary(
         method="/pkg.Svc/Auth",
         request=b"req",
         metadata=(("authorization", "Bearer token"),),
@@ -908,7 +908,7 @@ def test_metadata_passed_through(bigfoot_verifier: StrictVerifier) -> None:
 def test_secure_channel_interception(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/Secure", returns=b"secure-ok")
+    bigfoot.grpc.mock_unary_unary("/pkg.Svc/Secure", returns=b"secure-ok")
     with bigfoot.sandbox():
         creds = grpc.ssl_channel_credentials()
         channel = grpc.secure_channel("localhost:443", creds)
@@ -916,7 +916,7 @@ def test_secure_channel_interception(bigfoot_verifier: StrictVerifier) -> None:
         result = stub(b"req")
 
     assert result == b"secure-ok"
-    bigfoot.grpc_mock.assert_unary_unary(
+    bigfoot.grpc.assert_unary_unary(
         method="/pkg.Svc/Secure",
         request=b"req",
         metadata=None,
@@ -976,7 +976,7 @@ def test_format_mock_hint() -> None:
         plugin=p,
     )
     assert p.format_mock_hint(interaction) == (
-        "    bigfoot.grpc_mock.mock_unary_unary('/pkg.Svc/Do', returns=...)"
+        "    bigfoot.grpc.mock_unary_unary('/pkg.Svc/Do', returns=...)"
     )
 
 
@@ -996,7 +996,7 @@ def test_format_unmocked_hint() -> None:
     assert result == (
         "grpc.unary_unary('/pkg.Svc/Do') was called but no mock was registered.\n"
         "Register a mock with:\n"
-        "    bigfoot.grpc_mock.mock_unary_unary('/pkg.Svc/Do', returns=...)"
+        "    bigfoot.grpc.mock_unary_unary('/pkg.Svc/Do', returns=...)"
     )
 
 
@@ -1022,7 +1022,7 @@ def test_format_assert_hint() -> None:
         plugin=p,
     )
     assert p.format_assert_hint(interaction) == (
-        "    bigfoot.grpc_mock.assert_unary_unary(\n"
+        "    bigfoot.grpc.assert_unary_unary(\n"
         "        method='/pkg.Svc/Do',\n"
         "        request=b'data',\n"
         "        metadata=None,\n"
@@ -1094,12 +1094,12 @@ def test_matches_field_comparison() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.grpc_mock
+# Module-level proxy: bigfoot.grpc
 # ---------------------------------------------------------------------------
 
 
 # ESCAPE: test_grpc_mock_proxy_works
-#   CLAIM: bigfoot.grpc_mock.mock_unary_unary() works when verifier is active.
+#   CLAIM: bigfoot.grpc.mock_unary_unary() works when verifier is active.
 #   PATH:  _GrpcProxy.__getattr__("mock_unary_unary") -> get verifier ->
 #          find/create GrpcPlugin -> return plugin.mock_unary_unary.
 #   CHECK: The proxy call does not raise and the mock is registered and consumed.
@@ -1108,14 +1108,14 @@ def test_matches_field_comparison() -> None:
 def test_grpc_mock_proxy_works(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/Proxy", returns=b"proxy-ok")
+    bigfoot.grpc.mock_unary_unary("/pkg.Svc/Proxy", returns=b"proxy-ok")
     with bigfoot.sandbox():
         channel = grpc.insecure_channel("localhost:50051")
         stub = channel.unary_unary("/pkg.Svc/Proxy")
         result = stub(b"req")
 
     assert result == b"proxy-ok"
-    bigfoot.grpc_mock.assert_unary_unary(
+    bigfoot.grpc.assert_unary_unary(
         method="/pkg.Svc/Proxy",
         request=b"req",
         metadata=None,
@@ -1123,7 +1123,7 @@ def test_grpc_mock_proxy_works(bigfoot_verifier: StrictVerifier) -> None:
 
 
 # ESCAPE: test_grpc_mock_proxy_raises_outside_context
-#   CLAIM: Accessing grpc_mock outside a test context raises NoActiveVerifierError.
+#   CLAIM: Accessing grpc outside a test context raises NoActiveVerifierError.
 #   PATH:  _GrpcProxy.__getattr__() -> _get_test_verifier_or_raise() -> raises.
 #   CHECK: The appropriate error is raised.
 #   MUTATION: Not checking for active verifier allows access.
@@ -1136,7 +1136,7 @@ def test_grpc_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/Do", returns=b"val")
+            bigfoot.grpc.mock_unary_unary("/pkg.Svc/Do", returns=b"val")
     finally:
         _current_test_verifier.reset(token)
 
@@ -1147,7 +1147,7 @@ def test_grpc_mock_proxy_raises_outside_context() -> None:
 
 
 # ESCAPE: test_grpc_plugin_in_all
-#   CLAIM: GrpcPlugin and grpc_mock are exported in bigfoot.__all__.
+#   CLAIM: GrpcPlugin and grpc are exported in bigfoot.__all__.
 #   PATH:  __init__.py __all__ list.
 #   CHECK: Both names are in __all__.
 #   MUTATION: Removing from __all__ fails the membership check.
@@ -1156,7 +1156,7 @@ def test_grpc_plugin_in_all() -> None:
     import bigfoot
 
     assert "GrpcPlugin" in bigfoot.__all__
-    assert "grpc_mock" in bigfoot.__all__
+    assert "grpc" in bigfoot.__all__
 
 
 # ---------------------------------------------------------------------------
@@ -1173,8 +1173,8 @@ def test_grpc_plugin_in_all() -> None:
 def test_separate_queues_per_call_type(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.grpc_mock.mock_unary_unary("/pkg.Svc/Multi", returns=b"unary-resp")
-    bigfoot.grpc_mock.mock_unary_stream("/pkg.Svc/Multi", returns=[b"stream-resp"])
+    bigfoot.grpc.mock_unary_unary("/pkg.Svc/Multi", returns=b"unary-resp")
+    bigfoot.grpc.mock_unary_stream("/pkg.Svc/Multi", returns=[b"stream-resp"])
     with bigfoot.sandbox():
         channel = grpc.insecure_channel("localhost:50051")
 
@@ -1186,12 +1186,12 @@ def test_separate_queues_per_call_type(bigfoot_verifier: StrictVerifier) -> None
 
     assert r1 == b"unary-resp"
     assert r2 == [b"stream-resp"]
-    bigfoot.grpc_mock.assert_unary_unary(
+    bigfoot.grpc.assert_unary_unary(
         method="/pkg.Svc/Multi",
         request=b"req1",
         metadata=None,
     )
-    bigfoot.grpc_mock.assert_unary_stream(
+    bigfoot.grpc.assert_unary_stream(
         method="/pkg.Svc/Multi",
         request=b"req2",
         metadata=None,

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -83,38 +83,38 @@ def test_all_contains_expected_names() -> None:
         "current_verifier",
         "spy",
         "http",
-        "subprocess_mock",
-        "popen_mock",
-        "smtp_mock",
-        "socket_mock",
-        "db_mock",
-        "async_websocket_mock",
-        "sync_websocket_mock",
-        "redis_mock",
-        "mongo_mock",
-        "dns_mock",
-        "memcache_mock",
-        "celery_mock",
-        "log_mock",
-        "async_subprocess_mock",
-        "psycopg2_mock",
-        "asyncpg_mock",
-        "boto3_mock",
-        "elasticsearch_mock",
-        "jwt_mock",
-        "crypto_mock",
+        "subprocess",
+        "popen",
+        "smtp",
+        "socket",
+        "db",
+        "async_websocket",
+        "sync_websocket",
+        "redis",
+        "mongo",
+        "dns",
+        "memcache",
+        "celery",
+        "log",
+        "async_subprocess",
+        "psycopg2",
+        "asyncpg",
+        "boto3",
+        "elasticsearch",
+        "jwt",
+        "crypto",
         "FileIoPlugin",
-        "file_io_mock",
+        "file_io",
         "PikaPlugin",
-        "pika_mock",
+        "pika",
         "SshPlugin",
-        "ssh_mock",
+        "ssh",
         "GrpcPlugin",
-        "grpc_mock",
+        "grpc",
         "McpPlugin",
-        "mcp_mock",
+        "mcp",
         "NativePlugin",
-        "native_mock",
+        "native",
     }
     assert set(bigfoot.__all__) == expected_all
 
@@ -375,13 +375,13 @@ def test_mock_accepts_path_parameter() -> None:
     assert "path" in sig.parameters
 
 
-def test_async_websocket_mock_raises_import_error_when_websockets_unavailable(
+def test_async_websocket_raises_import_error_when_websockets_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """async_websocket_mock.__getattr__ raises ImportError with install instructions when websockets is not installed.
+    """async_websocket.__getattr__ raises ImportError with install instructions when websockets is not installed.
 
-    ESCAPE: async_websocket_mock
-      CLAIM: Accessing any attribute on async_websocket_mock raises ImportError with
+    ESCAPE: async_websocket
+      CLAIM: Accessing any attribute on async_websocket raises ImportError with
              instructions when bigfoot.plugins.websocket_plugin._WEBSOCKETS_AVAILABLE is False.
       PATH:  _AsyncWebSocketProxy.__getattr__ -> checks _WEBSOCKETS_AVAILABLE -> raises ImportError.
       CHECK: Raises ImportError with message containing "bigfoot[websockets]" and "pip install".
@@ -396,7 +396,7 @@ def test_async_websocket_mock_raises_import_error_when_websockets_unavailable(
     monkeypatch.setattr(ws_mod, "_WEBSOCKETS_AVAILABLE", False)
 
     with pytest.raises(ImportError) as exc_info:
-        _ = bigfoot.async_websocket_mock.new_session  # noqa: B018
+        _ = bigfoot.async_websocket.new_session  # noqa: B018
 
     assert "bigfoot[websockets]" in str(exc_info.value)
     assert "pip install" in str(exc_info.value)
@@ -489,13 +489,13 @@ def test_bigfoot_nested_sandboxes_via_with_bigfoot(bigfoot_verifier: object) -> 
             assert v1 is v2
 
 
-def test_sync_websocket_mock_raises_import_error_when_websocket_client_unavailable(
+def test_sync_websocket_raises_import_error_when_websocket_client_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """sync_websocket_mock.__getattr__ raises ImportError with install instructions when websocket-client is not installed.
+    """sync_websocket.__getattr__ raises ImportError with install instructions when websocket-client is not installed.
 
-    ESCAPE: sync_websocket_mock
-      CLAIM: Accessing any attribute on sync_websocket_mock raises ImportError with
+    ESCAPE: sync_websocket
+      CLAIM: Accessing any attribute on sync_websocket raises ImportError with
              instructions when bigfoot.plugins.websocket_plugin._WEBSOCKET_CLIENT_AVAILABLE is False.
       PATH:  _SyncWebSocketProxy.__getattr__ -> checks _WEBSOCKET_CLIENT_AVAILABLE -> raises ImportError.
       CHECK: Raises ImportError with message containing "bigfoot[websocket-client]" and "pip install".
@@ -510,7 +510,188 @@ def test_sync_websocket_mock_raises_import_error_when_websocket_client_unavailab
     monkeypatch.setattr(ws_mod, "_WEBSOCKET_CLIENT_AVAILABLE", False)
 
     with pytest.raises(ImportError) as exc_info:
-        _ = bigfoot.sync_websocket_mock.new_session  # noqa: B018
+        _ = bigfoot.sync_websocket.new_session  # noqa: B018
 
     assert "bigfoot[websocket-client]" in str(exc_info.value)
     assert "pip install" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Deprecated ``_mock`` aliases
+# ---------------------------------------------------------------------------
+#
+# The 26 ``bigfoot.X_mock`` names are retained as deprecated aliases for the
+# canonical un-suffixed proxy singletons (e.g. ``bigfoot.subprocess``).
+# Accessing an alias must:
+#   1. return the SAME object as the canonical proxy (identity, not equality);
+#   2. emit a DeprecationWarning with a specific message on FIRST access only;
+#   3. NOT emit a second warning on subsequent access of the same alias.
+# Unknown attributes must still raise AttributeError with the standard message.
+#
+# We cover three representative aliases: ``subprocess_mock`` (always-available
+# core), ``redis_mock`` (optional extra), and ``async_websocket_mock``
+# (compound name). Exhaustive coverage of all 26 is unnecessary -- the
+# behavior is driven by the same ``__getattr__`` hook.
+
+
+@pytest.fixture
+def _clear_warned_aliases():  # type: ignore[no-untyped-def]
+    """Reset bigfoot's per-process ``_warned_aliases`` set so each test starts fresh.
+
+    ``__getattr__`` only emits a DeprecationWarning the first time a given alias
+    is accessed in a process. Other tests (or pytest collection itself) may have
+    already triggered the warning, so we clear the set before the test runs and
+    restore it afterwards.
+    """
+    import bigfoot
+
+    snapshot = set(bigfoot._warned_aliases)
+    bigfoot._warned_aliases.clear()
+    yield
+    bigfoot._warned_aliases.clear()
+    bigfoot._warned_aliases.update(snapshot)
+
+
+@pytest.mark.parametrize(
+    ("alias", "canonical"),
+    [
+        ("subprocess_mock", "subprocess"),
+        ("redis_mock", "redis"),
+        ("async_websocket_mock", "async_websocket"),
+    ],
+)
+def test_deprecated_alias_returns_canonical_object(
+    alias: str, canonical: str, _clear_warned_aliases: object
+) -> None:
+    """``bigfoot.<alias>`` returns the SAME object as ``bigfoot.<canonical>``.
+
+    ESCAPE: deprecated alias identity
+      CLAIM: Accessing the deprecated alias returns the identical proxy singleton
+             that the canonical name returns -- not a copy, not a wrapper.
+      PATH:  __getattr__ -> _DEPRECATED_PROXY_ALIASES.get(name) -> globals()[target].
+      CHECK: ``alias_obj is canonical_obj`` (identity).
+      MUTATION: A wrapper that delegates would pass equality but fail identity.
+      ESCAPE: Returning a freshly constructed proxy each call would also fail identity.
+    """
+    import bigfoot
+
+    canonical_obj = getattr(bigfoot, canonical)
+    with pytest.warns(DeprecationWarning):
+        alias_obj = getattr(bigfoot, alias)
+
+    assert alias_obj is canonical_obj
+
+
+@pytest.mark.parametrize(
+    ("alias", "canonical"),
+    [
+        ("subprocess_mock", "subprocess"),
+        ("redis_mock", "redis"),
+        ("async_websocket_mock", "async_websocket"),
+    ],
+)
+def test_deprecated_alias_emits_deprecation_warning_on_first_access(
+    alias: str, canonical: str, _clear_warned_aliases: object
+) -> None:
+    """First access of a deprecated alias emits a DeprecationWarning with exact text.
+
+    ESCAPE: deprecated alias warning message
+      CLAIM: First access emits a single DeprecationWarning whose message is
+             exactly ``"bigfoot.<alias> is deprecated; use bigfoot.<canonical> instead."``.
+      PATH:  __getattr__ -> warnings.warn(..., DeprecationWarning, stacklevel=2).
+      CHECK: Exactly one warning recorded; category is DeprecationWarning;
+             str(message) matches the exact expected text.
+      MUTATION: Wrong category (e.g., FutureWarning) fails the category check.
+                Wrong wording fails the exact string check.
+      ESCAPE: Issuing two warnings on first access would fail the count check.
+    """
+    import bigfoot
+
+    expected_message = f"bigfoot.{alias} is deprecated; use bigfoot.{canonical} instead."
+
+    with pytest.warns(DeprecationWarning) as record:
+        getattr(bigfoot, alias)
+
+    matching = [w for w in record if str(w.message) == expected_message]
+    assert len(matching) == 1, (
+        f"expected exactly one DeprecationWarning with message "
+        f"{expected_message!r}, got: {[str(w.message) for w in record]}"
+    )
+    assert matching[0].category is DeprecationWarning
+    assert matching[0].filename.endswith("test_init.py"), (
+        f"stacklevel should point to caller; got filename={matching[0].filename!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("alias", "canonical"),
+    [
+        ("subprocess_mock", "subprocess"),
+        ("redis_mock", "redis"),
+        ("async_websocket_mock", "async_websocket"),
+    ],
+)
+def test_deprecated_alias_does_not_warn_on_second_access(
+    alias: str, canonical: str, _clear_warned_aliases: object
+) -> None:
+    """Second access of the SAME alias in the same process emits no further warning.
+
+    ESCAPE: alias warning is once-per-process
+      CLAIM: __getattr__ tracks already-warned aliases via ``_warned_aliases`` and
+             skips the ``warnings.warn`` call on subsequent access.
+      PATH:  __getattr__ -> if name in _warned_aliases: skip warn -> return target.
+      CHECK: After a first access (which emits the warning), a second access
+             produces zero matching DeprecationWarnings.
+      MUTATION: Removing the membership guard would emit the warning every access.
+      ESCAPE: Tracking the canonical name instead of the alias would let two
+              different aliases for the same target collide -- not what we test
+              here, but the matching message check still catches that mistake.
+    """
+    import warnings as _warnings
+
+    import bigfoot
+
+    expected_message = f"bigfoot.{alias} is deprecated; use bigfoot.{canonical} instead."
+
+    # Prime: trigger the first-access warning so the alias is registered in
+    # _warned_aliases. We don't assert on this warning here -- a separate test
+    # covers first-access semantics.
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("ignore")
+        getattr(bigfoot, alias)
+
+    # Second access: must NOT emit any DeprecationWarning matching this alias.
+    with _warnings.catch_warnings(record=True) as record:
+        _warnings.simplefilter("always")
+        getattr(bigfoot, alias)
+
+    matching = [
+        w for w in record
+        if w.category is DeprecationWarning and str(w.message) == expected_message
+    ]
+    assert matching == [], (
+        f"second access of bigfoot.{alias} unexpectedly emitted DeprecationWarning(s): "
+        f"{[str(w.message) for w in matching]}"
+    )
+
+
+def test_unknown_attribute_raises_attribute_error(_clear_warned_aliases: object) -> None:
+    """Accessing an unknown attribute on bigfoot raises AttributeError.
+
+    ESCAPE: unknown attribute fallback
+      CLAIM: Names not in ``_DEPRECATED_PROXY_ALIASES`` and not defined as real
+             module globals raise AttributeError with the standard ``module
+             'bigfoot' has no attribute 'X'`` message.
+      PATH:  __getattr__ -> alias miss -> raise AttributeError(...).
+      CHECK: AttributeError raised; message exactly matches the standard form.
+      MUTATION: Returning ``None`` instead would fail the raises check.
+                Wrong message text would fail the equality check.
+      ESCAPE: Using ``hasattr`` instead of attribute access would swallow the error,
+              so we test attribute access directly.
+    """
+    import bigfoot
+
+    with pytest.raises(AttributeError) as exc_info:
+        _ = bigfoot.not_a_thing  # type: ignore[attr-defined] # noqa: B018
+
+    assert str(exc_info.value) == "module 'bigfoot' has no attribute 'not_a_thing'"

--- a/tests/unit/test_jwt_plugin.py
+++ b/tests/unit/test_jwt_plugin.py
@@ -389,7 +389,7 @@ def test_format_mock_hint() -> None:
         plugin=p,
     )
     result = p.format_mock_hint(interaction)
-    assert result == "    bigfoot.jwt_mock.mock_encode(returns=...)"
+    assert result == "    bigfoot.jwt.mock_encode(returns=...)"
 
 
 def test_format_unmocked_hint() -> None:
@@ -398,7 +398,7 @@ def test_format_unmocked_hint() -> None:
     assert result == (
         "jwt.encode(...) was called but no mock was registered.\n"
         "Register a mock with:\n"
-        "    bigfoot.jwt_mock.mock_encode(returns=...)"
+        "    bigfoot.jwt.mock_encode(returns=...)"
     )
 
 
@@ -413,7 +413,7 @@ def test_format_unused_mock_hint() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.jwt_mock
+# Module-level proxy: bigfoot.jwt
 # ---------------------------------------------------------------------------
 
 
@@ -422,13 +422,13 @@ def test_jwt_mock_proxy_mock_encode(bigfoot_verifier: StrictVerifier) -> None:
 
     import bigfoot
 
-    bigfoot.jwt_mock.mock_encode(returns="proxied_token")
+    bigfoot.jwt.mock_encode(returns="proxied_token")
 
     with bigfoot.sandbox():
         result = jwt_mod.encode({"sub": "1"}, "secret", algorithm="HS256")
 
     assert result == "proxied_token"
-    bigfoot.jwt_mock.assert_encode(payload={"sub": "1"}, algorithm="HS256", extra_kwargs={})
+    bigfoot.jwt.assert_encode(payload={"sub": "1"}, algorithm="HS256", extra_kwargs={})
 
 
 def test_jwt_mock_proxy_raises_outside_context() -> None:
@@ -438,7 +438,7 @@ def test_jwt_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.jwt_mock.mock_encode
+            _ = bigfoot.jwt.mock_encode
     finally:
         _current_test_verifier.reset(token)
 
@@ -453,7 +453,7 @@ def test_jwt_plugin_in_all() -> None:
     from bigfoot.plugins.jwt_plugin import JwtPlugin as _JwtPlugin
 
     assert bigfoot.JwtPlugin is _JwtPlugin
-    assert type(bigfoot.jwt_mock).__name__ == "_JwtProxy"
+    assert type(bigfoot.jwt).__name__ == "_JwtProxy"
 
 
 # ---------------------------------------------------------------------------
@@ -466,7 +466,7 @@ def test_jwt_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier) ->
 
     import bigfoot
 
-    bigfoot.jwt_mock.mock_encode(returns="token")
+    bigfoot.jwt.mock_encode(returns="token")
     with bigfoot.sandbox():
         jwt_mod.encode({"sub": "1"}, "secret", algorithm="HS256")
 
@@ -474,7 +474,7 @@ def test_jwt_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier) ->
     interactions = timeline.all_unasserted()
     assert len(interactions) == 1
     assert interactions[0].source_id == "jwt:encode"
-    bigfoot.jwt_mock.assert_encode(payload={"sub": "1"}, algorithm="HS256", extra_kwargs={})
+    bigfoot.jwt.assert_encode(payload={"sub": "1"}, algorithm="HS256", extra_kwargs={})
 
 
 def test_assert_encode_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
@@ -482,10 +482,10 @@ def test_assert_encode_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
 
     import bigfoot
 
-    bigfoot.jwt_mock.mock_encode(returns="token")
+    bigfoot.jwt.mock_encode(returns="token")
     with bigfoot.sandbox():
         jwt_mod.encode({"sub": "1"}, "secret", algorithm="HS256")
-    bigfoot.jwt_mock.assert_encode(payload={"sub": "1"}, algorithm="HS256", extra_kwargs={})
+    bigfoot.jwt.assert_encode(payload={"sub": "1"}, algorithm="HS256", extra_kwargs={})
 
 
 def test_assert_decode_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
@@ -493,10 +493,10 @@ def test_assert_decode_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
 
     import bigfoot
 
-    bigfoot.jwt_mock.mock_decode(returns={"sub": "1"})
+    bigfoot.jwt.mock_decode(returns={"sub": "1"})
     with bigfoot.sandbox():
         jwt_mod.decode("tok", "secret", algorithms=["HS256"])
-    bigfoot.jwt_mock.assert_decode(token="tok", algorithms=["HS256"], options=None)
+    bigfoot.jwt.assert_decode(token="tok", algorithms=["HS256"], options=None)
 
 
 def test_assert_encode_wrong_params_raises(bigfoot_verifier: StrictVerifier) -> None:
@@ -504,12 +504,12 @@ def test_assert_encode_wrong_params_raises(bigfoot_verifier: StrictVerifier) -> 
 
     import bigfoot
 
-    bigfoot.jwt_mock.mock_encode(returns="token")
+    bigfoot.jwt.mock_encode(returns="token")
     with bigfoot.sandbox():
         jwt_mod.encode({"sub": "1"}, "secret", algorithm="HS256")
     with pytest.raises(InteractionMismatchError):
-        bigfoot.jwt_mock.assert_encode(payload={"sub": "wrong"}, algorithm="HS256", extra_kwargs={})
-    bigfoot.jwt_mock.assert_encode(payload={"sub": "1"}, algorithm="HS256", extra_kwargs={})
+        bigfoot.jwt.assert_encode(payload={"sub": "wrong"}, algorithm="HS256", extra_kwargs={})
+    bigfoot.jwt.assert_encode(payload={"sub": "1"}, algorithm="HS256", extra_kwargs={})
 
 
 def test_missing_assertion_fields_raises(bigfoot_verifier: StrictVerifier) -> None:
@@ -517,7 +517,7 @@ def test_missing_assertion_fields_raises(bigfoot_verifier: StrictVerifier) -> No
 
     import bigfoot
 
-    bigfoot.jwt_mock.mock_encode(returns="token")
+    bigfoot.jwt.mock_encode(returns="token")
     with bigfoot.sandbox():
         jwt_mod.encode({"sub": "1"}, "secret", algorithm="HS256")
 
@@ -526,4 +526,4 @@ def test_missing_assertion_fields_raises(bigfoot_verifier: StrictVerifier) -> No
     sentinel = _JwtSentinel("encode")
     with pytest.raises(MissingAssertionFieldsError):
         bigfoot.assert_interaction(sentinel, payload={"sub": "1"})
-    bigfoot.jwt_mock.assert_encode(payload={"sub": "1"}, algorithm="HS256", extra_kwargs={})
+    bigfoot.jwt.assert_encode(payload={"sub": "1"}, algorithm="HS256", extra_kwargs={})

--- a/tests/unit/test_logging_plugin.py
+++ b/tests/unit/test_logging_plugin.py
@@ -502,7 +502,7 @@ def test_format_assert_hint() -> None:
         plugin=p,
     )
     result = p.format_assert_hint(interaction)
-    assert "bigfoot.log_mock.assert_log" in result
+    assert "bigfoot.log.assert_log" in result
     assert "'INFO'" in result
     assert "'started'" in result
     assert "'myapp'" in result
@@ -517,7 +517,7 @@ def test_format_mock_hint() -> None:
         plugin=p,
     )
     result = p.format_mock_hint(interaction)
-    assert "bigfoot.log_mock.mock_log" in result
+    assert "bigfoot.log.mock_log" in result
     assert "'WARNING'" in result
     assert "'low memory'" in result
     assert "'system'" in result
@@ -534,7 +534,7 @@ def test_format_unused_mock_hint() -> None:
 def test_format_unmocked_hint() -> None:
     v, p = _make_verifier_with_plugin()
     result = p.format_unmocked_hint("logging:log", ("INFO", "hello"), {})
-    assert "bigfoot.log_mock.mock_log" in result
+    assert "bigfoot.log.mock_log" in result
 
 
 # ---------------------------------------------------------------------------
@@ -555,7 +555,7 @@ def test_conflict_error_logger_log_already_patched() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level API via bigfoot.log_mock proxy
+# Module-level API via bigfoot.log proxy
 # ---------------------------------------------------------------------------
 
 
@@ -565,7 +565,7 @@ def test_log_mock_proxy_in_sandbox(bigfoot_verifier: StrictVerifier) -> None:
     with bigfoot.sandbox():
         logger.info("via proxy")
 
-    bigfoot.log_mock.assert_info("via proxy", "test.proxy")
+    bigfoot.log.assert_info("via proxy", "test.proxy")
 
 
 def test_log_mock_proxy_raises_outside_context() -> None:
@@ -574,6 +574,6 @@ def test_log_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.log_mock.mock_log
+            _ = bigfoot.log.mock_log
     finally:
         _current_test_verifier.reset(token)

--- a/tests/unit/test_mcp_plugin.py
+++ b/tests/unit/test_mcp_plugin.py
@@ -161,14 +161,14 @@ async def test_client_call_tool_mock_and_assert(bigfoot_verifier: StrictVerifier
     import bigfoot
 
     mock_result = {"content": [{"type": "text", "text": "hello"}]}
-    bigfoot.mcp_mock.mock_call_tool("my_tool", returns=mock_result)
+    bigfoot.mcp.mock_call_tool("my_tool", returns=mock_result)
 
     with bigfoot.sandbox():
         session = object.__new__(ClientSession)
         result = await ClientSession.call_tool(session, "my_tool", {"arg1": "val1"})
 
     assert result == mock_result
-    bigfoot.mcp_mock.assert_call_tool(
+    bigfoot.mcp.assert_call_tool(
         "my_tool",
         arguments={"arg1": "val1"},
         direction="client",
@@ -188,14 +188,14 @@ async def test_client_read_resource_mock_and_assert(bigfoot_verifier: StrictVeri
     import bigfoot
 
     mock_result = {"contents": [{"uri": "file:///data.txt", "text": "content"}]}
-    bigfoot.mcp_mock.mock_read_resource("file:///data.txt", returns=mock_result)
+    bigfoot.mcp.mock_read_resource("file:///data.txt", returns=mock_result)
 
     with bigfoot.sandbox():
         session = object.__new__(ClientSession)
         result = await ClientSession.read_resource(session, "file:///data.txt")
 
     assert result == mock_result
-    bigfoot.mcp_mock.assert_read_resource(
+    bigfoot.mcp.assert_read_resource(
         "file:///data.txt",
         direction="client",
     )
@@ -214,14 +214,14 @@ async def test_client_get_prompt_mock_and_assert(bigfoot_verifier: StrictVerifie
     import bigfoot
 
     mock_result = {"messages": [{"role": "user", "content": "hello"}]}
-    bigfoot.mcp_mock.mock_get_prompt("greeting", returns=mock_result)
+    bigfoot.mcp.mock_get_prompt("greeting", returns=mock_result)
 
     with bigfoot.sandbox():
         session = object.__new__(ClientSession)
         result = await ClientSession.get_prompt(session, "greeting", {"name": "world"})
 
     assert result == mock_result
-    bigfoot.mcp_mock.assert_get_prompt(
+    bigfoot.mcp.assert_get_prompt(
         "greeting",
         arguments={"name": "world"},
         direction="client",
@@ -240,8 +240,8 @@ async def test_client_call_tool_fifo_ordering(bigfoot_verifier: StrictVerifier) 
 
     import bigfoot
 
-    bigfoot.mcp_mock.mock_call_tool("tool_a", returns={"seq": 1})
-    bigfoot.mcp_mock.mock_call_tool("tool_a", returns={"seq": 2})
+    bigfoot.mcp.mock_call_tool("tool_a", returns={"seq": 1})
+    bigfoot.mcp.mock_call_tool("tool_a", returns={"seq": 2})
 
     with bigfoot.sandbox():
         session = object.__new__(ClientSession)
@@ -251,8 +251,8 @@ async def test_client_call_tool_fifo_ordering(bigfoot_verifier: StrictVerifier) 
     assert first == {"seq": 1}
     assert second == {"seq": 2}
 
-    bigfoot.mcp_mock.assert_call_tool("tool_a", arguments={"x": "1"}, direction="client")
-    bigfoot.mcp_mock.assert_call_tool("tool_a", arguments={"x": "2"}, direction="client")
+    bigfoot.mcp.assert_call_tool("tool_a", arguments={"x": "1"}, direction="client")
+    bigfoot.mcp.assert_call_tool("tool_a", arguments={"x": "2"}, direction="client")
 
 
 # ---------------------------------------------------------------------------
@@ -267,7 +267,7 @@ async def test_unasserted_interaction_recorded(bigfoot_verifier: StrictVerifier)
 
     import bigfoot
 
-    bigfoot.mcp_mock.mock_call_tool("my_tool", returns={"ok": True})
+    bigfoot.mcp.mock_call_tool("my_tool", returns={"ok": True})
 
     with bigfoot.sandbox():
         session = object.__new__(ClientSession)
@@ -279,7 +279,7 @@ async def test_unasserted_interaction_recorded(bigfoot_verifier: StrictVerifier)
     assert unasserted[0].source_id == "mcp:client:call_tool:my_tool"
 
     # Clean up by asserting
-    bigfoot.mcp_mock.assert_call_tool("my_tool", arguments={"k": "v"}, direction="client")
+    bigfoot.mcp.assert_call_tool("my_tool", arguments={"k": "v"}, direction="client")
 
 
 # ---------------------------------------------------------------------------
@@ -370,17 +370,17 @@ async def test_assert_wrong_tool_name_raises(bigfoot_verifier: StrictVerifier) -
 
     import bigfoot
 
-    bigfoot.mcp_mock.mock_call_tool("real_tool", returns={"ok": True})
+    bigfoot.mcp.mock_call_tool("real_tool", returns={"ok": True})
 
     with bigfoot.sandbox():
         session = object.__new__(ClientSession)
         await ClientSession.call_tool(session, "real_tool", {"k": "v"})
 
     with pytest.raises(InteractionMismatchError):
-        bigfoot.mcp_mock.assert_call_tool("wrong_tool", arguments={"k": "v"}, direction="client")
+        bigfoot.mcp.assert_call_tool("wrong_tool", arguments={"k": "v"}, direction="client")
 
     # Clean up by asserting correctly
-    bigfoot.mcp_mock.assert_call_tool("real_tool", arguments={"k": "v"}, direction="client")
+    bigfoot.mcp.assert_call_tool("real_tool", arguments={"k": "v"}, direction="client")
 
 
 # ---------------------------------------------------------------------------
@@ -456,7 +456,7 @@ async def test_missing_assertion_fields_raises(bigfoot_verifier: StrictVerifier)
 
     import bigfoot
 
-    bigfoot.mcp_mock.mock_call_tool("my_tool", returns={"ok": True})
+    bigfoot.mcp.mock_call_tool("my_tool", returns={"ok": True})
 
     with bigfoot.sandbox():
         session = object.__new__(ClientSession)
@@ -467,7 +467,7 @@ async def test_missing_assertion_fields_raises(bigfoot_verifier: StrictVerifier)
         bigfoot.assert_interaction(sentinel, direction="client")
 
     # Clean up by asserting correctly
-    bigfoot.mcp_mock.assert_call_tool("my_tool", arguments={"k": "v"}, direction="client")
+    bigfoot.mcp.assert_call_tool("my_tool", arguments={"k": "v"}, direction="client")
 
 
 # ---------------------------------------------------------------------------
@@ -529,14 +529,14 @@ async def test_mock_call_tool_raises_exception(bigfoot_verifier: StrictVerifier)
     import bigfoot
 
     err = RuntimeError("boom")
-    bigfoot.mcp_mock.mock_call_tool("failing_tool", returns=None, raises=err)
+    bigfoot.mcp.mock_call_tool("failing_tool", returns=None, raises=err)
 
     with bigfoot.sandbox():
         session = object.__new__(ClientSession)
         with pytest.raises(RuntimeError, match="boom"):
             await ClientSession.call_tool(session, "failing_tool")
 
-    bigfoot.mcp_mock.assert_call_tool(
+    bigfoot.mcp.assert_call_tool(
         "failing_tool", arguments={}, direction="client",
         raised=err,
     )
@@ -636,7 +636,7 @@ def test_format_mock_hint_client_call_tool() -> None:
         plugin=p,
     )
     result = p.format_mock_hint(interaction)
-    assert result == "    bigfoot.mcp_mock.mock_call_tool('my_tool', returns=...)"
+    assert result == "    bigfoot.mcp.mock_call_tool('my_tool', returns=...)"
 
 
 def test_format_mock_hint_server_read_resource() -> None:
@@ -652,7 +652,7 @@ def test_format_mock_hint_server_read_resource() -> None:
         plugin=p,
     )
     result = p.format_mock_hint(interaction)
-    assert result == "    bigfoot.mcp_mock.mock_server_read_resource('file:///x.txt', returns=...)"
+    assert result == "    bigfoot.mcp.mock_server_read_resource('file:///x.txt', returns=...)"
 
 
 def test_format_unmocked_hint() -> None:
@@ -661,7 +661,7 @@ def test_format_unmocked_hint() -> None:
     assert result == (
         "mcp client call_tool('my_tool') was called but no mock was registered.\n"
         "Register a mock with:\n"
-        "    bigfoot.mcp_mock.mock_call_tool('my_tool', returns=...)"
+        "    bigfoot.mcp.mock_call_tool('my_tool', returns=...)"
     )
 
 
@@ -671,7 +671,7 @@ def test_format_unmocked_hint_server() -> None:
     assert result == (
         "mcp server call_tool('server_tool') was called but no mock was registered.\n"
         "Register a mock with:\n"
-        "    bigfoot.mcp_mock.mock_server_call_tool('server_tool', returns=...)"
+        "    bigfoot.mcp.mock_server_call_tool('server_tool', returns=...)"
     )
 
 
@@ -690,7 +690,7 @@ def test_format_assert_hint_call_tool() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        "    bigfoot.mcp_mock.assert_call_tool(\n"
+        "    bigfoot.mcp.assert_call_tool(\n"
         "        tool_name='my_tool',\n"
         "        arguments={'x': 1},\n"
         "        direction='client',\n"
@@ -712,7 +712,7 @@ def test_format_assert_hint_read_resource() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        "    bigfoot.mcp_mock.assert_read_resource(\n"
+        "    bigfoot.mcp.assert_read_resource(\n"
         "        uri='file:///x.txt',\n"
         "        direction='client',\n"
         "    )"
@@ -734,7 +734,7 @@ def test_format_assert_hint_get_prompt() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        "    bigfoot.mcp_mock.assert_get_prompt(\n"
+        "    bigfoot.mcp.assert_get_prompt(\n"
         "        prompt_name='greeting',\n"
         "        arguments={'name': 'world'},\n"
         "        direction='client',\n"
@@ -766,7 +766,7 @@ def test_sentinel_source_id() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.mcp_mock
+# Module-level proxy: bigfoot.mcp
 # ---------------------------------------------------------------------------
 
 
@@ -777,14 +777,14 @@ async def test_mcp_mock_proxy_mock_call_tool(bigfoot_verifier: StrictVerifier) -
 
     import bigfoot
 
-    bigfoot.mcp_mock.mock_call_tool("proxy_tool", returns={"proxied": True})
+    bigfoot.mcp.mock_call_tool("proxy_tool", returns={"proxied": True})
 
     with bigfoot.sandbox():
         session = object.__new__(ClientSession)
         result = await ClientSession.call_tool(session, "proxy_tool", {"a": "b"})
 
     assert result == {"proxied": True}
-    bigfoot.mcp_mock.assert_call_tool(
+    bigfoot.mcp.assert_call_tool(
         "proxy_tool", arguments={"a": "b"}, direction="client"
     )
 
@@ -796,7 +796,7 @@ def test_mcp_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.mcp_mock.mock_call_tool
+            _ = bigfoot.mcp.mock_call_tool
     finally:
         _current_test_verifier.reset(token)
 
@@ -811,7 +811,7 @@ def test_mcp_plugin_in_all() -> None:
     from bigfoot.plugins.mcp_plugin import McpPlugin as _McpPlugin
 
     assert bigfoot.McpPlugin is _McpPlugin
-    assert type(bigfoot.mcp_mock).__name__ == "_McpProxy"
+    assert type(bigfoot.mcp).__name__ == "_McpProxy"
 
 
 # ---------------------------------------------------------------------------
@@ -828,13 +828,13 @@ async def test_call_tool_none_arguments_become_empty_dict(
 
     import bigfoot
 
-    bigfoot.mcp_mock.mock_call_tool("tool_no_args", returns={"ok": True})
+    bigfoot.mcp.mock_call_tool("tool_no_args", returns={"ok": True})
 
     with bigfoot.sandbox():
         session = object.__new__(ClientSession)
         await ClientSession.call_tool(session, "tool_no_args")
 
-    bigfoot.mcp_mock.assert_call_tool(
+    bigfoot.mcp.assert_call_tool(
         "tool_no_args", arguments={}, direction="client"
     )
 
@@ -848,12 +848,12 @@ async def test_get_prompt_none_arguments_become_empty_dict(
 
     import bigfoot
 
-    bigfoot.mcp_mock.mock_get_prompt("my_prompt", returns={"messages": []})
+    bigfoot.mcp.mock_get_prompt("my_prompt", returns={"messages": []})
 
     with bigfoot.sandbox():
         session = object.__new__(ClientSession)
         await ClientSession.get_prompt(session, "my_prompt")
 
-    bigfoot.mcp_mock.assert_get_prompt(
+    bigfoot.mcp.assert_get_prompt(
         "my_prompt", arguments={}, direction="client"
     )

--- a/tests/unit/test_memcache_plugin.py
+++ b/tests/unit/test_memcache_plugin.py
@@ -179,7 +179,7 @@ def test_mock_command_set_returns_value() -> None:
 def test_assert_get_full_assertion(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.memcache_mock.mock_command("GET", returns=b"value")
+    bigfoot.memcache.mock_command("GET", returns=b"value")
 
     with bigfoot.sandbox():
         from pymemcache.client.base import Client
@@ -187,13 +187,13 @@ def test_assert_get_full_assertion(bigfoot_verifier: StrictVerifier) -> None:
         client = Client(("localhost", 11211))
         client.get("mykey")
 
-    bigfoot.memcache_mock.assert_get(command="GET", key="mykey")
+    bigfoot.memcache.assert_get(command="GET", key="mykey")
 
 
 def test_assert_set_full_assertion(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.memcache_mock.mock_command("SET", returns=True)
+    bigfoot.memcache.mock_command("SET", returns=True)
 
     with bigfoot.sandbox():
         from pymemcache.client.base import Client
@@ -201,7 +201,7 @@ def test_assert_set_full_assertion(bigfoot_verifier: StrictVerifier) -> None:
         client = Client(("localhost", 11211))
         client.set("mykey", b"myvalue", expire=300)
 
-    bigfoot.memcache_mock.assert_set(
+    bigfoot.memcache.assert_set(
         command="SET", key="mykey", value=b"myvalue", expire=300,
     )
 
@@ -343,7 +343,7 @@ def test_missing_assertion_fields(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
     from bigfoot.plugins.memcache_plugin import _MemcacheSentinel
 
-    bigfoot.memcache_mock.mock_command("SET", returns=True)
+    bigfoot.memcache.mock_command("SET", returns=True)
 
     with bigfoot.sandbox():
         from pymemcache.client.base import Client
@@ -358,7 +358,7 @@ def test_missing_assertion_fields(bigfoot_verifier: StrictVerifier) -> None:
 
     assert "key" in exc_info.value.missing_fields
     # Now assert fully so teardown passes
-    bigfoot.memcache_mock.assert_set(
+    bigfoot.memcache.assert_set(
         command="SET", key="mykey", value=b"myvalue", expire=300,
     )
 
@@ -371,7 +371,7 @@ def test_missing_assertion_fields(bigfoot_verifier: StrictVerifier) -> None:
 def test_memcache_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.memcache_mock.mock_command("GET", returns=b"value")
+    bigfoot.memcache.mock_command("GET", returns=b"value")
 
     with bigfoot.sandbox():
         from pymemcache.client.base import Client
@@ -384,7 +384,7 @@ def test_memcache_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifie
     assert len(interactions) == 1
     assert interactions[0].source_id == "memcache:get"
     # Assert it so verify_all() at teardown succeeds
-    bigfoot.memcache_mock.assert_get(command="GET", key="mykey")
+    bigfoot.memcache.assert_get(command="GET", key="mykey")
 
 
 # ---------------------------------------------------------------------------
@@ -442,7 +442,7 @@ def test_format_mock_hint() -> None:
         plugin=p,
     )
     result = p.format_mock_hint(interaction)
-    assert result == "    bigfoot.memcache_mock.mock_command('GET', returns=...)"
+    assert result == "    bigfoot.memcache.mock_command('GET', returns=...)"
 
 
 def test_format_unmocked_hint() -> None:
@@ -451,7 +451,7 @@ def test_format_unmocked_hint() -> None:
     assert result == (
         "memcache.GET(...) was called but no mock was registered.\n"
         "Register a mock with:\n"
-        "    bigfoot.memcache_mock.mock_command('GET', returns=...)"
+        "    bigfoot.memcache.mock_command('GET', returns=...)"
     )
 
 
@@ -465,7 +465,7 @@ def test_format_assert_hint() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        "    bigfoot.memcache_mock.assert_get(\n"
+        "    bigfoot.memcache.assert_get(\n"
         "        command='GET',\n"
         "        key='mykey',\n"
         "    )"
@@ -484,14 +484,14 @@ def test_format_unused_mock_hint() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.memcache_mock
+# Module-level proxy: bigfoot.memcache
 # ---------------------------------------------------------------------------
 
 
 def test_memcache_mock_proxy_mock_command(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.memcache_mock.mock_command("GET", returns=b"proxy_value")
+    bigfoot.memcache.mock_command("GET", returns=b"proxy_value")
 
     with bigfoot.sandbox():
         from pymemcache.client.base import Client
@@ -500,7 +500,7 @@ def test_memcache_mock_proxy_mock_command(bigfoot_verifier: StrictVerifier) -> N
         result = client.get("somekey")
 
     assert result == b"proxy_value"
-    bigfoot.memcache_mock.assert_get(command="GET", key="somekey")
+    bigfoot.memcache.assert_get(command="GET", key="somekey")
 
 
 def test_memcache_mock_proxy_raises_outside_context() -> None:
@@ -510,7 +510,7 @@ def test_memcache_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.memcache_mock.mock_command
+            _ = bigfoot.memcache.mock_command
     finally:
         _current_test_verifier.reset(token)
 
@@ -524,8 +524,8 @@ def test_memcache_plugin_in_all() -> None:
     import bigfoot
 
     assert "MemcachePlugin" in bigfoot.__all__
-    assert "memcache_mock" in bigfoot.__all__
-    assert type(bigfoot.memcache_mock).__name__ == "_MemcacheProxy"
+    assert "memcache" in bigfoot.__all__
+    assert type(bigfoot.memcache).__name__ == "_MemcacheProxy"
 
 
 # ---------------------------------------------------------------------------
@@ -536,7 +536,7 @@ def test_memcache_plugin_in_all() -> None:
 def test_assert_delete(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.memcache_mock.mock_command("DELETE", returns=True)
+    bigfoot.memcache.mock_command("DELETE", returns=True)
 
     with bigfoot.sandbox():
         from pymemcache.client.base import Client
@@ -544,13 +544,13 @@ def test_assert_delete(bigfoot_verifier: StrictVerifier) -> None:
         client = Client(("localhost", 11211))
         client.delete("mykey")
 
-    bigfoot.memcache_mock.assert_delete(command="DELETE", key="mykey")
+    bigfoot.memcache.assert_delete(command="DELETE", key="mykey")
 
 
 def test_assert_incr(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.memcache_mock.mock_command("INCR", returns=42)
+    bigfoot.memcache.mock_command("INCR", returns=42)
 
     with bigfoot.sandbox():
         from pymemcache.client.base import Client
@@ -558,13 +558,13 @@ def test_assert_incr(bigfoot_verifier: StrictVerifier) -> None:
         client = Client(("localhost", 11211))
         client.incr("counter", 1)
 
-    bigfoot.memcache_mock.assert_incr(command="INCR", key="counter", value=1)
+    bigfoot.memcache.assert_incr(command="INCR", key="counter", value=1)
 
 
 def test_assert_get_wrong_args_raises(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.memcache_mock.mock_command("GET", returns=b"val")
+    bigfoot.memcache.mock_command("GET", returns=b"val")
 
     with bigfoot.sandbox():
         from pymemcache.client.base import Client
@@ -573,6 +573,6 @@ def test_assert_get_wrong_args_raises(bigfoot_verifier: StrictVerifier) -> None:
         client.get("mykey")
 
     with pytest.raises(InteractionMismatchError):
-        bigfoot.memcache_mock.assert_get(command="GET", key="wrongkey")
+        bigfoot.memcache.assert_get(command="GET", key="wrongkey")
     # Assert correctly so teardown passes
-    bigfoot.memcache_mock.assert_get(command="GET", key="mykey")
+    bigfoot.memcache.assert_get(command="GET", key="mykey")

--- a/tests/unit/test_mongo_plugin.py
+++ b/tests/unit/test_mongo_plugin.py
@@ -518,7 +518,7 @@ def test_format_mock_hint() -> None:
         plugin=p,
     )
     result = p.format_mock_hint(interaction)
-    assert result == "    bigfoot.mongo_mock.mock_operation('find_one', returns=...)"
+    assert result == "    bigfoot.mongo.mock_operation('find_one', returns=...)"
 
 
 # ESCAPE: test_format_unmocked_hint
@@ -533,7 +533,7 @@ def test_format_unmocked_hint() -> None:
     assert result == (
         "mongo.find_one(...) was called but no mock was registered.\n"
         "Register a mock with:\n"
-        "    bigfoot.mongo_mock.mock_operation('find_one', returns=...)"
+        "    bigfoot.mongo.mock_operation('find_one', returns=...)"
     )
 
 
@@ -561,7 +561,7 @@ def test_format_assert_hint() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        "    bigfoot.mongo_mock.assert_find_one(\n"
+        "    bigfoot.mongo.assert_find_one(\n"
         "        database='testdb',\n"
         "        collection='testcoll',\n"
         "        filter={'_id': 1},\n"
@@ -593,7 +593,7 @@ def test_format_assert_hint_insert_one() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        "    bigfoot.mongo_mock.assert_insert_one(\n"
+        "    bigfoot.mongo.assert_insert_one(\n"
         "        database='testdb',\n"
         "        collection='testcoll',\n"
         "        document={'name': 'Alice'},\n"
@@ -631,12 +631,12 @@ def test_format_unused_mock_hint() -> None:
 def test_assert_find_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.mongo_mock.mock_operation("find", returns=[{"x": 1}])
+    bigfoot.mongo.mock_operation("find", returns=[{"x": 1}])
     with bigfoot.sandbox():
         coll = _make_collection("mydb", "users")
         coll.find({"active": True}, {"name": 1})
 
-    bigfoot.mongo_mock.assert_find(
+    bigfoot.mongo.assert_find(
         database="mydb",
         collection="users",
         filter={"active": True},
@@ -653,12 +653,12 @@ def test_assert_find_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
 def test_assert_find_one_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.mongo_mock.mock_operation("find_one", returns={"_id": 1})
+    bigfoot.mongo.mock_operation("find_one", returns={"_id": 1})
     with bigfoot.sandbox():
         coll = _make_collection("mydb", "users")
         coll.find_one({"_id": 1}, {"name": 1})
 
-    bigfoot.mongo_mock.assert_find_one(
+    bigfoot.mongo.assert_find_one(
         database="mydb",
         collection="users",
         filter={"_id": 1},
@@ -675,12 +675,12 @@ def test_assert_find_one_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
 def test_assert_insert_one_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.mongo_mock.mock_operation("insert_one", returns=MagicMock(inserted_id="abc"))
+    bigfoot.mongo.mock_operation("insert_one", returns=MagicMock(inserted_id="abc"))
     with bigfoot.sandbox():
         coll = _make_collection("mydb", "users")
         coll.insert_one({"name": "Alice"})
 
-    bigfoot.mongo_mock.assert_insert_one(
+    bigfoot.mongo.assert_insert_one(
         database="mydb",
         collection="users",
         document={"name": "Alice"},
@@ -696,12 +696,12 @@ def test_assert_insert_one_typed_helper(bigfoot_verifier: StrictVerifier) -> Non
 def test_assert_update_one_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.mongo_mock.mock_operation("update_one", returns=MagicMock(modified_count=1))
+    bigfoot.mongo.mock_operation("update_one", returns=MagicMock(modified_count=1))
     with bigfoot.sandbox():
         coll = _make_collection("mydb", "users")
         coll.update_one({"_id": 1}, {"$set": {"name": "Bob"}})
 
-    bigfoot.mongo_mock.assert_update_one(
+    bigfoot.mongo.assert_update_one(
         database="mydb",
         collection="users",
         filter={"_id": 1},
@@ -718,12 +718,12 @@ def test_assert_update_one_typed_helper(bigfoot_verifier: StrictVerifier) -> Non
 def test_assert_delete_one_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.mongo_mock.mock_operation("delete_one", returns=MagicMock(deleted_count=1))
+    bigfoot.mongo.mock_operation("delete_one", returns=MagicMock(deleted_count=1))
     with bigfoot.sandbox():
         coll = _make_collection("mydb", "users")
         coll.delete_one({"_id": 1})
 
-    bigfoot.mongo_mock.assert_delete_one(
+    bigfoot.mongo.assert_delete_one(
         database="mydb",
         collection="users",
         filter={"_id": 1},
@@ -740,12 +740,12 @@ def test_assert_aggregate_typed_helper(bigfoot_verifier: StrictVerifier) -> None
     import bigfoot
 
     pipeline = [{"$match": {"active": True}}, {"$group": {"_id": "$type"}}]
-    bigfoot.mongo_mock.mock_operation("aggregate", returns=[{"_id": "A"}])
+    bigfoot.mongo.mock_operation("aggregate", returns=[{"_id": "A"}])
     with bigfoot.sandbox():
         coll = _make_collection("mydb", "users")
         coll.aggregate(pipeline)
 
-    bigfoot.mongo_mock.assert_aggregate(
+    bigfoot.mongo.assert_aggregate(
         database="mydb",
         collection="users",
         pipeline=pipeline,
@@ -761,12 +761,12 @@ def test_assert_aggregate_typed_helper(bigfoot_verifier: StrictVerifier) -> None
 def test_assert_insert_many_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.mongo_mock.mock_operation("insert_many", returns=MagicMock(inserted_ids=["a", "b"]))
+    bigfoot.mongo.mock_operation("insert_many", returns=MagicMock(inserted_ids=["a", "b"]))
     with bigfoot.sandbox():
         coll = _make_collection("mydb", "items")
         coll.insert_many([{"x": 1}, {"x": 2}])
 
-    bigfoot.mongo_mock.assert_insert_many(
+    bigfoot.mongo.assert_insert_many(
         database="mydb",
         collection="items",
         documents=[{"x": 1}, {"x": 2}],
@@ -782,12 +782,12 @@ def test_assert_insert_many_typed_helper(bigfoot_verifier: StrictVerifier) -> No
 def test_assert_update_many_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.mongo_mock.mock_operation("update_many", returns=MagicMock(modified_count=5))
+    bigfoot.mongo.mock_operation("update_many", returns=MagicMock(modified_count=5))
     with bigfoot.sandbox():
         coll = _make_collection("mydb", "items")
         coll.update_many({"status": "old"}, {"$set": {"status": "new"}})
 
-    bigfoot.mongo_mock.assert_update_many(
+    bigfoot.mongo.assert_update_many(
         database="mydb",
         collection="items",
         filter={"status": "old"},
@@ -804,12 +804,12 @@ def test_assert_update_many_typed_helper(bigfoot_verifier: StrictVerifier) -> No
 def test_assert_delete_many_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.mongo_mock.mock_operation("delete_many", returns=MagicMock(deleted_count=3))
+    bigfoot.mongo.mock_operation("delete_many", returns=MagicMock(deleted_count=3))
     with bigfoot.sandbox():
         coll = _make_collection("mydb", "items")
         coll.delete_many({"status": "old"})
 
-    bigfoot.mongo_mock.assert_delete_many(
+    bigfoot.mongo.assert_delete_many(
         database="mydb",
         collection="items",
         filter={"status": "old"},
@@ -825,12 +825,12 @@ def test_assert_delete_many_typed_helper(bigfoot_verifier: StrictVerifier) -> No
 def test_assert_count_documents_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.mongo_mock.mock_operation("count_documents", returns=42)
+    bigfoot.mongo.mock_operation("count_documents", returns=42)
     with bigfoot.sandbox():
         coll = _make_collection("mydb", "items")
         coll.count_documents({"active": True})
 
-    bigfoot.mongo_mock.assert_count_documents(
+    bigfoot.mongo.assert_count_documents(
         database="mydb",
         collection="items",
         filter={"active": True},
@@ -851,20 +851,20 @@ def test_assert_count_documents_typed_helper(bigfoot_verifier: StrictVerifier) -
 def test_assert_find_one_wrong_filter_raises(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.mongo_mock.mock_operation("find_one", returns={"x": 1})
+    bigfoot.mongo.mock_operation("find_one", returns={"x": 1})
     with bigfoot.sandbox():
         coll = _make_collection("mydb", "users")
         coll.find_one({"_id": 1})
 
     with pytest.raises(InteractionMismatchError):
-        bigfoot.mongo_mock.assert_find_one(
+        bigfoot.mongo.assert_find_one(
             database="mydb",
             collection="users",
             filter={"_id": 999},
             projection=None,
         )
     # Now assert correctly so teardown passes
-    bigfoot.mongo_mock.assert_find_one(
+    bigfoot.mongo.assert_find_one(
         database="mydb",
         collection="users",
         filter={"_id": 1},
@@ -886,7 +886,7 @@ def test_assert_find_one_wrong_filter_raises(bigfoot_verifier: StrictVerifier) -
 def test_mongo_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.mongo_mock.mock_operation("find_one", returns={"x": 1})
+    bigfoot.mongo.mock_operation("find_one", returns={"x": 1})
     with bigfoot.sandbox():
         coll = _make_collection("mydb", "users")
         coll.find_one({"_id": 1})
@@ -896,7 +896,7 @@ def test_mongo_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier) 
     assert len(interactions) == 1
     assert interactions[0].source_id == "mongo:find_one"
     # Assert it so verify_all() at teardown succeeds
-    bigfoot.mongo_mock.assert_find_one(
+    bigfoot.mongo.assert_find_one(
         database="mydb",
         collection="users",
         filter={"_id": 1},
@@ -905,12 +905,12 @@ def test_mongo_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier) 
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.mongo_mock
+# Module-level proxy: bigfoot.mongo
 # ---------------------------------------------------------------------------
 
 
 # ESCAPE: test_mongo_mock_proxy_mock_operation
-#   CLAIM: bigfoot.mongo_mock.mock_operation("find_one", returns=...) works when verifier active.
+#   CLAIM: bigfoot.mongo.mock_operation("find_one", returns=...) works when verifier active.
 #   PATH:  _MongoProxy.__getattr__("mock_operation") -> get verifier ->
 #          find/create MongoPlugin -> return plugin.mock_operation.
 #   CHECK: The proxy call does not raise and the mock is registered.
@@ -919,13 +919,13 @@ def test_mongo_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier) 
 def test_mongo_mock_proxy_mock_operation(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.mongo_mock.mock_operation("find_one", returns={"proxy": True})
+    bigfoot.mongo.mock_operation("find_one", returns={"proxy": True})
     with bigfoot.sandbox():
         coll = _make_collection("proxydb", "proxycoll")
         result = coll.find_one({"k": 1})
 
     assert result == {"proxy": True}
-    bigfoot.mongo_mock.assert_find_one(
+    bigfoot.mongo.assert_find_one(
         database="proxydb",
         collection="proxycoll",
         filter={"k": 1},
@@ -934,7 +934,7 @@ def test_mongo_mock_proxy_mock_operation(bigfoot_verifier: StrictVerifier) -> No
 
 
 # ESCAPE: test_mongo_mock_proxy_raises_outside_context
-#   CLAIM: Accessing bigfoot.mongo_mock outside a test context raises NoActiveVerifierError.
+#   CLAIM: Accessing bigfoot.mongo outside a test context raises NoActiveVerifierError.
 #   PATH:  _MongoProxy.__getattr__ -> _get_test_verifier_or_raise -> NoActiveVerifierError.
 #   CHECK: NoActiveVerifierError raised.
 #   MUTATION: Silently returning None would not raise.
@@ -946,7 +946,7 @@ def test_mongo_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.mongo_mock.mock_operation
+            _ = bigfoot.mongo.mock_operation
     finally:
         _current_test_verifier.reset(token)
 
@@ -957,16 +957,16 @@ def test_mongo_mock_proxy_raises_outside_context() -> None:
 
 
 # ESCAPE: test_mongo_plugin_in_all
-#   CLAIM: MongoPlugin and mongo_mock are exported from bigfoot.__all__.
-#   PATH:  bigfoot.__all__ contains "MongoPlugin" and "mongo_mock".
-#   CHECK: "MongoPlugin" in bigfoot.__all__; "mongo_mock" in bigfoot.__all__.
+#   CLAIM: MongoPlugin and mongo are exported from bigfoot.__all__.
+#   PATH:  bigfoot.__all__ contains "MongoPlugin" and "mongo".
+#   CHECK: "MongoPlugin" in bigfoot.__all__; "mongo" in bigfoot.__all__.
 #   MUTATION: Omitting either from __all__ fails the membership check.
 #   ESCAPE: Nothing reasonable -- exact membership check.
 def test_mongo_plugin_in_all() -> None:
     import bigfoot
 
     assert "MongoPlugin" in bigfoot.__all__
-    assert "mongo_mock" in bigfoot.__all__
+    assert "mongo" in bigfoot.__all__
 
 
 # ---------------------------------------------------------------------------
@@ -984,7 +984,7 @@ def test_missing_fields_raises_error(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
     from bigfoot.plugins.mongo_plugin import _MongoSentinel
 
-    bigfoot.mongo_mock.mock_operation("find_one", returns={"x": 1})
+    bigfoot.mongo.mock_operation("find_one", returns={"x": 1})
     with bigfoot.sandbox():
         coll = _make_collection("mydb", "users")
         coll.find_one({"_id": 1})
@@ -1001,7 +1001,7 @@ def test_missing_fields_raises_error(bigfoot_verifier: StrictVerifier) -> None:
     assert "filter" in exc_info.value.missing_fields
 
     # Now assert correctly so teardown passes
-    bigfoot.mongo_mock.assert_find_one(
+    bigfoot.mongo.assert_find_one(
         database="mydb",
         collection="users",
         filter={"_id": 1},
@@ -1135,13 +1135,13 @@ def test_aggregate_interception() -> None:
 def test_find_one_records_correct_details(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.mongo_mock.mock_operation("find_one", returns={"x": 1})
+    bigfoot.mongo.mock_operation("find_one", returns={"x": 1})
     with bigfoot.sandbox():
         coll = _make_collection("recdb", "reccoll")
         coll.find_one({"_id": 1}, {"name": 1})
 
     # This asserts ALL required fields
-    bigfoot.mongo_mock.assert_find_one(
+    bigfoot.mongo.assert_find_one(
         database="recdb",
         collection="reccoll",
         filter={"_id": 1},
@@ -1158,12 +1158,12 @@ def test_find_one_records_correct_details(bigfoot_verifier: StrictVerifier) -> N
 def test_insert_one_records_correct_details(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.mongo_mock.mock_operation("insert_one", returns=MagicMock(inserted_id="abc"))
+    bigfoot.mongo.mock_operation("insert_one", returns=MagicMock(inserted_id="abc"))
     with bigfoot.sandbox():
         coll = _make_collection("recdb", "reccoll")
         coll.insert_one({"name": "Alice", "age": 30})
 
-    bigfoot.mongo_mock.assert_insert_one(
+    bigfoot.mongo.assert_insert_one(
         database="recdb",
         collection="reccoll",
         document={"name": "Alice", "age": 30},
@@ -1179,12 +1179,12 @@ def test_insert_one_records_correct_details(bigfoot_verifier: StrictVerifier) ->
 def test_update_one_records_correct_details(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.mongo_mock.mock_operation("update_one", returns=MagicMock(modified_count=1))
+    bigfoot.mongo.mock_operation("update_one", returns=MagicMock(modified_count=1))
     with bigfoot.sandbox():
         coll = _make_collection("recdb", "reccoll")
         coll.update_one({"_id": 1}, {"$set": {"name": "Bob"}})
 
-    bigfoot.mongo_mock.assert_update_one(
+    bigfoot.mongo.assert_update_one(
         database="recdb",
         collection="reccoll",
         filter={"_id": 1},
@@ -1201,12 +1201,12 @@ def test_update_one_records_correct_details(bigfoot_verifier: StrictVerifier) ->
 def test_delete_one_records_correct_details(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.mongo_mock.mock_operation("delete_one", returns=MagicMock(deleted_count=1))
+    bigfoot.mongo.mock_operation("delete_one", returns=MagicMock(deleted_count=1))
     with bigfoot.sandbox():
         coll = _make_collection("recdb", "reccoll")
         coll.delete_one({"_id": 1})
 
-    bigfoot.mongo_mock.assert_delete_one(
+    bigfoot.mongo.assert_delete_one(
         database="recdb",
         collection="reccoll",
         filter={"_id": 1},
@@ -1223,12 +1223,12 @@ def test_aggregate_records_correct_details(bigfoot_verifier: StrictVerifier) -> 
     import bigfoot
 
     pipeline = [{"$match": {"active": True}}]
-    bigfoot.mongo_mock.mock_operation("aggregate", returns=[])
+    bigfoot.mongo.mock_operation("aggregate", returns=[])
     with bigfoot.sandbox():
         coll = _make_collection("recdb", "reccoll")
         coll.aggregate(pipeline)
 
-    bigfoot.mongo_mock.assert_aggregate(
+    bigfoot.mongo.assert_aggregate(
         database="recdb",
         collection="reccoll",
         pipeline=pipeline,
@@ -1245,7 +1245,7 @@ def test_count_documents_records_correct_details(bigfoot_verifier: StrictVerifie
     import bigfoot
     from bigfoot.plugins.mongo_plugin import _MongoSentinel
 
-    bigfoot.mongo_mock.mock_operation("count_documents", returns=42)
+    bigfoot.mongo.mock_operation("count_documents", returns=42)
     with bigfoot.sandbox():
         coll = _make_collection("recdb", "reccoll")
         coll.count_documents({"active": True})
@@ -1270,12 +1270,12 @@ def test_insert_many_records_correct_details(bigfoot_verifier: StrictVerifier) -
     import bigfoot
 
     docs = [{"x": 1}, {"x": 2}]
-    bigfoot.mongo_mock.mock_operation("insert_many", returns=MagicMock(inserted_ids=["a", "b"]))
+    bigfoot.mongo.mock_operation("insert_many", returns=MagicMock(inserted_ids=["a", "b"]))
     with bigfoot.sandbox():
         coll = _make_collection("recdb", "reccoll")
         coll.insert_many(docs)
 
-    bigfoot.mongo_mock.assert_insert_many(
+    bigfoot.mongo.assert_insert_many(
         database="recdb",
         collection="reccoll",
         documents=docs,
@@ -1291,12 +1291,12 @@ def test_insert_many_records_correct_details(bigfoot_verifier: StrictVerifier) -
 def test_update_many_records_correct_details(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.mongo_mock.mock_operation("update_many", returns=MagicMock(modified_count=5))
+    bigfoot.mongo.mock_operation("update_many", returns=MagicMock(modified_count=5))
     with bigfoot.sandbox():
         coll = _make_collection("recdb", "reccoll")
         coll.update_many({"status": "old"}, {"$set": {"status": "new"}})
 
-    bigfoot.mongo_mock.assert_update_many(
+    bigfoot.mongo.assert_update_many(
         database="recdb",
         collection="reccoll",
         filter={"status": "old"},
@@ -1313,12 +1313,12 @@ def test_update_many_records_correct_details(bigfoot_verifier: StrictVerifier) -
 def test_delete_many_records_correct_details(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.mongo_mock.mock_operation("delete_many", returns=MagicMock(deleted_count=3))
+    bigfoot.mongo.mock_operation("delete_many", returns=MagicMock(deleted_count=3))
     with bigfoot.sandbox():
         coll = _make_collection("recdb", "reccoll")
         coll.delete_many({"status": "old"})
 
-    bigfoot.mongo_mock.assert_delete_many(
+    bigfoot.mongo.assert_delete_many(
         database="recdb",
         collection="reccoll",
         filter={"status": "old"},
@@ -1339,12 +1339,12 @@ def test_delete_many_records_correct_details(bigfoot_verifier: StrictVerifier) -
 def test_find_one_kwargs_extraction(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.mongo_mock.mock_operation("find_one", returns={"x": 1})
+    bigfoot.mongo.mock_operation("find_one", returns={"x": 1})
     with bigfoot.sandbox():
         coll = _make_collection("mydb", "users")
         coll.find_one(filter={"_id": 1}, projection={"name": 1})
 
-    bigfoot.mongo_mock.assert_find_one(
+    bigfoot.mongo.assert_find_one(
         database="mydb",
         collection="users",
         filter={"_id": 1},
@@ -1361,12 +1361,12 @@ def test_find_one_kwargs_extraction(bigfoot_verifier: StrictVerifier) -> None:
 def test_insert_one_kwargs_extraction(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.mongo_mock.mock_operation("insert_one", returns=MagicMock(inserted_id="abc"))
+    bigfoot.mongo.mock_operation("insert_one", returns=MagicMock(inserted_id="abc"))
     with bigfoot.sandbox():
         coll = _make_collection("mydb", "users")
         coll.insert_one(document={"name": "Alice"})
 
-    bigfoot.mongo_mock.assert_insert_one(
+    bigfoot.mongo.assert_insert_one(
         database="mydb",
         collection="users",
         document={"name": "Alice"},

--- a/tests/unit/test_native_plugin.py
+++ b/tests/unit/test_native_plugin.py
@@ -184,7 +184,7 @@ def test_unused_mock_excludes_required_false() -> None:
 def test_missing_fields_error(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.native_mock.mock_call("libm", "sqrt", returns=6.48)
+    bigfoot.native.mock_call("libm", "sqrt", returns=6.48)
     with bigfoot.sandbox():
         lib = ctypes.CDLL("libm")
         lib.sqrt(42)
@@ -201,7 +201,7 @@ def test_missing_fields_error(bigfoot_verifier: StrictVerifier) -> None:
     assert exc_info.value.missing_fields == frozenset({"args"})
 
     # Assert correctly for teardown
-    bigfoot.native_mock.assert_call("libm", "sqrt", args=(42,))
+    bigfoot.native.assert_call("libm", "sqrt", args=(42,))
 
 
 # ---------------------------------------------------------------------------
@@ -218,12 +218,12 @@ def test_missing_fields_error(bigfoot_verifier: StrictVerifier) -> None:
 def test_assert_call_typed_helper_positive(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.native_mock.mock_call("libm", "sqrt", returns=6.48)
+    bigfoot.native.mock_call("libm", "sqrt", returns=6.48)
     with bigfoot.sandbox():
         lib = ctypes.CDLL("libm")
         lib.sqrt(42)
 
-    bigfoot.native_mock.assert_call("libm", "sqrt", args=(42,))
+    bigfoot.native.assert_call("libm", "sqrt", args=(42,))
 
 
 # ESCAPE: test_assert_call_typed_helper_negative_wrong_args
@@ -235,16 +235,16 @@ def test_assert_call_typed_helper_positive(bigfoot_verifier: StrictVerifier) -> 
 def test_assert_call_typed_helper_negative_wrong_args(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.native_mock.mock_call("libm", "sqrt", returns=6.48)
+    bigfoot.native.mock_call("libm", "sqrt", returns=6.48)
     with bigfoot.sandbox():
         lib = ctypes.CDLL("libm")
         lib.sqrt(42)
 
     with pytest.raises(InteractionMismatchError):
-        bigfoot.native_mock.assert_call("libm", "sqrt", args=(999,))
+        bigfoot.native.assert_call("libm", "sqrt", args=(999,))
 
     # Assert correctly for teardown
-    bigfoot.native_mock.assert_call("libm", "sqrt", args=(42,))
+    bigfoot.native.assert_call("libm", "sqrt", args=(42,))
 
 
 # ESCAPE: test_assert_call_typed_helper_negative_wrong_function
@@ -256,16 +256,16 @@ def test_assert_call_typed_helper_negative_wrong_args(bigfoot_verifier: StrictVe
 def test_assert_call_typed_helper_negative_wrong_function(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.native_mock.mock_call("libm", "sqrt", returns=6.48)
+    bigfoot.native.mock_call("libm", "sqrt", returns=6.48)
     with bigfoot.sandbox():
         lib = ctypes.CDLL("libm")
         lib.sqrt(42)
 
     with pytest.raises(InteractionMismatchError):
-        bigfoot.native_mock.assert_call("libm", "cos", args=(42,))
+        bigfoot.native.assert_call("libm", "cos", args=(42,))
 
     # Assert correctly for teardown
-    bigfoot.native_mock.assert_call("libm", "sqrt", args=(42,))
+    bigfoot.native.assert_call("libm", "sqrt", args=(42,))
 
 
 # ESCAPE: test_assert_call_typed_helper_negative_wrong_library
@@ -277,16 +277,16 @@ def test_assert_call_typed_helper_negative_wrong_function(bigfoot_verifier: Stri
 def test_assert_call_typed_helper_negative_wrong_library(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.native_mock.mock_call("libm", "sqrt", returns=6.48)
+    bigfoot.native.mock_call("libm", "sqrt", returns=6.48)
     with bigfoot.sandbox():
         lib = ctypes.CDLL("libm")
         lib.sqrt(42)
 
     with pytest.raises(InteractionMismatchError):
-        bigfoot.native_mock.assert_call("libz", "sqrt", args=(42,))
+        bigfoot.native.assert_call("libz", "sqrt", args=(42,))
 
     # Assert correctly for teardown
-    bigfoot.native_mock.assert_call("libm", "sqrt", args=(42,))
+    bigfoot.native.assert_call("libm", "sqrt", args=(42,))
 
 
 # ---------------------------------------------------------------------------
@@ -580,7 +580,7 @@ def test_not_default_enabled() -> None:
 def test_flow_assert_interaction_records_details(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.native_mock.mock_call("libm", "sqrt", returns=6.48)
+    bigfoot.native.mock_call("libm", "sqrt", returns=6.48)
     with bigfoot.sandbox():
         lib = ctypes.CDLL("libm")
         lib.sqrt(42)
@@ -597,7 +597,7 @@ def test_flow_assert_interaction_records_details(bigfoot_verifier: StrictVerifie
     }
 
     # Assert to satisfy teardown
-    bigfoot.native_mock.assert_call("libm", "sqrt", args=(42,))
+    bigfoot.native.assert_call("libm", "sqrt", args=(42,))
 
 
 # ESCAPE: test_flow_interactions_not_auto_asserted
@@ -609,7 +609,7 @@ def test_flow_assert_interaction_records_details(bigfoot_verifier: StrictVerifie
 def test_flow_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.native_mock.mock_call("libm", "sqrt", returns=6.48)
+    bigfoot.native.mock_call("libm", "sqrt", returns=6.48)
     with bigfoot.sandbox():
         lib = ctypes.CDLL("libm")
         lib.sqrt(42)
@@ -619,7 +619,7 @@ def test_flow_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier) -
     assert interactions[0].source_id == "native:libm:sqrt"
 
     # Assert to satisfy teardown
-    bigfoot.native_mock.assert_call("libm", "sqrt", args=(42,))
+    bigfoot.native.assert_call("libm", "sqrt", args=(42,))
 
 
 # ---------------------------------------------------------------------------
@@ -696,7 +696,7 @@ def test_format_mock_hint() -> None:
         plugin=p,
     )
     result = p.format_mock_hint(interaction)
-    assert result == "    bigfoot.native_mock.mock_call('libm', 'sqrt', returns=...)"
+    assert result == "    bigfoot.native.mock_call('libm', 'sqrt', returns=...)"
 
 
 # ESCAPE: test_format_unmocked_hint
@@ -711,7 +711,7 @@ def test_format_unmocked_hint() -> None:
     assert result == (
         "libm.sqrt(...) was called but no mock was registered.\n"
         "Register a mock with:\n"
-        "    bigfoot.native_mock.mock_call('libm', 'sqrt', returns=...)"
+        "    bigfoot.native.mock_call('libm', 'sqrt', returns=...)"
     )
 
 
@@ -731,7 +731,7 @@ def test_format_assert_hint() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        "    bigfoot.native_mock.assert_call(\n"
+        "    bigfoot.native.assert_call(\n"
         "        library='libm',\n"
         "        function='sqrt',\n"
         "        args=(42,),\n"
@@ -890,8 +890,8 @@ def test_activate_deactivate_reference_counting() -> None:
 
 
 # ESCAPE: test_native_plugin_in_all
-#   CLAIM: NativePlugin and native_mock are exported from bigfoot.__all__.
-#   PATH:  bigfoot.__all__ includes "NativePlugin" and "native_mock".
+#   CLAIM: NativePlugin and native are exported from bigfoot.__all__.
+#   PATH:  bigfoot.__all__ includes "NativePlugin" and "native".
 #   CHECK: Both names present in __all__.
 #   MUTATION: Omitting either from __all__ fails membership.
 #   ESCAPE: Nothing reasonable -- exact membership check.
@@ -899,7 +899,7 @@ def test_native_plugin_in_all() -> None:
     import bigfoot
 
     assert "NativePlugin" in bigfoot.__all__
-    assert "native_mock" in bigfoot.__all__
+    assert "native" in bigfoot.__all__
 
 
 # ESCAPE: test_native_plugin_importable_from_bigfoot
@@ -916,19 +916,19 @@ def test_native_plugin_importable_from_bigfoot() -> None:
 
 
 # ESCAPE: test_native_mock_proxy_type
-#   CLAIM: bigfoot.native_mock is a _NativeProxy instance.
-#   PATH:  bigfoot.native_mock is a module-level proxy.
-#   CHECK: type(bigfoot.native_mock).__name__ == "_NativeProxy".
+#   CLAIM: bigfoot.native is a _NativeProxy instance.
+#   PATH:  bigfoot.native is a module-level proxy.
+#   CHECK: type(bigfoot.native).__name__ == "_NativeProxy".
 #   MUTATION: Wrong proxy type fails name check.
 #   ESCAPE: Nothing reasonable -- exact string equality on type name.
 def test_native_mock_proxy_type() -> None:
     import bigfoot
 
-    assert type(bigfoot.native_mock).__name__ == "_NativeProxy"
+    assert type(bigfoot.native).__name__ == "_NativeProxy"
 
 
 # ESCAPE: test_native_mock_proxy_raises_outside_context
-#   CLAIM: Accessing bigfoot.native_mock outside test context raises NoActiveVerifierError.
+#   CLAIM: Accessing bigfoot.native outside test context raises NoActiveVerifierError.
 #   PATH:  _NativeProxy.__getattr__ -> _get_test_verifier_or_raise -> raises.
 #   CHECK: NoActiveVerifierError raised.
 #   MUTATION: Not raising allows silent use outside tests.
@@ -940,7 +940,7 @@ def test_native_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.native_mock.mock_call
+            _ = bigfoot.native.mock_call
     finally:
         _current_test_verifier.reset(token)
 

--- a/tests/unit/test_pika_plugin.py
+++ b/tests/unit/test_pika_plugin.py
@@ -566,7 +566,7 @@ def test_assert_interaction_missing_fields_raises() -> None:
 #   MUTATION: Wrong host/port/virtual_host would raise InteractionMismatchError.
 #   ESCAPE: Nothing reasonable -- helper delegates to assert_interaction with full fields.
 def test_assert_connect_helper(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.pika_mock.new_session()
+    session = bigfoot.pika.new_session()
     session.expect("connect", returns=None)
     session.expect("close", returns=None)
 
@@ -576,8 +576,8 @@ def test_assert_connect_helper(bigfoot_verifier: StrictVerifier) -> None:
         )
         conn.close()
 
-    bigfoot.pika_mock.assert_connect(host="rabbitmq.local", port=5672, virtual_host="/")
-    bigfoot.pika_mock.assert_close()
+    bigfoot.pika.assert_connect(host="rabbitmq.local", port=5672, virtual_host="/")
+    bigfoot.pika.assert_close()
 
 
 # ESCAPE: test_assert_publish_helper
@@ -587,7 +587,7 @@ def test_assert_connect_helper(bigfoot_verifier: StrictVerifier) -> None:
 #   MUTATION: Wrong exchange/routing_key/body/properties would raise InteractionMismatchError.
 #   ESCAPE: Nothing reasonable -- helper delegates to assert_interaction with full fields.
 def test_assert_publish_helper(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.pika_mock.new_session()
+    session = bigfoot.pika.new_session()
     session.expect("connect", returns=None)
     session.expect("channel", returns=None)
     session.expect("publish", returns=None)
@@ -606,15 +606,15 @@ def test_assert_publish_helper(bigfoot_verifier: StrictVerifier) -> None:
         )
         conn.close()
 
-    bigfoot.pika_mock.assert_connect(host="localhost", port=5672, virtual_host="/")
-    bigfoot.pika_mock.assert_channel()
-    bigfoot.pika_mock.assert_publish(
+    bigfoot.pika.assert_connect(host="localhost", port=5672, virtual_host="/")
+    bigfoot.pika.assert_channel()
+    bigfoot.pika.assert_publish(
         exchange="amq.direct",
         routing_key="test.route",
         body=b"payload",
         properties=None,
     )
-    bigfoot.pika_mock.assert_close()
+    bigfoot.pika.assert_close()
 
 
 # ESCAPE: test_assert_consume_helper
@@ -624,7 +624,7 @@ def test_assert_publish_helper(bigfoot_verifier: StrictVerifier) -> None:
 #   MUTATION: Wrong queue/auto_ack would raise InteractionMismatchError.
 #   ESCAPE: Nothing reasonable -- helper delegates to assert_interaction with full fields.
 def test_assert_consume_helper(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.pika_mock.new_session()
+    session = bigfoot.pika.new_session()
     session.expect("connect", returns=None)
     session.expect("channel", returns=None)
     session.expect("consume", returns="ctag_1")
@@ -638,10 +638,10 @@ def test_assert_consume_helper(bigfoot_verifier: StrictVerifier) -> None:
         ch.basic_consume(queue="my_queue", auto_ack=True)
         conn.close()
 
-    bigfoot.pika_mock.assert_connect(host="localhost", port=5672, virtual_host="/")
-    bigfoot.pika_mock.assert_channel()
-    bigfoot.pika_mock.assert_consume(queue="my_queue", auto_ack=True)
-    bigfoot.pika_mock.assert_close()
+    bigfoot.pika.assert_connect(host="localhost", port=5672, virtual_host="/")
+    bigfoot.pika.assert_channel()
+    bigfoot.pika.assert_consume(queue="my_queue", auto_ack=True)
+    bigfoot.pika.assert_close()
 
 
 # ---------------------------------------------------------------------------
@@ -688,7 +688,7 @@ def test_pika_available_flag() -> None:
 
 
 # ESCAPE: test_pika_mock_proxy_raises_import_error_when_unavailable
-#   CLAIM: Accessing bigfoot.pika_mock raises ImportError when pika is not installed.
+#   CLAIM: Accessing bigfoot.pika raises ImportError when pika is not installed.
 #   PATH:  _PikaProxy.__getattr__ -> checks _PIKA_AVAILABLE -> raises ImportError.
 #   CHECK: ImportError raised with message containing "bigfoot[pika]" and "pip install".
 #   MUTATION: Not checking _PIKA_AVAILABLE would defer the error.
@@ -701,10 +701,10 @@ def test_pika_mock_proxy_raises_import_error_when_unavailable(
     monkeypatch.setattr(pika_mod, "_PIKA_AVAILABLE", False)
 
     with pytest.raises(ImportError) as exc_info:
-        _ = bigfoot.pika_mock.new_session  # noqa: B018
+        _ = bigfoot.pika.new_session  # noqa: B018
 
     assert str(exc_info.value) == (
-        "bigfoot[pika] is required to use bigfoot.pika_mock. "
+        "bigfoot[pika] is required to use bigfoot.pika. "
         "Install it with: pip install bigfoot[pika]"
     )
 
@@ -953,12 +953,12 @@ def test_sentinel_properties() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.pika_mock
+# Module-level proxy: bigfoot.pika
 # ---------------------------------------------------------------------------
 
 
 # ESCAPE: test_pika_mock_proxy_new_session
-#   CLAIM: bigfoot.pika_mock.new_session() returns a SessionHandle.
+#   CLAIM: bigfoot.pika.new_session() returns a SessionHandle.
 #   PATH:  _PikaProxy.__getattr__("new_session") -> get verifier -> find/create PikaPlugin ->
 #          return plugin.new_session.
 #   CHECK: session is a SessionHandle instance; chaining .expect() does not raise.
@@ -967,14 +967,14 @@ def test_sentinel_properties() -> None:
 def test_pika_mock_proxy_new_session(bigfoot_verifier: StrictVerifier) -> None:
     from bigfoot._state_machine_plugin import SessionHandle
 
-    session = bigfoot.pika_mock.new_session()
+    session = bigfoot.pika.new_session()
     assert isinstance(session, SessionHandle)
     result = session.expect("connect", returns=None, required=False)
     assert result is session  # expect() returns self for chaining
 
 
 # ESCAPE: test_pika_mock_proxy_raises_outside_context
-#   CLAIM: Accessing bigfoot.pika_mock outside a test context raises NoActiveVerifierError.
+#   CLAIM: Accessing bigfoot.pika outside a test context raises NoActiveVerifierError.
 #   PATH:  _PikaProxy.__getattr__ -> _get_test_verifier_or_raise -> NoActiveVerifierError.
 #   CHECK: NoActiveVerifierError raised.
 #   MUTATION: Silently returning None would not raise and hide context failures.
@@ -985,7 +985,7 @@ def test_pika_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.pika_mock.new_session  # noqa: B018
+            _ = bigfoot.pika.new_session  # noqa: B018
     finally:
         _current_test_verifier.reset(token)
 
@@ -1028,7 +1028,7 @@ def test_close_from_connected() -> None:
 #   MUTATION: Wrong detail values in any step fail the assertion.
 #   ESCAPE: Nothing reasonable -- full field coverage on all assertable steps.
 def test_full_publish_flow_assertions(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.pika_mock.new_session()
+    session = bigfoot.pika.new_session()
     session.expect("connect", returns=None)
     session.expect("channel", returns=None)
     session.expect("publish", returns=None)
@@ -1046,15 +1046,15 @@ def test_full_publish_flow_assertions(bigfoot_verifier: StrictVerifier) -> None:
         )
         conn.close()
 
-    bigfoot.pika_mock.assert_connect(host="localhost", port=5672, virtual_host="/")
-    bigfoot.pika_mock.assert_channel()
-    bigfoot.pika_mock.assert_publish(
+    bigfoot.pika.assert_connect(host="localhost", port=5672, virtual_host="/")
+    bigfoot.pika.assert_channel()
+    bigfoot.pika.assert_publish(
         exchange="test_exchange",
         routing_key="test.key",
         body=b"hello",
         properties=None,
     )
-    bigfoot.pika_mock.assert_close()
+    bigfoot.pika.assert_close()
 
 
 # ESCAPE: test_consume_flow_assertions
@@ -1064,7 +1064,7 @@ def test_full_publish_flow_assertions(bigfoot_verifier: StrictVerifier) -> None:
 #   MUTATION: Wrong queue or auto_ack values fail the assertion.
 #   ESCAPE: Nothing reasonable -- full field coverage on all assertable steps.
 def test_consume_flow_assertions(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.pika_mock.new_session()
+    session = bigfoot.pika.new_session()
     session.expect("connect", returns=None)
     session.expect("channel", returns=None)
     session.expect("consume", returns="ctag_1")
@@ -1080,10 +1080,10 @@ def test_consume_flow_assertions(bigfoot_verifier: StrictVerifier) -> None:
 
     assert tag == "ctag_1"
 
-    bigfoot.pika_mock.assert_connect(host="localhost", port=5672, virtual_host="/")
-    bigfoot.pika_mock.assert_channel()
-    bigfoot.pika_mock.assert_consume(queue="test_queue", auto_ack=True)
-    bigfoot.pika_mock.assert_close()
+    bigfoot.pika.assert_connect(host="localhost", port=5672, virtual_host="/")
+    bigfoot.pika.assert_channel()
+    bigfoot.pika.assert_consume(queue="test_queue", auto_ack=True)
+    bigfoot.pika.assert_close()
 
 
 # ESCAPE: test_ack_nack_flow_assertions
@@ -1093,7 +1093,7 @@ def test_consume_flow_assertions(bigfoot_verifier: StrictVerifier) -> None:
 #   MUTATION: Wrong delivery_tag or requeue values fail the assertion.
 #   ESCAPE: Nothing reasonable -- full field coverage on all assertable steps.
 def test_ack_nack_flow_assertions(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.pika_mock.new_session()
+    session = bigfoot.pika.new_session()
     session.expect("connect", returns=None)
     session.expect("channel", returns=None)
     session.expect("ack", returns=None)
@@ -1109,11 +1109,11 @@ def test_ack_nack_flow_assertions(bigfoot_verifier: StrictVerifier) -> None:
         ch.basic_nack(delivery_tag=2, requeue=True)
         conn.close()
 
-    bigfoot.pika_mock.assert_connect(host="localhost", port=5672, virtual_host="/")
-    bigfoot.pika_mock.assert_channel()
-    bigfoot.pika_mock.assert_ack(delivery_tag=1)
-    bigfoot.pika_mock.assert_nack(delivery_tag=2, requeue=True)
-    bigfoot.pika_mock.assert_close()
+    bigfoot.pika.assert_connect(host="localhost", port=5672, virtual_host="/")
+    bigfoot.pika.assert_channel()
+    bigfoot.pika.assert_ack(delivery_tag=1)
+    bigfoot.pika.assert_nack(delivery_tag=2, requeue=True)
+    bigfoot.pika.assert_close()
 
 
 # ESCAPE: test_close_from_connected_assertions
@@ -1123,7 +1123,7 @@ def test_ack_nack_flow_assertions(bigfoot_verifier: StrictVerifier) -> None:
 #   MUTATION: Wrong host/port/virtual_host fail the assertion.
 #   ESCAPE: Nothing reasonable -- full field coverage.
 def test_close_from_connected_assertions(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.pika_mock.new_session()
+    session = bigfoot.pika.new_session()
     session.expect("connect", returns=None)
     session.expect("close", returns=None)
 
@@ -1133,8 +1133,8 @@ def test_close_from_connected_assertions(bigfoot_verifier: StrictVerifier) -> No
         )
         conn.close()
 
-    bigfoot.pika_mock.assert_connect(host="rabbitmq.local", port=5672, virtual_host="/")
-    bigfoot.pika_mock.assert_close()
+    bigfoot.pika.assert_connect(host="rabbitmq.local", port=5672, virtual_host="/")
+    bigfoot.pika.assert_close()
 
 
 # ESCAPE: test_session_lifecycle_assertions
@@ -1144,7 +1144,7 @@ def test_close_from_connected_assertions(bigfoot_verifier: StrictVerifier) -> No
 #   MUTATION: Wrong detail values fail the assertion.
 #   ESCAPE: Nothing reasonable -- full field coverage.
 def test_session_lifecycle_assertions(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.pika_mock.new_session()
+    session = bigfoot.pika.new_session()
     session.expect("connect", returns=None)
     session.expect("channel", returns=None)
     session.expect("publish", returns=None)
@@ -1158,12 +1158,12 @@ def test_session_lifecycle_assertions(bigfoot_verifier: StrictVerifier) -> None:
         ch.basic_publish(exchange="", routing_key="q", body=b"data")
         conn.close()
 
-    bigfoot.pika_mock.assert_connect(host="localhost", port=5672, virtual_host="/")
-    bigfoot.pika_mock.assert_channel()
-    bigfoot.pika_mock.assert_publish(
+    bigfoot.pika.assert_connect(host="localhost", port=5672, virtual_host="/")
+    bigfoot.pika.assert_channel()
+    bigfoot.pika.assert_publish(
         exchange="", routing_key="q", body=b"data", properties=None,
     )
-    bigfoot.pika_mock.assert_close()
+    bigfoot.pika.assert_close()
 
 
 # ESCAPE: test_multiple_sequential_sessions_assertions
@@ -1175,14 +1175,14 @@ def test_session_lifecycle_assertions(bigfoot_verifier: StrictVerifier) -> None:
 #   ESCAPE: Nothing reasonable -- full field coverage on both sessions.
 def test_multiple_sequential_sessions_assertions(bigfoot_verifier: StrictVerifier) -> None:
     # First session
-    s1 = bigfoot.pika_mock.new_session()
+    s1 = bigfoot.pika.new_session()
     s1.expect("connect", returns=None)
     s1.expect("channel", returns=None)
     s1.expect("publish", returns=None)
     s1.expect("close", returns=None)
 
     # Second session
-    s2 = bigfoot.pika_mock.new_session()
+    s2 = bigfoot.pika.new_session()
     s2.expect("connect", returns=None)
     s2.expect("channel", returns=None)
     s2.expect("consume", returns="ctag_2")
@@ -1208,18 +1208,18 @@ def test_multiple_sequential_sessions_assertions(bigfoot_verifier: StrictVerifie
     assert tag == "ctag_2"
 
     # Assert first session interactions
-    bigfoot.pika_mock.assert_connect(host="host1", port=5672, virtual_host="/")
-    bigfoot.pika_mock.assert_channel()
-    bigfoot.pika_mock.assert_publish(
+    bigfoot.pika.assert_connect(host="host1", port=5672, virtual_host="/")
+    bigfoot.pika.assert_channel()
+    bigfoot.pika.assert_publish(
         exchange="", routing_key="q1", body=b"msg1", properties=None,
     )
-    bigfoot.pika_mock.assert_close()
+    bigfoot.pika.assert_close()
 
     # Assert second session interactions
-    bigfoot.pika_mock.assert_connect(host="host2", port=5672, virtual_host="/")
-    bigfoot.pika_mock.assert_channel()
-    bigfoot.pika_mock.assert_consume(queue="q2", auto_ack=False)
-    bigfoot.pika_mock.assert_close()
+    bigfoot.pika.assert_connect(host="host2", port=5672, virtual_host="/")
+    bigfoot.pika.assert_channel()
+    bigfoot.pika.assert_consume(queue="q2", auto_ack=False)
+    bigfoot.pika.assert_close()
 
 
 # ---------------------------------------------------------------------------
@@ -1234,7 +1234,7 @@ def test_multiple_sequential_sessions_assertions(bigfoot_verifier: StrictVerifie
 #   MUTATION: Wrong delivery_tag would raise InteractionMismatchError.
 #   ESCAPE: Nothing reasonable -- helper delegates to assert_interaction with full fields.
 def test_assert_ack_helper(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.pika_mock.new_session()
+    session = bigfoot.pika.new_session()
     session.expect("connect", returns=None)
     session.expect("channel", returns=None)
     session.expect("ack", returns=None)
@@ -1248,10 +1248,10 @@ def test_assert_ack_helper(bigfoot_verifier: StrictVerifier) -> None:
         ch.basic_ack(delivery_tag=42)
         conn.close()
 
-    bigfoot.pika_mock.assert_connect(host="localhost", port=5672, virtual_host="/")
-    bigfoot.pika_mock.assert_channel()
-    bigfoot.pika_mock.assert_ack(delivery_tag=42)
-    bigfoot.pika_mock.assert_close()
+    bigfoot.pika.assert_connect(host="localhost", port=5672, virtual_host="/")
+    bigfoot.pika.assert_channel()
+    bigfoot.pika.assert_ack(delivery_tag=42)
+    bigfoot.pika.assert_close()
 
 
 # ESCAPE: test_assert_nack_helper
@@ -1261,7 +1261,7 @@ def test_assert_ack_helper(bigfoot_verifier: StrictVerifier) -> None:
 #   MUTATION: Wrong delivery_tag or requeue would raise InteractionMismatchError.
 #   ESCAPE: Nothing reasonable -- helper delegates to assert_interaction with full fields.
 def test_assert_nack_helper(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.pika_mock.new_session()
+    session = bigfoot.pika.new_session()
     session.expect("connect", returns=None)
     session.expect("channel", returns=None)
     session.expect("nack", returns=None)
@@ -1275,10 +1275,10 @@ def test_assert_nack_helper(bigfoot_verifier: StrictVerifier) -> None:
         ch.basic_nack(delivery_tag=7, requeue=False)
         conn.close()
 
-    bigfoot.pika_mock.assert_connect(host="localhost", port=5672, virtual_host="/")
-    bigfoot.pika_mock.assert_channel()
-    bigfoot.pika_mock.assert_nack(delivery_tag=7, requeue=False)
-    bigfoot.pika_mock.assert_close()
+    bigfoot.pika.assert_connect(host="localhost", port=5672, virtual_host="/")
+    bigfoot.pika.assert_channel()
+    bigfoot.pika.assert_nack(delivery_tag=7, requeue=False)
+    bigfoot.pika.assert_close()
 
 
 # ---------------------------------------------------------------------------
@@ -1558,7 +1558,7 @@ def test_format_mock_hint() -> None:
         plugin=p,
     )
     result = p.format_mock_hint(interaction)
-    assert result == "    bigfoot.pika_mock.new_session().expect('publish', returns=...)"
+    assert result == "    bigfoot.pika.new_session().expect('publish', returns=...)"
 
 
 # ESCAPE: test_format_mock_hint_connect
@@ -1578,7 +1578,7 @@ def test_format_mock_hint_connect() -> None:
         plugin=p,
     )
     result = p.format_mock_hint(interaction)
-    assert result == "    bigfoot.pika_mock.new_session().expect('connect', returns=...)"
+    assert result == "    bigfoot.pika.new_session().expect('connect', returns=...)"
 
 
 # ESCAPE: test_format_unmocked_hint
@@ -1593,7 +1593,7 @@ def test_format_unmocked_hint() -> None:
     assert result == (
         "pika.BlockingConnection.connect(...) was called but no session was queued.\n"
         "Register a session with:\n"
-        "    bigfoot.pika_mock.new_session().expect('connect', returns=...)"
+        "    bigfoot.pika.new_session().expect('connect', returns=...)"
     )
 
 
@@ -1609,7 +1609,7 @@ def test_format_unmocked_hint_publish() -> None:
     assert result == (
         "pika.BlockingConnection.publish(...) was called but no session was queued.\n"
         "Register a session with:\n"
-        "    bigfoot.pika_mock.new_session().expect('publish', returns=...)"
+        "    bigfoot.pika.new_session().expect('publish', returns=...)"
     )
 
 
@@ -1630,7 +1630,7 @@ def test_format_assert_hint_connect() -> None:
         plugin=p,
     )
     result = p.format_assert_hint(interaction)
-    assert result == "    bigfoot.pika_mock.assert_connect(host='localhost', port=5672, virtual_host='/')"
+    assert result == "    bigfoot.pika.assert_connect(host='localhost', port=5672, virtual_host='/')"
 
 
 # ESCAPE: test_format_assert_hint_channel
@@ -1650,7 +1650,7 @@ def test_format_assert_hint_channel() -> None:
         plugin=p,
     )
     result = p.format_assert_hint(interaction)
-    assert result == "    bigfoot.pika_mock.assert_channel()"
+    assert result == "    bigfoot.pika.assert_channel()"
 
 
 # ESCAPE: test_format_assert_hint_publish
@@ -1671,7 +1671,7 @@ def test_format_assert_hint_publish() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        "    bigfoot.pika_mock.assert_publish("
+        "    bigfoot.pika.assert_publish("
         "exchange='amq.direct', routing_key='test', "
         "body=b'msg', properties=None)"
     )
@@ -1694,7 +1694,7 @@ def test_format_assert_hint_consume() -> None:
         plugin=p,
     )
     result = p.format_assert_hint(interaction)
-    assert result == "    bigfoot.pika_mock.assert_consume(queue='my_queue', auto_ack=True)"
+    assert result == "    bigfoot.pika.assert_consume(queue='my_queue', auto_ack=True)"
 
 
 # ESCAPE: test_format_assert_hint_ack
@@ -1714,7 +1714,7 @@ def test_format_assert_hint_ack() -> None:
         plugin=p,
     )
     result = p.format_assert_hint(interaction)
-    assert result == "    bigfoot.pika_mock.assert_ack(delivery_tag=42)"
+    assert result == "    bigfoot.pika.assert_ack(delivery_tag=42)"
 
 
 # ESCAPE: test_format_assert_hint_nack
@@ -1734,7 +1734,7 @@ def test_format_assert_hint_nack() -> None:
         plugin=p,
     )
     result = p.format_assert_hint(interaction)
-    assert result == "    bigfoot.pika_mock.assert_nack(delivery_tag=5, requeue=False)"
+    assert result == "    bigfoot.pika.assert_nack(delivery_tag=5, requeue=False)"
 
 
 # ESCAPE: test_format_assert_hint_close
@@ -1754,7 +1754,7 @@ def test_format_assert_hint_close() -> None:
         plugin=p,
     )
     result = p.format_assert_hint(interaction)
-    assert result == "    bigfoot.pika_mock.assert_close()"
+    assert result == "    bigfoot.pika.assert_close()"
 
 
 # ESCAPE: test_format_assert_hint_unknown
@@ -1774,7 +1774,7 @@ def test_format_assert_hint_unknown() -> None:
         plugin=p,
     )
     result = p.format_assert_hint(interaction)
-    assert result == "    # bigfoot.pika_mock: unknown source_id='pika:unknown_op'"
+    assert result == "    # bigfoot.pika: unknown source_id='pika:unknown_op'"
 
 
 # ESCAPE: test_format_unused_mock_hint

--- a/tests/unit/test_popen_plugin.py
+++ b/tests/unit/test_popen_plugin.py
@@ -557,12 +557,12 @@ def test_popen_with_empty_queue_raises_unmocked() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.popen_mock
+# Module-level proxy: bigfoot.popen
 # ---------------------------------------------------------------------------
 
 
 # ESCAPE: test_popen_mock_proxy_new_session
-#   CLAIM: bigfoot.popen_mock.new_session() returns a SessionHandle that can
+#   CLAIM: bigfoot.popen.new_session() returns a SessionHandle that can
 #          be used to configure a session without importing PopenPlugin directly.
 #   PATH:  _PopenProxy.__getattr__("new_session") -> get verifier -> find/create PopenPlugin ->
 #          return plugin.new_session.
@@ -572,14 +572,14 @@ def test_popen_with_empty_queue_raises_unmocked() -> None:
 def test_popen_mock_proxy_new_session(bigfoot_verifier: StrictVerifier) -> None:
     from bigfoot._state_machine_plugin import SessionHandle
 
-    session = bigfoot.popen_mock.new_session()
+    session = bigfoot.popen.new_session()
     assert isinstance(session, SessionHandle)
     result = session.expect("spawn", returns=None, required=False)
     assert result is session  # expect() returns self for chaining
 
 
 # ESCAPE: test_popen_mock_proxy_raises_outside_context
-#   CLAIM: Accessing bigfoot.popen_mock outside a test context raises NoActiveVerifierError.
+#   CLAIM: Accessing bigfoot.popen outside a test context raises NoActiveVerifierError.
 #   PATH:  _PopenProxy.__getattr__ -> _get_test_verifier_or_raise -> NoActiveVerifierError.
 #   CHECK: NoActiveVerifierError raised.
 #   MUTATION: Silently returning None would not raise and hide context failures.
@@ -590,7 +590,7 @@ def test_popen_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.popen_mock.new_session
+            _ = bigfoot.popen.new_session
     finally:
         _current_test_verifier.reset(token)
 
@@ -699,12 +699,12 @@ def test_conflict_error_popen_already_patched() -> None:
 # ESCAPE: test_full_session_via_sandbox
 #   CLAIM: A complete Popen session (spawn -> communicate) runs end-to-end through
 #          the module-level bigfoot.sandbox() API, returning the scripted values.
-#   PATH:  bigfoot.popen_mock.new_session() -> sandbox -> _FakePopen.__init__ -> communicate.
+#   PATH:  bigfoot.popen.new_session() -> sandbox -> _FakePopen.__init__ -> communicate.
 #   CHECK: stdout == b"build output"; stderr == b""; proc.returncode == 0.
 #   MUTATION: Returning wrong stdout bytes would fail the equality check.
 #   ESCAPE: Nothing reasonable -- exact bytes equality on all three fields.
 def test_full_session_via_sandbox(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.popen_mock.new_session()
+    session = bigfoot.popen.new_session()
     session.expect("spawn", returns=None)
     session.expect("communicate", returns=(b"build output", b"", 0))
 
@@ -712,8 +712,8 @@ def test_full_session_via_sandbox(bigfoot_verifier: StrictVerifier) -> None:
         proc = subprocess.Popen(["make", "all"])
         stdout, stderr = proc.communicate()
 
-    bigfoot.popen_mock.assert_spawn(command=["make", "all"], stdin=None)
-    bigfoot.popen_mock.assert_communicate(input=None)
+    bigfoot.popen.assert_spawn(command=["make", "all"], stdin=None)
+    bigfoot.popen.assert_communicate(input=None)
 
     assert stdout == b"build output"
     assert stderr == b""

--- a/tests/unit/test_psycopg2_plugin.py
+++ b/tests/unit/test_psycopg2_plugin.py
@@ -355,14 +355,14 @@ def test_connect_with_empty_queue_raises_unmocked() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.psycopg2_mock
+# Module-level proxy: bigfoot.psycopg2
 # ---------------------------------------------------------------------------
 
 
 def test_psycopg2_mock_proxy_new_session(bigfoot_verifier: StrictVerifier) -> None:
     from bigfoot._state_machine_plugin import SessionHandle
 
-    session = bigfoot.psycopg2_mock.new_session()
+    session = bigfoot.psycopg2.new_session()
     assert isinstance(session, SessionHandle)
     result = session.expect("execute", returns=[], required=False)
     assert result is session
@@ -374,7 +374,7 @@ def test_psycopg2_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.psycopg2_mock.new_session
+            _ = bigfoot.psycopg2.new_session
     finally:
         _current_test_verifier.reset(token)
 

--- a/tests/unit/test_redis_plugin.py
+++ b/tests/unit/test_redis_plugin.py
@@ -494,7 +494,7 @@ def test_format_mock_hint() -> None:
         plugin=p,
     )
     result = p.format_mock_hint(interaction)
-    assert result == "    bigfoot.redis_mock.mock_command('GET', returns=...)"
+    assert result == "    bigfoot.redis.mock_command('GET', returns=...)"
 
 
 # ESCAPE: test_format_unmocked_hint
@@ -509,7 +509,7 @@ def test_format_unmocked_hint() -> None:
     assert result == (
         "redis.GET(...) was called but no mock was registered.\n"
         "Register a mock with:\n"
-        "    bigfoot.redis_mock.mock_command('GET', returns=...)"
+        "    bigfoot.redis.mock_command('GET', returns=...)"
     )
 
 
@@ -531,7 +531,7 @@ def test_format_assert_hint() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        "    bigfoot.redis_mock.assert_command(\n"
+        "    bigfoot.redis.assert_command(\n"
         "        command='GET',\n"
         "        args=('mykey',),\n"
         "        kwargs={},\n"
@@ -556,12 +556,12 @@ def test_format_unused_mock_hint() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.redis_mock
+# Module-level proxy: bigfoot.redis
 # ---------------------------------------------------------------------------
 
 
 # ESCAPE: test_redis_mock_proxy_mock_command
-#   CLAIM: bigfoot.redis_mock.mock_command("GET", returns="v") works when verifier is active.
+#   CLAIM: bigfoot.redis.mock_command("GET", returns="v") works when verifier is active.
 #   PATH:  _RedisProxy.__getattr__("mock_command") -> get verifier ->
 #          find/create RedisPlugin -> return plugin.mock_command.
 #   CHECK: The proxy call does not raise and the mock is registered.
@@ -570,18 +570,18 @@ def test_format_unused_mock_hint() -> None:
 def test_redis_mock_proxy_mock_command(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    bigfoot.redis_mock.mock_command("GET", returns="proxy_value", required=True)
+    bigfoot.redis.mock_command("GET", returns="proxy_value", required=True)
 
     with bigfoot.sandbox():
         r = redis.Redis()
         result = r.execute_command("GET", "somekey")
 
     assert result == "proxy_value"
-    bigfoot.redis_mock.assert_command("GET", args=("somekey",), kwargs={})
+    bigfoot.redis.assert_command("GET", args=("somekey",), kwargs={})
 
 
 # ESCAPE: test_redis_mock_proxy_raises_outside_context
-#   CLAIM: Accessing bigfoot.redis_mock outside a test context raises NoActiveVerifierError.
+#   CLAIM: Accessing bigfoot.redis outside a test context raises NoActiveVerifierError.
 #   PATH:  _RedisProxy.__getattr__ -> _get_test_verifier_or_raise -> NoActiveVerifierError.
 #   CHECK: NoActiveVerifierError raised.
 #   MUTATION: Silently returning None would not raise.
@@ -593,7 +593,7 @@ def test_redis_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.redis_mock.mock_command
+            _ = bigfoot.redis.mock_command
     finally:
         _current_test_verifier.reset(token)
 
@@ -604,9 +604,9 @@ def test_redis_mock_proxy_raises_outside_context() -> None:
 
 
 # ESCAPE: test_redis_plugin_in_all
-#   CLAIM: RedisPlugin and redis_mock are exported from bigfoot.__all__.
-#   PATH:  bigfoot.__all__ contains "RedisPlugin" and "redis_mock".
-#   CHECK: "RedisPlugin" in bigfoot.__all__; "redis_mock" in bigfoot.__all__.
+#   CLAIM: RedisPlugin and redis are exported from bigfoot.__all__.
+#   PATH:  bigfoot.__all__ contains "RedisPlugin" and "redis".
+#   CHECK: "RedisPlugin" in bigfoot.__all__; "redis" in bigfoot.__all__.
 #   MUTATION: Omitting either from __all__ fails the membership check.
 #   ESCAPE: Nothing reasonable -- exact membership check.
 def test_redis_plugin_in_all() -> None:
@@ -614,7 +614,7 @@ def test_redis_plugin_in_all() -> None:
     from bigfoot.plugins.redis_plugin import RedisPlugin as _RedisPlugin
 
     assert bigfoot.RedisPlugin is _RedisPlugin
-    assert type(bigfoot.redis_mock).__name__ == "_RedisProxy"
+    assert type(bigfoot.redis).__name__ == "_RedisProxy"
 
 
 # ---------------------------------------------------------------------------
@@ -626,7 +626,7 @@ def test_redis_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier) 
     """Redis interactions are NOT auto-asserted — they land on the timeline unasserted."""
     import bigfoot
 
-    bigfoot.redis_mock.mock_command("GET", returns=b"value")
+    bigfoot.redis.mock_command("GET", returns=b"value")
     with bigfoot.sandbox():
         client = redis.Redis()
         client.execute_command("GET", "key")
@@ -636,29 +636,29 @@ def test_redis_interactions_not_auto_asserted(bigfoot_verifier: StrictVerifier) 
     assert len(interactions) == 1
     assert interactions[0].source_id == "redis:get"
     # Assert it so verify_all() at teardown succeeds
-    bigfoot.redis_mock.assert_command("GET", args=("key",), kwargs={})
+    bigfoot.redis.assert_command("GET", args=("key",), kwargs={})
 
 
 def test_assert_command_typed_helper(bigfoot_verifier: StrictVerifier) -> None:
     """assert_command() asserts the next Redis interaction."""
     import bigfoot
 
-    bigfoot.redis_mock.mock_command("SET", returns=True)
+    bigfoot.redis.mock_command("SET", returns=True)
     with bigfoot.sandbox():
         client = redis.Redis()
         client.execute_command("SET", "key", "value")
-    bigfoot.redis_mock.assert_command("SET", args=("key", "value"), kwargs={})
+    bigfoot.redis.assert_command("SET", args=("key", "value"), kwargs={})
 
 
 def test_assert_command_wrong_args_raises(bigfoot_verifier: StrictVerifier) -> None:
     """assert_command() with wrong args raises InteractionMismatchError."""
     import bigfoot
 
-    bigfoot.redis_mock.mock_command("GET", returns=b"val")
+    bigfoot.redis.mock_command("GET", returns=b"val")
     with bigfoot.sandbox():
         client = redis.Redis()
         client.execute_command("GET", "key")
     with pytest.raises(InteractionMismatchError):
-        bigfoot.redis_mock.assert_command("GET", args=("wrong_key",), kwargs={})
+        bigfoot.redis.assert_command("GET", args=("wrong_key",), kwargs={})
     # Now assert correctly so teardown passes
-    bigfoot.redis_mock.assert_command("GET", args=("key",), kwargs={})
+    bigfoot.redis.assert_command("GET", args=("key",), kwargs={})

--- a/tests/unit/test_smtp_plugin.py
+++ b/tests/unit/test_smtp_plugin.py
@@ -484,12 +484,12 @@ def test_smtp_with_empty_queue_raises_unmocked() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.smtp_mock
+# Module-level proxy: bigfoot.smtp
 # ---------------------------------------------------------------------------
 
 
 # ESCAPE: test_smtp_mock_proxy_new_session
-#   CLAIM: bigfoot.smtp_mock.new_session() returns a SessionHandle that can
+#   CLAIM: bigfoot.smtp.new_session() returns a SessionHandle that can
 #          be used to configure a session without importing SmtpPlugin directly.
 #   PATH:  _SmtpProxy.__getattr__("new_session") -> get verifier -> find/create SmtpPlugin ->
 #          return plugin.new_session.
@@ -499,14 +499,14 @@ def test_smtp_with_empty_queue_raises_unmocked() -> None:
 def test_smtp_mock_proxy_new_session(bigfoot_verifier: StrictVerifier) -> None:
     from bigfoot._state_machine_plugin import SessionHandle
 
-    session = bigfoot.smtp_mock.new_session()
+    session = bigfoot.smtp.new_session()
     assert isinstance(session, SessionHandle)
     result = session.expect("connect", returns=None, required=False)
     assert result is session  # expect() returns self for chaining
 
 
 # ESCAPE: test_smtp_mock_proxy_raises_outside_context
-#   CLAIM: Accessing bigfoot.smtp_mock outside a test context raises NoActiveVerifierError.
+#   CLAIM: Accessing bigfoot.smtp outside a test context raises NoActiveVerifierError.
 #   PATH:  _SmtpProxy.__getattr__ -> _get_test_verifier_or_raise -> NoActiveVerifierError.
 #   CHECK: NoActiveVerifierError raised.
 #   MUTATION: Silently returning None would not raise and hide context failures.
@@ -517,7 +517,7 @@ def test_smtp_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.smtp_mock.new_session
+            _ = bigfoot.smtp.new_session
     finally:
         _current_test_verifier.reset(token)
 
@@ -530,13 +530,13 @@ def test_smtp_mock_proxy_raises_outside_context() -> None:
 # ESCAPE: test_full_session_via_sandbox
 #   CLAIM: A complete SMTP session (connect -> ehlo -> sendmail -> quit) runs end-to-end
 #          through the module-level bigfoot.sandbox() API, returning the scripted values.
-#   PATH:  bigfoot.smtp_mock.new_session() -> sandbox -> _FakeSMTP.__init__ ->
+#   PATH:  bigfoot.smtp.new_session() -> sandbox -> _FakeSMTP.__init__ ->
 #          ehlo -> sendmail -> quit.
 #   CHECK: sendmail_result == {}; quit_result == (221, b"Bye").
 #   MUTATION: Returning wrong sendmail result would fail the equality check.
 #   ESCAPE: Nothing reasonable -- exact equality on both returns.
 def test_full_session_via_sandbox(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.smtp_mock.new_session()
+    session = bigfoot.smtp.new_session()
     session.expect("connect", returns=None)
     session.expect("ehlo", returns=(250, b"OK"))
     session.expect("sendmail", returns={})
@@ -553,11 +553,11 @@ def test_full_session_via_sandbox(bigfoot_verifier: StrictVerifier) -> None:
     assert sendmail_result == {}
     assert quit_result == (221, b"Bye")
 
-    bigfoot.smtp_mock.assert_connect(host="mail.example.com", port=25)
-    bigfoot.smtp_mock.assert_ehlo(name="")
-    bigfoot.smtp_mock.assert_sendmail(
+    bigfoot.smtp.assert_connect(host="mail.example.com", port=25)
+    bigfoot.smtp.assert_ehlo(name="")
+    bigfoot.smtp.assert_sendmail(
         from_addr="from@example.com",
         to_addrs=["to@example.com"],
         msg="Subject: test\r\n\r\ntest",
     )
-    bigfoot.smtp_mock.assert_quit()
+    bigfoot.smtp.assert_quit()

--- a/tests/unit/test_socket_plugin.py
+++ b/tests/unit/test_socket_plugin.py
@@ -384,12 +384,12 @@ def test_connect_with_empty_queue_raises_unmocked() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.socket_mock
+# Module-level proxy: bigfoot.socket
 # ---------------------------------------------------------------------------
 
 
 # ESCAPE: test_socket_mock_proxy_new_session
-#   CLAIM: bigfoot.socket_mock.new_session() returns a SessionHandle that can
+#   CLAIM: bigfoot.socket.new_session() returns a SessionHandle that can
 #          be used to configure a session without importing SocketPlugin directly.
 #   PATH:  _SocketProxy.__getattr__("new_session") -> get verifier -> find/create SocketPlugin ->
 #          return plugin.new_session.
@@ -400,7 +400,7 @@ def test_connect_with_empty_queue_raises_unmocked() -> None:
 def test_socket_mock_proxy_new_session(bigfoot_verifier: StrictVerifier) -> None:
     from bigfoot._state_machine_plugin import SessionHandle
 
-    session = bigfoot.socket_mock.new_session()
+    session = bigfoot.socket.new_session()
     assert isinstance(session, SessionHandle)
     # Chaining expect() with required=False so it doesn't trigger UnusedMocksError at teardown.
     result = session.expect("connect", returns=None, required=False)
@@ -408,7 +408,7 @@ def test_socket_mock_proxy_new_session(bigfoot_verifier: StrictVerifier) -> None
 
 
 # ESCAPE: test_socket_mock_proxy_raises_outside_context
-#   CLAIM: Accessing bigfoot.socket_mock outside a test context raises NoActiveVerifierError.
+#   CLAIM: Accessing bigfoot.socket outside a test context raises NoActiveVerifierError.
 #   PATH:  _SocketProxy.__getattr__ -> _get_test_verifier_or_raise -> NoActiveVerifierError.
 #   CHECK: NoActiveVerifierError raised.
 #   MUTATION: Silently returning None would not raise and hide context failures.
@@ -419,7 +419,7 @@ def test_socket_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.socket_mock.new_session
+            _ = bigfoot.socket.new_session
     finally:
         _current_test_verifier.reset(token)
 

--- a/tests/unit/test_ssh_plugin.py
+++ b/tests/unit/test_ssh_plugin.py
@@ -651,7 +651,7 @@ def test_assert_interaction_missing_fields_raises() -> None:
 #   MUTATION: Wrong hostname/port/username/auth_method would raise InteractionMismatchError.
 #   ESCAPE: Nothing reasonable -- helper delegates to assert_interaction with full fields.
 def test_assert_connect_helper(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.ssh_mock.new_session()
+    session = bigfoot.ssh.new_session()
     session.expect("connect", returns=None)
     session.expect("close", returns=None)
 
@@ -660,10 +660,10 @@ def test_assert_connect_helper(bigfoot_verifier: StrictVerifier) -> None:
         client.connect("server.example.com", port=22, username="deploy")
         client.close()
 
-    bigfoot.ssh_mock.assert_connect(
+    bigfoot.ssh.assert_connect(
         hostname="server.example.com", port=22, username="deploy", auth_method="password"
     )
-    bigfoot.ssh_mock.assert_close()
+    bigfoot.ssh.assert_close()
 
 
 # ESCAPE: test_assert_exec_command_helper
@@ -673,7 +673,7 @@ def test_assert_connect_helper(bigfoot_verifier: StrictVerifier) -> None:
 #   MUTATION: Wrong command would raise InteractionMismatchError.
 #   ESCAPE: Nothing reasonable -- helper delegates to assert_interaction with full fields.
 def test_assert_exec_command_helper(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.ssh_mock.new_session()
+    session = bigfoot.ssh.new_session()
     session.expect("connect", returns=None)
     session.expect("exec_command", returns=("stdin", "stdout", "stderr"))
     session.expect("close", returns=None)
@@ -684,11 +684,11 @@ def test_assert_exec_command_helper(bigfoot_verifier: StrictVerifier) -> None:
         client.exec_command("uptime")
         client.close()
 
-    bigfoot.ssh_mock.assert_connect(
+    bigfoot.ssh.assert_connect(
         hostname="server.example.com", port=22, username="deploy", auth_method="password"
     )
-    bigfoot.ssh_mock.assert_exec_command(command="uptime")
-    bigfoot.ssh_mock.assert_close()
+    bigfoot.ssh.assert_exec_command(command="uptime")
+    bigfoot.ssh.assert_close()
 
 
 # ESCAPE: test_assert_sftp_get_helper
@@ -698,7 +698,7 @@ def test_assert_exec_command_helper(bigfoot_verifier: StrictVerifier) -> None:
 #   MUTATION: Wrong remotepath/localpath would raise InteractionMismatchError.
 #   ESCAPE: Nothing reasonable -- helper delegates to assert_interaction with full fields.
 def test_assert_sftp_get_helper(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.ssh_mock.new_session()
+    session = bigfoot.ssh.new_session()
     session.expect("connect", returns=None)
     session.expect("open_sftp", returns=None)
     session.expect("sftp_get", returns=None)
@@ -711,12 +711,12 @@ def test_assert_sftp_get_helper(bigfoot_verifier: StrictVerifier) -> None:
         sftp.get("/remote/data.csv", "/local/data.csv")
         client.close()
 
-    bigfoot.ssh_mock.assert_connect(
+    bigfoot.ssh.assert_connect(
         hostname="server.example.com", port=22, username="deploy", auth_method="password"
     )
-    bigfoot.ssh_mock.assert_open_sftp()
-    bigfoot.ssh_mock.assert_sftp_get(remotepath="/remote/data.csv", localpath="/local/data.csv")
-    bigfoot.ssh_mock.assert_close()
+    bigfoot.ssh.assert_open_sftp()
+    bigfoot.ssh.assert_sftp_get(remotepath="/remote/data.csv", localpath="/local/data.csv")
+    bigfoot.ssh.assert_close()
 
 
 # ESCAPE: test_assert_sftp_put_helper
@@ -726,7 +726,7 @@ def test_assert_sftp_get_helper(bigfoot_verifier: StrictVerifier) -> None:
 #   MUTATION: Wrong localpath/remotepath would raise InteractionMismatchError.
 #   ESCAPE: Nothing reasonable -- helper delegates to assert_interaction with full fields.
 def test_assert_sftp_put_helper(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.ssh_mock.new_session()
+    session = bigfoot.ssh.new_session()
     session.expect("connect", returns=None)
     session.expect("open_sftp", returns=None)
     session.expect("sftp_put", returns=None)
@@ -739,12 +739,12 @@ def test_assert_sftp_put_helper(bigfoot_verifier: StrictVerifier) -> None:
         sftp.put("/local/upload.txt", "/remote/upload.txt")
         client.close()
 
-    bigfoot.ssh_mock.assert_connect(
+    bigfoot.ssh.assert_connect(
         hostname="server.example.com", port=22, username="deploy", auth_method="password"
     )
-    bigfoot.ssh_mock.assert_open_sftp()
-    bigfoot.ssh_mock.assert_sftp_put(localpath="/local/upload.txt", remotepath="/remote/upload.txt")
-    bigfoot.ssh_mock.assert_close()
+    bigfoot.ssh.assert_open_sftp()
+    bigfoot.ssh.assert_sftp_put(localpath="/local/upload.txt", remotepath="/remote/upload.txt")
+    bigfoot.ssh.assert_close()
 
 
 # ---------------------------------------------------------------------------
@@ -920,7 +920,7 @@ def test_paramiko_available_flag() -> None:
 
 
 # ESCAPE: test_ssh_mock_proxy_raises_import_error_when_unavailable
-#   CLAIM: Accessing bigfoot.ssh_mock raises ImportError when paramiko is not installed.
+#   CLAIM: Accessing bigfoot.ssh raises ImportError when paramiko is not installed.
 #   PATH:  _SshProxy.__getattr__ -> checks _PARAMIKO_AVAILABLE -> raises ImportError.
 #   CHECK: ImportError raised with exact expected message.
 #   MUTATION: Not checking _PARAMIKO_AVAILABLE would defer the error.
@@ -933,10 +933,10 @@ def test_ssh_mock_proxy_raises_import_error_when_unavailable(
     monkeypatch.setattr(ssh_mod, "_PARAMIKO_AVAILABLE", False)
 
     with pytest.raises(ImportError) as exc_info:
-        _ = bigfoot.ssh_mock.new_session  # noqa: B018
+        _ = bigfoot.ssh.new_session  # noqa: B018
 
     assert str(exc_info.value) == (
-        "bigfoot[ssh] is required to use bigfoot.ssh_mock. "
+        "bigfoot[ssh] is required to use bigfoot.ssh. "
         "Install it with: pip install bigfoot[ssh]"
     )
 
@@ -1278,12 +1278,12 @@ def test_sentinel_properties() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.ssh_mock
+# Module-level proxy: bigfoot.ssh
 # ---------------------------------------------------------------------------
 
 
 # ESCAPE: test_ssh_mock_proxy_new_session
-#   CLAIM: bigfoot.ssh_mock.new_session() returns a SessionHandle.
+#   CLAIM: bigfoot.ssh.new_session() returns a SessionHandle.
 #   PATH:  _SshProxy.__getattr__("new_session") -> get verifier -> find/create SshPlugin ->
 #          return plugin.new_session.
 #   CHECK: session is a SessionHandle instance; chaining .expect() does not raise.
@@ -1292,14 +1292,14 @@ def test_sentinel_properties() -> None:
 def test_ssh_mock_proxy_new_session(bigfoot_verifier: StrictVerifier) -> None:
     from bigfoot._state_machine_plugin import SessionHandle
 
-    session = bigfoot.ssh_mock.new_session()
+    session = bigfoot.ssh.new_session()
     assert isinstance(session, SessionHandle)
     result = session.expect("connect", returns=None, required=False)
     assert result is session  # expect() returns self for chaining
 
 
 # ESCAPE: test_ssh_mock_proxy_raises_outside_context
-#   CLAIM: Accessing bigfoot.ssh_mock outside a test context raises NoActiveVerifierError.
+#   CLAIM: Accessing bigfoot.ssh outside a test context raises NoActiveVerifierError.
 #   PATH:  _SshProxy.__getattr__ -> _get_test_verifier_or_raise -> NoActiveVerifierError.
 #   CHECK: NoActiveVerifierError raised.
 #   MUTATION: Silently returning None would not raise and hide context failures.
@@ -1310,7 +1310,7 @@ def test_ssh_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.ssh_mock.new_session  # noqa: B018
+            _ = bigfoot.ssh.new_session  # noqa: B018
     finally:
         _current_test_verifier.reset(token)
 
@@ -1327,7 +1327,7 @@ def test_ssh_mock_proxy_raises_outside_context() -> None:
 #   MUTATION: Wrong detail values in any step fail the assertion.
 #   ESCAPE: Nothing reasonable -- full field coverage on all assertable steps.
 def test_full_exec_command_flow_assertions(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.ssh_mock.new_session()
+    session = bigfoot.ssh.new_session()
     session.expect("connect", returns=None)
     session.expect("exec_command", returns=("stdin", "stdout", "stderr"))
     session.expect("close", returns=None)
@@ -1338,11 +1338,11 @@ def test_full_exec_command_flow_assertions(bigfoot_verifier: StrictVerifier) -> 
         client.exec_command("whoami")
         client.close()
 
-    bigfoot.ssh_mock.assert_connect(
+    bigfoot.ssh.assert_connect(
         hostname="server.example.com", port=2222, username="admin", auth_method="password"
     )
-    bigfoot.ssh_mock.assert_exec_command(command="whoami")
-    bigfoot.ssh_mock.assert_close()
+    bigfoot.ssh.assert_exec_command(command="whoami")
+    bigfoot.ssh.assert_close()
 
 
 # ESCAPE: test_sftp_flow_assertions
@@ -1352,7 +1352,7 @@ def test_full_exec_command_flow_assertions(bigfoot_verifier: StrictVerifier) -> 
 #   MUTATION: Wrong detail values in any step fail the assertion.
 #   ESCAPE: Nothing reasonable -- full field coverage on all assertable steps.
 def test_sftp_flow_assertions(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.ssh_mock.new_session()
+    session = bigfoot.ssh.new_session()
     session.expect("connect", returns=None)
     session.expect("open_sftp", returns=None)
     session.expect("sftp_get", returns=None)
@@ -1367,13 +1367,13 @@ def test_sftp_flow_assertions(bigfoot_verifier: StrictVerifier) -> None:
         sftp.put("/local/results.csv", "/remote/results.csv")
         client.close()
 
-    bigfoot.ssh_mock.assert_connect(
+    bigfoot.ssh.assert_connect(
         hostname="sftp.example.com", port=22, username="transfer", auth_method="password"
     )
-    bigfoot.ssh_mock.assert_open_sftp()
-    bigfoot.ssh_mock.assert_sftp_get(remotepath="/remote/data.csv", localpath="/local/data.csv")
-    bigfoot.ssh_mock.assert_sftp_put(localpath="/local/results.csv", remotepath="/remote/results.csv")
-    bigfoot.ssh_mock.assert_close()
+    bigfoot.ssh.assert_open_sftp()
+    bigfoot.ssh.assert_sftp_get(remotepath="/remote/data.csv", localpath="/local/data.csv")
+    bigfoot.ssh.assert_sftp_put(localpath="/local/results.csv", remotepath="/remote/results.csv")
+    bigfoot.ssh.assert_close()
 
 
 # ESCAPE: test_multiple_sequential_sessions_assertions
@@ -1385,13 +1385,13 @@ def test_sftp_flow_assertions(bigfoot_verifier: StrictVerifier) -> None:
 #   ESCAPE: Nothing reasonable -- full field coverage on both sessions.
 def test_multiple_sequential_sessions_assertions(bigfoot_verifier: StrictVerifier) -> None:
     # First session
-    s1 = bigfoot.ssh_mock.new_session()
+    s1 = bigfoot.ssh.new_session()
     s1.expect("connect", returns=None)
     s1.expect("exec_command", returns=("stdin", "stdout", "stderr"))
     s1.expect("close", returns=None)
 
     # Second session
-    s2 = bigfoot.ssh_mock.new_session()
+    s2 = bigfoot.ssh.new_session()
     s2.expect("connect", returns=None)
     s2.expect("open_sftp", returns=None)
     s2.expect("sftp_get", returns=None)
@@ -1412,19 +1412,19 @@ def test_multiple_sequential_sessions_assertions(bigfoot_verifier: StrictVerifie
         client2.close()
 
     # Assert first session interactions
-    bigfoot.ssh_mock.assert_connect(
+    bigfoot.ssh.assert_connect(
         hostname="host1", port=22, username="user1", auth_method="password"
     )
-    bigfoot.ssh_mock.assert_exec_command(command="ls")
-    bigfoot.ssh_mock.assert_close()
+    bigfoot.ssh.assert_exec_command(command="ls")
+    bigfoot.ssh.assert_close()
 
     # Assert second session interactions
-    bigfoot.ssh_mock.assert_connect(
+    bigfoot.ssh.assert_connect(
         hostname="host2", port=22, username="user2", auth_method="password"
     )
-    bigfoot.ssh_mock.assert_open_sftp()
-    bigfoot.ssh_mock.assert_sftp_get(remotepath="/remote/file.txt", localpath="/local/file.txt")
-    bigfoot.ssh_mock.assert_close()
+    bigfoot.ssh.assert_open_sftp()
+    bigfoot.ssh.assert_sftp_get(remotepath="/remote/file.txt", localpath="/local/file.txt")
+    bigfoot.ssh.assert_close()
 
 
 # ---------------------------------------------------------------------------
@@ -1669,7 +1669,7 @@ def test_format_mock_hint() -> None:
         plugin=p,
     )
     result = p.format_mock_hint(interaction)
-    assert result == "    bigfoot.ssh_mock.new_session().expect('exec_command', returns=...)"
+    assert result == "    bigfoot.ssh.new_session().expect('exec_command', returns=...)"
 
 
 # ESCAPE: test_format_mock_hint_connect
@@ -1689,7 +1689,7 @@ def test_format_mock_hint_connect() -> None:
         plugin=p,
     )
     result = p.format_mock_hint(interaction)
-    assert result == "    bigfoot.ssh_mock.new_session().expect('connect', returns=...)"
+    assert result == "    bigfoot.ssh.new_session().expect('connect', returns=...)"
 
 
 # ESCAPE: test_format_unmocked_hint
@@ -1704,7 +1704,7 @@ def test_format_unmocked_hint() -> None:
     assert result == (
         "paramiko.SSHClient.connect(...) was called but no session was queued.\n"
         "Register a session with:\n"
-        "    bigfoot.ssh_mock.new_session().expect('connect', returns=...)"
+        "    bigfoot.ssh.new_session().expect('connect', returns=...)"
     )
 
 
@@ -1720,7 +1720,7 @@ def test_format_unmocked_hint_exec_command() -> None:
     assert result == (
         "paramiko.SSHClient.exec_command(...) was called but no session was queued.\n"
         "Register a session with:\n"
-        "    bigfoot.ssh_mock.new_session().expect('exec_command', returns=...)"
+        "    bigfoot.ssh.new_session().expect('exec_command', returns=...)"
     )
 
 
@@ -1742,7 +1742,7 @@ def test_format_assert_hint_connect() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        "    bigfoot.ssh_mock.assert_connect("
+        "    bigfoot.ssh.assert_connect("
         "hostname='myhost', port=22, username='user', auth_method='password')"
     )
 
@@ -1764,7 +1764,7 @@ def test_format_assert_hint_exec_command() -> None:
         plugin=p,
     )
     result = p.format_assert_hint(interaction)
-    assert result == "    bigfoot.ssh_mock.assert_exec_command(command='uptime')"
+    assert result == "    bigfoot.ssh.assert_exec_command(command='uptime')"
 
 
 # ESCAPE: test_format_assert_hint_open_sftp
@@ -1784,7 +1784,7 @@ def test_format_assert_hint_open_sftp() -> None:
         plugin=p,
     )
     result = p.format_assert_hint(interaction)
-    assert result == "    bigfoot.ssh_mock.assert_open_sftp()"
+    assert result == "    bigfoot.ssh.assert_open_sftp()"
 
 
 # ESCAPE: test_format_assert_hint_sftp_get
@@ -1805,7 +1805,7 @@ def test_format_assert_hint_sftp_get() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        "    bigfoot.ssh_mock.assert_sftp_get("
+        "    bigfoot.ssh.assert_sftp_get("
         "remotepath='/remote/file.txt', localpath='/local/file.txt')"
     )
 
@@ -1828,7 +1828,7 @@ def test_format_assert_hint_sftp_put() -> None:
     )
     result = p.format_assert_hint(interaction)
     assert result == (
-        "    bigfoot.ssh_mock.assert_sftp_put("
+        "    bigfoot.ssh.assert_sftp_put("
         "localpath='/local/file.txt', remotepath='/remote/file.txt')"
     )
 
@@ -1850,7 +1850,7 @@ def test_format_assert_hint_close() -> None:
         plugin=p,
     )
     result = p.format_assert_hint(interaction)
-    assert result == "    bigfoot.ssh_mock.assert_close()"
+    assert result == "    bigfoot.ssh.assert_close()"
 
 
 # ESCAPE: test_format_assert_hint_unknown
@@ -1870,7 +1870,7 @@ def test_format_assert_hint_unknown() -> None:
         plugin=p,
     )
     result = p.format_assert_hint(interaction)
-    assert result == "    # bigfoot.ssh_mock: unknown source_id='ssh:unknown_op'"
+    assert result == "    # bigfoot.ssh: unknown source_id='ssh:unknown_op'"
 
 
 # ESCAPE: test_format_unused_mock_hint
@@ -1912,7 +1912,7 @@ def test_format_assert_hint_sftp_listdir() -> None:
         plugin=p,
     )
     result = p.format_assert_hint(interaction)
-    assert result == "    bigfoot.ssh_mock.assert_sftp_listdir(path='/remote/dir')"
+    assert result == "    bigfoot.ssh.assert_sftp_listdir(path='/remote/dir')"
 
 
 # ESCAPE: test_format_assert_hint_sftp_stat
@@ -1932,7 +1932,7 @@ def test_format_assert_hint_sftp_stat() -> None:
         plugin=p,
     )
     result = p.format_assert_hint(interaction)
-    assert result == "    bigfoot.ssh_mock.assert_sftp_stat(path='/remote/file.txt')"
+    assert result == "    bigfoot.ssh.assert_sftp_stat(path='/remote/file.txt')"
 
 
 # ESCAPE: test_format_assert_hint_sftp_mkdir
@@ -1952,7 +1952,7 @@ def test_format_assert_hint_sftp_mkdir() -> None:
         plugin=p,
     )
     result = p.format_assert_hint(interaction)
-    assert result == "    bigfoot.ssh_mock.assert_sftp_mkdir(path='/remote/newdir')"
+    assert result == "    bigfoot.ssh.assert_sftp_mkdir(path='/remote/newdir')"
 
 
 # ESCAPE: test_format_assert_hint_sftp_remove
@@ -1972,7 +1972,7 @@ def test_format_assert_hint_sftp_remove() -> None:
         plugin=p,
     )
     result = p.format_assert_hint(interaction)
-    assert result == "    bigfoot.ssh_mock.assert_sftp_remove(path='/remote/oldfile.txt')"
+    assert result == "    bigfoot.ssh.assert_sftp_remove(path='/remote/oldfile.txt')"
 
 
 # ---------------------------------------------------------------------------
@@ -1987,7 +1987,7 @@ def test_format_assert_hint_sftp_remove() -> None:
 #   MUTATION: Wrong path would raise InteractionMismatchError.
 #   ESCAPE: Nothing reasonable -- helper delegates to assert_interaction with full fields.
 def test_assert_sftp_listdir_helper(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.ssh_mock.new_session()
+    session = bigfoot.ssh.new_session()
     session.expect("connect", returns=None)
     session.expect("open_sftp", returns=None)
     session.expect("sftp_listdir", returns=["file1.txt", "file2.txt"])
@@ -2000,12 +2000,12 @@ def test_assert_sftp_listdir_helper(bigfoot_verifier: StrictVerifier) -> None:
         sftp.listdir("/remote/dir")
         client.close()
 
-    bigfoot.ssh_mock.assert_connect(
+    bigfoot.ssh.assert_connect(
         hostname="server.example.com", port=22, username="deploy", auth_method="password"
     )
-    bigfoot.ssh_mock.assert_open_sftp()
-    bigfoot.ssh_mock.assert_sftp_listdir(path="/remote/dir")
-    bigfoot.ssh_mock.assert_close()
+    bigfoot.ssh.assert_open_sftp()
+    bigfoot.ssh.assert_sftp_listdir(path="/remote/dir")
+    bigfoot.ssh.assert_close()
 
 
 # ESCAPE: test_assert_sftp_stat_helper
@@ -2015,7 +2015,7 @@ def test_assert_sftp_listdir_helper(bigfoot_verifier: StrictVerifier) -> None:
 #   MUTATION: Wrong path would raise InteractionMismatchError.
 #   ESCAPE: Nothing reasonable -- helper delegates to assert_interaction with full fields.
 def test_assert_sftp_stat_helper(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.ssh_mock.new_session()
+    session = bigfoot.ssh.new_session()
     session.expect("connect", returns=None)
     session.expect("open_sftp", returns=None)
     session.expect("sftp_stat", returns="fake_stat_result")
@@ -2028,12 +2028,12 @@ def test_assert_sftp_stat_helper(bigfoot_verifier: StrictVerifier) -> None:
         sftp.stat("/remote/file.txt")
         client.close()
 
-    bigfoot.ssh_mock.assert_connect(
+    bigfoot.ssh.assert_connect(
         hostname="server.example.com", port=22, username="deploy", auth_method="password"
     )
-    bigfoot.ssh_mock.assert_open_sftp()
-    bigfoot.ssh_mock.assert_sftp_stat(path="/remote/file.txt")
-    bigfoot.ssh_mock.assert_close()
+    bigfoot.ssh.assert_open_sftp()
+    bigfoot.ssh.assert_sftp_stat(path="/remote/file.txt")
+    bigfoot.ssh.assert_close()
 
 
 # ESCAPE: test_assert_sftp_mkdir_helper
@@ -2043,7 +2043,7 @@ def test_assert_sftp_stat_helper(bigfoot_verifier: StrictVerifier) -> None:
 #   MUTATION: Wrong path would raise InteractionMismatchError.
 #   ESCAPE: Nothing reasonable -- helper delegates to assert_interaction with full fields.
 def test_assert_sftp_mkdir_helper(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.ssh_mock.new_session()
+    session = bigfoot.ssh.new_session()
     session.expect("connect", returns=None)
     session.expect("open_sftp", returns=None)
     session.expect("sftp_mkdir", returns=None)
@@ -2056,12 +2056,12 @@ def test_assert_sftp_mkdir_helper(bigfoot_verifier: StrictVerifier) -> None:
         sftp.mkdir("/remote/newdir")
         client.close()
 
-    bigfoot.ssh_mock.assert_connect(
+    bigfoot.ssh.assert_connect(
         hostname="server.example.com", port=22, username="deploy", auth_method="password"
     )
-    bigfoot.ssh_mock.assert_open_sftp()
-    bigfoot.ssh_mock.assert_sftp_mkdir(path="/remote/newdir")
-    bigfoot.ssh_mock.assert_close()
+    bigfoot.ssh.assert_open_sftp()
+    bigfoot.ssh.assert_sftp_mkdir(path="/remote/newdir")
+    bigfoot.ssh.assert_close()
 
 
 # ESCAPE: test_assert_sftp_remove_helper
@@ -2071,7 +2071,7 @@ def test_assert_sftp_mkdir_helper(bigfoot_verifier: StrictVerifier) -> None:
 #   MUTATION: Wrong path would raise InteractionMismatchError.
 #   ESCAPE: Nothing reasonable -- helper delegates to assert_interaction with full fields.
 def test_assert_sftp_remove_helper(bigfoot_verifier: StrictVerifier) -> None:
-    session = bigfoot.ssh_mock.new_session()
+    session = bigfoot.ssh.new_session()
     session.expect("connect", returns=None)
     session.expect("open_sftp", returns=None)
     session.expect("sftp_remove", returns=None)
@@ -2084,12 +2084,12 @@ def test_assert_sftp_remove_helper(bigfoot_verifier: StrictVerifier) -> None:
         sftp.remove("/remote/oldfile.txt")
         client.close()
 
-    bigfoot.ssh_mock.assert_connect(
+    bigfoot.ssh.assert_connect(
         hostname="server.example.com", port=22, username="deploy", auth_method="password"
     )
-    bigfoot.ssh_mock.assert_open_sftp()
-    bigfoot.ssh_mock.assert_sftp_remove(path="/remote/oldfile.txt")
-    bigfoot.ssh_mock.assert_close()
+    bigfoot.ssh.assert_open_sftp()
+    bigfoot.ssh.assert_sftp_remove(path="/remote/oldfile.txt")
+    bigfoot.ssh.assert_close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_subprocess_plugin.py
+++ b/tests/unit/test_subprocess_plugin.py
@@ -266,7 +266,7 @@ def test_mock_run_raises_exception() -> None:
 #   MUTATION: Recording interaction with wrong command would cause assert_interaction to raise.
 #   ESCAPE: Nothing reasonable -- assert_interaction is the definitive check here.
 def test_mock_run_in_sandbox(bigfoot_verifier: StrictVerifier) -> None:
-    bigfoot.subprocess_mock.mock_run(["make", "build"], returncode=0, stdout="ok")
+    bigfoot.subprocess.mock_run(["make", "build"], returncode=0, stdout="ok")
 
     with bigfoot.sandbox():
         result = subprocess.run(["make", "build"])
@@ -276,7 +276,7 @@ def test_mock_run_in_sandbox(bigfoot_verifier: StrictVerifier) -> None:
     assert result.stderr == ""
     assert result.args == ["make", "build"]
 
-    bigfoot.assert_interaction(bigfoot.subprocess_mock.run, command=["make", "build"], returncode=0, stdout="ok", stderr="")
+    bigfoot.assert_interaction(bigfoot.subprocess.run, command=["make", "build"], returncode=0, stdout="ok", stderr="")
 
 
 # ESCAPE: test_unregistered_run_in_sandbox_raises
@@ -286,8 +286,8 @@ def test_mock_run_in_sandbox(bigfoot_verifier: StrictVerifier) -> None:
 #   MUTATION: Returning a default response silently lets unmocked calls through.
 #   ESCAPE: Nothing reasonable -- exact exception type and source_id.
 def test_unregistered_run_in_sandbox_raises(bigfoot_verifier: StrictVerifier) -> None:
-    # Access subprocess_mock to ensure SubprocessPlugin is created and registered
-    bigfoot.subprocess_mock.install()
+    # Access subprocess proxy to ensure SubprocessPlugin is created and registered
+    bigfoot.subprocess.install()
 
     with bigfoot.sandbox():
         with pytest.raises(UnmockedInteractionError) as exc_info:
@@ -424,7 +424,7 @@ def test_unmocked_which_asserted_passes() -> None:
 
 
 # ESCAPE: test_assert_interaction_run
-#   CLAIM: After sandbox with mock_run, assert_interaction(subprocess_mock.run, command=...)
+#   CLAIM: After sandbox with mock_run, assert_interaction(subprocess.run, command=...)
 #          passes without raising.
 #   PATH:  assert_interaction -> verifier._timeline.peek_next_unasserted ->
 #          matches source_id + command -> mark asserted.
@@ -433,30 +433,30 @@ def test_unmocked_which_asserted_passes() -> None:
 #             InteractionMismatchError.
 #   ESCAPE: Recording with wrong command would cause field match to fail.
 def test_assert_interaction_run(bigfoot_verifier: StrictVerifier) -> None:
-    bigfoot.subprocess_mock.mock_run(["pytest", "--tb=short"], returncode=0, stdout="passed")
+    bigfoot.subprocess.mock_run(["pytest", "--tb=short"], returncode=0, stdout="passed")
 
     with bigfoot.sandbox():
         subprocess.run(["pytest", "--tb=short"])
 
     # Must not raise
-    bigfoot.assert_interaction(bigfoot.subprocess_mock.run, command=["pytest", "--tb=short"], returncode=0, stdout="passed", stderr="")
+    bigfoot.assert_interaction(bigfoot.subprocess.run, command=["pytest", "--tb=short"], returncode=0, stdout="passed", stderr="")
 
 
 # ESCAPE: test_assert_interaction_which
-#   CLAIM: After sandbox with mock_which, assert_interaction(subprocess_mock.which, name=...)
+#   CLAIM: After sandbox with mock_which, assert_interaction(subprocess.which, name=...)
 #          passes without raising.
 #   PATH:  assert_interaction -> matches source_id "subprocess:which" + name field.
 #   CHECK: No exception raised.
 #   MUTATION: Recording interaction with wrong name would cause field mismatch.
 #   ESCAPE: Recording source_id as "subprocess:run" instead would fail source_id match.
 def test_assert_interaction_which(bigfoot_verifier: StrictVerifier) -> None:
-    bigfoot.subprocess_mock.mock_which("python3", returns="/usr/bin/python3")
+    bigfoot.subprocess.mock_which("python3", returns="/usr/bin/python3")
 
     with bigfoot.sandbox():
         shutil.which("python3")
 
     # Must not raise
-    bigfoot.assert_interaction(bigfoot.subprocess_mock.which, name="python3", returns="/usr/bin/python3")
+    bigfoot.assert_interaction(bigfoot.subprocess.which, name="python3", returns="/usr/bin/python3")
 
 
 # ---------------------------------------------------------------------------
@@ -509,7 +509,7 @@ def test_conflict_error_shutil_which_already_patched() -> None:
 
 
 # ESCAPE: test_subprocess_mock_proxy_raises_outside_sandbox
-#   CLAIM: Accessing bigfoot.subprocess_mock.mock_run outside a pytest test context
+#   CLAIM: Accessing bigfoot.subprocess.mock_run outside a pytest test context
 #          raises NoActiveVerifierError (because _current_test_verifier is not set).
 #   PATH:  _SubprocessProxy.__getattr__ -> _get_test_verifier_or_raise -> NoActiveVerifierError.
 #   CHECK: NoActiveVerifierError (or subclass) raised when ContextVar is explicitly cleared.
@@ -523,7 +523,7 @@ def test_subprocess_mock_proxy_raises_outside_sandbox() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.subprocess_mock.mock_run
+            _ = bigfoot.subprocess.mock_run
     finally:
         _current_test_verifier.reset(token)
 
@@ -796,7 +796,7 @@ def test_format_assert_hint_run() -> None:
         plugin=p,
     )
     result = p.format_assert_hint(interaction)
-    assert "bigfoot.subprocess_mock.assert_run(" in result
+    assert "bigfoot.subprocess.assert_run(" in result
     assert "command=['git', 'status']" in result
     assert "returncode=0" in result
     assert "stdout=''" in result
@@ -815,7 +815,7 @@ def test_format_assert_hint_which() -> None:
         plugin=p,
     )
     result = p.format_assert_hint(interaction)
-    assert "bigfoot.subprocess_mock.assert_which(" in result
+    assert "bigfoot.subprocess.assert_which(" in result
     assert "name='gcc'" in result
     assert "returns='/usr/bin/gcc'" in result
     # Must NOT contain old assert_interaction pattern

--- a/tests/unit/test_websocket_plugin.py
+++ b/tests/unit/test_websocket_plugin.py
@@ -381,12 +381,12 @@ async def test_async_close_releases_session() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.async_websocket_mock
+# Module-level proxy: bigfoot.async_websocket
 # ---------------------------------------------------------------------------
 
 
 # ESCAPE: test_async_websocket_mock_proxy_new_session
-#   CLAIM: bigfoot.async_websocket_mock.new_session() returns a SessionHandle.
+#   CLAIM: bigfoot.async_websocket.new_session() returns a SessionHandle.
 #   PATH:  _AsyncWebSocketProxy.__getattr__("new_session") -> get verifier ->
 #          find/create AsyncWebSocketPlugin -> return plugin.new_session.
 #   CHECK: session is a SessionHandle instance; chaining .expect() returns self.
@@ -395,14 +395,14 @@ async def test_async_close_releases_session() -> None:
 def test_async_websocket_mock_proxy_new_session(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    session = bigfoot.async_websocket_mock.new_session()
+    session = bigfoot.async_websocket.new_session()
     assert isinstance(session, SessionHandle)
     result = session.expect("connect", returns=None, required=False)
     assert result is session
 
 
 # ESCAPE: test_async_websocket_mock_proxy_raises_outside_context
-#   CLAIM: Accessing bigfoot.async_websocket_mock outside a test context raises
+#   CLAIM: Accessing bigfoot.async_websocket outside a test context raises
 #          NoActiveVerifierError.
 #   PATH:  _AsyncWebSocketProxy.__getattr__ -> _get_test_verifier_or_raise ->
 #          NoActiveVerifierError.
@@ -416,7 +416,7 @@ def test_async_websocket_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.async_websocket_mock.new_session
+            _ = bigfoot.async_websocket.new_session
     finally:
         _current_test_verifier.reset(token)
 
@@ -734,12 +734,12 @@ def test_sync_fifo_two_sessions() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Module-level proxy: bigfoot.sync_websocket_mock
+# Module-level proxy: bigfoot.sync_websocket
 # ---------------------------------------------------------------------------
 
 
 # ESCAPE: test_sync_websocket_mock_proxy_new_session
-#   CLAIM: bigfoot.sync_websocket_mock.new_session() returns a SessionHandle.
+#   CLAIM: bigfoot.sync_websocket.new_session() returns a SessionHandle.
 #   PATH:  _SyncWebSocketProxy.__getattr__("new_session") -> get verifier ->
 #          find/create SyncWebSocketPlugin -> return plugin.new_session.
 #   CHECK: session is a SessionHandle instance; chaining .expect() returns self.
@@ -748,14 +748,14 @@ def test_sync_fifo_two_sessions() -> None:
 def test_sync_websocket_mock_proxy_new_session(bigfoot_verifier: StrictVerifier) -> None:
     import bigfoot
 
-    session = bigfoot.sync_websocket_mock.new_session()
+    session = bigfoot.sync_websocket.new_session()
     assert isinstance(session, SessionHandle)
     result = session.expect("connect", returns=None, required=False)
     assert result is session
 
 
 # ESCAPE: test_sync_websocket_mock_proxy_raises_outside_context
-#   CLAIM: Accessing bigfoot.sync_websocket_mock outside a test context raises
+#   CLAIM: Accessing bigfoot.sync_websocket outside a test context raises
 #          NoActiveVerifierError.
 #   PATH:  _SyncWebSocketProxy.__getattr__ -> _get_test_verifier_or_raise ->
 #          NoActiveVerifierError.
@@ -769,6 +769,6 @@ def test_sync_websocket_mock_proxy_raises_outside_context() -> None:
     token = _current_test_verifier.set(None)
     try:
         with pytest.raises(NoActiveVerifierError):
-            _ = bigfoot.sync_websocket_mock.new_session
+            _ = bigfoot.sync_websocket.new_session
     finally:
         _current_test_verifier.reset(token)


### PR DESCRIPTION
## Summary

- All 26 plugin proxy singletons on the `bigfoot` module are renamed to drop the `_mock` suffix. Canonical names are now un-suffixed: `bigfoot.subprocess`, `bigfoot.db`, `bigfoot.redis`, `bigfoot.mongo`, `bigfoot.popen`, `bigfoot.log`, etc. `bigfoot.http` was already un-suffixed and is unchanged.
- Old `_mock` names (`bigfoot.subprocess_mock`, etc.) are retained as deprecated backward-compat aliases wired through a module-level `__getattr__` in `src/bigfoot/__init__.py`. First access to any alias emits `DeprecationWarning` with message `"bigfoot.<old> is deprecated; use bigfoot.<new> instead."` and `stacklevel=2`. Subsequent accesses are silent.
- Aliases exist in `__init__.py` only — every test, doc, example, plugin hint string, and README has been migrated to the canonical names. Nothing else in the repo references the `_mock` names except the deprecation shim itself and the tests that intentionally exercise it.
- Version bump 0.19.2 → 0.20.0. CHANGELOG entry added with `### Changed` + `### Deprecated` sections.

## What changed

- `src/bigfoot/__init__.py` — canonical proxy assignments; `_DEPRECATED_PROXY_ALIASES` dict + module-level `__getattr__` emit warnings
- `src/bigfoot/__init__.pyi` — mirrored type stubs (canonical declarations + deprecated aliases, both declared for type-checker compat)
- `src/bigfoot/plugins/*.py` — hint strings (`format_mock_hint`, `format_assert_hint`, `format_unmocked_hint`) now emit canonical names
- `tests/unit/test_init.py` — new parametrized deprecation-alias tests covering: identity between alias and canonical, first-access emits warning with exact message + `stacklevel=2`, no re-warn on second access, unknown attribute still raises standard `AttributeError`. Uses a fixture to snapshot/restore `_warned_aliases` so state leaks don't mask behavior.
- All other `tests/unit/test_*_plugin.py` files migrated mechanically
- `docs/guides/*.md` (30 files) + `docs/reference/index.md` migrated
- `examples/*/test_app.py` and example `README.md` files (31 total) migrated
- `README.md` code samples migrated
- `CHANGELOG.md` 0.20.0 entry
- `pyproject.toml` version bump

## Verification

- Full test suite: **1809 passed** in `tests/`, **31 passed** in `examples/` (1840 total)
- Code review: ready-to-merge, no critical or important findings
- Green-mirage audit of new deprecation-alias tests: clean (4 functions × parametrize = 10 cases; 5/5 mutations killed)
- Grep sweep: no `bigfoot.X_mock` references survive outside `__init__.py`/`__init__.pyi`/the deprecation-alias test block/CHANGELOG history entries

## Follow-up (not in this PR)

- `docs/guides/stateful-plugins.md` documents an "Auto-assertion" behavior that contradicts the project's anti-auto-assert rule. Pre-existing, flagged by a review subagent during the migration sweep. Worth a separate cleanup PR.
