### PR TITLE
chore: rename PyPI distribution to pytest-tripwire (0.21.0)

### DIFF
--- a/.claude/skills/adding-plugins/SKILL.md
+++ b/.claude/skills/adding-plugins/SKILL.md
@@ -199,7 +199,7 @@ from tripwire._context import _current_test_verifier
 from tripwire._errors import InteractionMismatchError, UnmockedInteractionError
 from tripwire._verifier import StrictVerifier
 
-# Import the library directly -- all optional deps are in python-tripwire[dev].
+# Import the library directly -- all optional deps are in pytest-tripwire[dev].
 # Never use pytest.importorskip (green mirage).
 import [lib]
 
@@ -490,7 +490,7 @@ mock responses and assert exactly what your code sent.
 ## Installation
 
 ```bash
-pip install python-tripwire[[name]]
+pip install pytest-tripwire[[name]]
 ```
 
 ## Quick Start

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ def test_something():
 - **Never** put inline code examples in guide "Full example" sections. Always use snippet includes from `examples/`.
 - **Every** new plugin guide must have a corresponding `examples/` directory with working tests.
 - If a library generates DEBUG logs (boto3, pymongo, celery, etc.), add an autouse fixture to silence them so they don't interfere with LoggingPlugin.
-- **Never** use `pytest.importorskip()` in tests. All optional dependencies are included in `python-tripwire[dev]` and are expected to be installed. Skipping on missing imports is a green mirage.
+- **Never** use `pytest.importorskip()` in tests. All optional dependencies are included in `pytest-tripwire[dev]` and are expected to be installed. Skipping on missing imports is a green mirage.
 - The `.claude/skills/adding-plugins/SKILL.md` skill automates the full plugin creation lifecycle including examples and docs.
 
 ## Selective Installation
@@ -116,10 +116,10 @@ def test_something():
 Core plugins (subprocess, logging, database, socket, file-io, native, dns) require no extras. Optional plugins need:
 
 ```bash
-pip install python-tripwire[all]        # Everything
-pip install python-tripwire[http]       # httpx, requests, urllib
-pip install python-tripwire[redis]      # redis
-pip install python-tripwire[boto3]      # botocore
-pip install python-tripwire[pymongo]    # pymongo
+pip install pytest-tripwire[all]        # Everything
+pip install pytest-tripwire[http]       # httpx, requests, urllib
+pip install pytest-tripwire[redis]      # redis
+pip install pytest-tripwire[boto3]      # botocore
+pip install pytest-tripwire[pymongo]    # pymongo
 # ... see pyproject.toml [project.optional-dependencies] for full list
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.0] - 2026-04-30
+
+### Changed
+- **Breaking (PyPI dist name):** The PyPI distribution is renamed from `python-tripwire` to `pytest-tripwire`. Rationale: pytest plugins are conventionally distributed as `pytest-<name>`, so the new name reflects what this package actually is and surfaces it in pytest plugin indexes.
+- The Python import name is unchanged. Code keeps using `import tripwire`; the pytest11 entry-point is still registered under the name `tripwire`; the `[tool.tripwire]` config namespace is unchanged.
+- Project URLs (`Homepage`, `Repository`, `Issues`, `Changelog`) updated to `https://github.com/axiomantic/pytest-tripwire`.
+- Install/extras messaging in error strings, README, and plugin docs now references `pytest-tripwire[<extra>]`.
+
+### Added
+- A deprecation shim is published under the old `python-tripwire` name. It depends on `pytest-tripwire` so the upgrade path is `pip install -U python-tripwire` (or, preferred, `pip uninstall python-tripwire && pip install pytest-tripwire`).
+
+### Migration
+- Replace `pip install python-tripwire[...]` (or the `uv add` / `poetry add` / `uv pip install` equivalents) with `pip install pytest-tripwire[...]`.
+- No source changes are required: `import tripwire` continues to work, and existing `[tool.tripwire]` configuration in `pyproject.toml` is unchanged.
+
 ## [0.20.1] - 2026-04-29
 
 ### Changed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at https://github.com/axiomantic/python-tripwire/issues. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at https://github.com/axiomantic/pytest-tripwire/issues. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for your interest in contributing to tripwire! This guide will help you g
 
 ```bash
 # Clone the repo
-git clone https://github.com/axiomantic/python-tripwire.git
+git clone https://github.com/axiomantic/pytest-tripwire.git
 cd tripwire
 
 # Create a virtual environment
@@ -80,7 +80,7 @@ See the [Writing Plugins](https://axiomantic.github.io/tripwire/guides/writing-p
 
 ## Reporting Issues
 
-- Use the [issue tracker](https://github.com/axiomantic/python-tripwire/issues).
+- Use the [issue tracker](https://github.com/axiomantic/pytest-tripwire/issues).
 - For bugs, include: Python version, tripwire version, minimal reproduction, and full traceback.
 - For feature requests, describe the use case and why existing plugins don't cover it.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # tripwire
 
-[![CI](https://github.com/axiomantic/python-tripwire/actions/workflows/ci.yml/badge.svg)](https://github.com/axiomantic/python-tripwire/actions/workflows/ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/python-tripwire)](https://pypi.org/project/python-tripwire/)
+[![CI](https://github.com/axiomantic/pytest-tripwire/actions/workflows/ci.yml/badge.svg)](https://github.com/axiomantic/pytest-tripwire/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/pytest-tripwire)](https://pypi.org/project/pytest-tripwire/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 > *"Let me tell you why you're here. You're here because you know something. What you know you can't explain, but you feel it. You've felt it your entire life, that there's something wrong with the world. You don't know what it is, but it's there, like a splinter in your mind, driving you mad."*
 > -- Morpheus, The Matrix (1999)
+
+`pytest-tripwire` is a pytest plugin for full-certainty test mocking: every external call your code makes is recorded, and every recorded interaction must be explicitly asserted. The pytest entry point auto-installs the verifier into every test session, so unmocked I/O and forgotten assertions surface as loud failures instead of silent green checkmarks.
 
 You've had tests pass in CI and then watched the thing they were supposedly testing break in production. You go back and look at the test, and it turns out the mock was wrong, or incomplete, or your production code was making a call the test didn't even know about. The green checkmark was meaningless.
 
@@ -15,8 +17,10 @@ This is what testing with `unittest.mock` is like. It gives you the tools to moc
 tripwire replaces `unittest.mock` with mocking that actually enforces correctness.
 
 ```bash
-pip install python-tripwire[all]
+pip install pytest-tripwire[all]
 ```
+
+The import name stays `tripwire` (`import tripwire`); only the PyPI distribution was renamed. Previously published as `python-tripwire`; that name is now a deprecation shim that pulls in `pytest-tripwire`. Existing users only need to swap their `pip install` line. No code changes.
 
 ## The three guarantees
 
@@ -445,29 +449,29 @@ Per-call arguments override project-level settings. See the [configuration guide
 
 ## Selective Installation
 
-`python-tripwire[all]` installs everything. For a smaller footprint, pick only what you need:
+`pytest-tripwire[all]` installs everything. For a smaller footprint, pick only what you need:
 
 ```bash
-pip install python-tripwire                       # Core plugins (no optional deps)
-pip install python-tripwire[http]                 # + httpx, requests, urllib
-pip install python-tripwire[aiohttp]              # + aiohttp
-pip install python-tripwire[redis]                # + Redis
-pip install python-tripwire[pymemcache]           # + Memcached
-pip install python-tripwire[pymongo]              # + MongoDB
-pip install python-tripwire[elasticsearch]        # + Elasticsearch/OpenSearch
-pip install python-tripwire[psycopg2]             # + PostgreSQL (psycopg2)
-pip install python-tripwire[asyncpg]              # + PostgreSQL (asyncpg)
-pip install python-tripwire[boto3]                # + AWS SDK
-pip install python-tripwire[pika]                 # + RabbitMQ
-pip install python-tripwire[celery]               # + Celery tasks
-pip install python-tripwire[grpc]                 # + gRPC
-pip install python-tripwire[paramiko]             # + SSH
-pip install python-tripwire[jwt]                  # + PyJWT
-pip install python-tripwire[crypto]               # + cryptography
-pip install python-tripwire[cffi]                 # + cffi (C FFI)
-pip install python-tripwire[websockets]           # + async WebSocket
-pip install python-tripwire[websocket-client]     # + sync WebSocket
-pip install python-tripwire[matchers]             # + dirty-equals matchers
+pip install pytest-tripwire                       # Core plugins (no optional deps)
+pip install pytest-tripwire[http]                 # + httpx, requests, urllib
+pip install pytest-tripwire[aiohttp]              # + aiohttp
+pip install pytest-tripwire[redis]                # + Redis
+pip install pytest-tripwire[pymemcache]           # + Memcached
+pip install pytest-tripwire[pymongo]              # + MongoDB
+pip install pytest-tripwire[elasticsearch]        # + Elasticsearch/OpenSearch
+pip install pytest-tripwire[psycopg2]             # + PostgreSQL (psycopg2)
+pip install pytest-tripwire[asyncpg]              # + PostgreSQL (asyncpg)
+pip install pytest-tripwire[boto3]                # + AWS SDK
+pip install pytest-tripwire[pika]                 # + RabbitMQ
+pip install pytest-tripwire[celery]               # + Celery tasks
+pip install pytest-tripwire[grpc]                 # + gRPC
+pip install pytest-tripwire[paramiko]             # + SSH
+pip install pytest-tripwire[jwt]                  # + PyJWT
+pip install pytest-tripwire[crypto]               # + cryptography
+pip install pytest-tripwire[cffi]                 # + cffi (C FFI)
+pip install pytest-tripwire[websockets]           # + async WebSocket
+pip install pytest-tripwire[websocket-client]     # + sync WebSocket
+pip install pytest-tripwire[matchers]             # + dirty-equals matchers
 ```
 
 ## Documentation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ tripwire is a **testing library** that runs in development and CI environments. 
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-Instead, use [GitHub's private security advisory feature](https://github.com/axiomantic/python-tripwire/security/advisories/new) to report the issue confidentially.
+Instead, use [GitHub's private security advisory feature](https://github.com/axiomantic/pytest-tripwire/security/advisories/new) to report the issue confidentially.
 
 Include:
 

--- a/docs/guides/asyncpg-plugin.md
+++ b/docs/guides/asyncpg-plugin.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-pip install python-tripwire[asyncpg]
+pip install pytest-tripwire[asyncpg]
 ```
 
 ## Setup

--- a/docs/guides/boto3-plugin.md
+++ b/docs/guides/boto3-plugin.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-pip install python-tripwire[boto3]
+pip install pytest-tripwire[boto3]
 ```
 
 This installs `botocore`.

--- a/docs/guides/celery-plugin.md
+++ b/docs/guides/celery-plugin.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-pip install python-tripwire[celery]
+pip install pytest-tripwire[celery]
 ```
 
 This installs `celery`.

--- a/docs/guides/crypto-plugin.md
+++ b/docs/guides/crypto-plugin.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-pip install python-tripwire[crypto]
+pip install pytest-tripwire[crypto]
 ```
 
 This installs `cryptography`.

--- a/docs/guides/elasticsearch-plugin.md
+++ b/docs/guides/elasticsearch-plugin.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-pip install python-tripwire[elasticsearch]
+pip install pytest-tripwire[elasticsearch]
 ```
 
 This installs `elasticsearch`.

--- a/docs/guides/grpc-plugin.md
+++ b/docs/guides/grpc-plugin.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-pip install python-tripwire[grpc]
+pip install pytest-tripwire[grpc]
 ```
 
 This installs `grpcio`.

--- a/docs/guides/http-plugin.md
+++ b/docs/guides/http-plugin.md
@@ -1,16 +1,16 @@
 # HttpPlugin Guide
 
-`HttpPlugin` intercepts HTTP calls made through `httpx` (sync and async), `requests`, `urllib`, and `aiohttp` (if installed). It requires the `python-tripwire[http]` extra. For aiohttp support, also install `python-tripwire[aiohttp]`.
+`HttpPlugin` intercepts HTTP calls made through `httpx` (sync and async), `requests`, `urllib`, and `aiohttp` (if installed). It requires the `pytest-tripwire[http]` extra. For aiohttp support, also install `pytest-tripwire[aiohttp]`.
 
 ## Installation
 
 ```bash
-pip install python-tripwire[http]              # httpx, requests, urllib
-pip install python-tripwire[aiohttp]           # + aiohttp support
-pip install python-tripwire[http,aiohttp]      # both
+pip install pytest-tripwire[http]              # httpx, requests, urllib
+pip install pytest-tripwire[aiohttp]           # + aiohttp support
+pip install pytest-tripwire[http,aiohttp]      # both
 ```
 
-`python-tripwire[http]` installs `httpx>=0.25.0` and `requests>=2.31.0`. `python-tripwire[aiohttp]` installs `aiohttp>=3.9.0`.
+`pytest-tripwire[http]` installs `httpx>=0.25.0` and `requests>=2.31.0`. `pytest-tripwire[aiohttp]` installs `aiohttp>=3.9.0`.
 
 ## Setup
 
@@ -363,7 +363,7 @@ See the [Configuration Guide](configuration.md) for full details on `[tool.tripw
 
 ## Using with aiohttp
 
-Requires `python-tripwire[aiohttp]`. If aiohttp is not installed, `HttpPlugin` works normally for other transports.
+Requires `pytest-tripwire[aiohttp]`. If aiohttp is not installed, `HttpPlugin` works normally for other transports.
 
 ```python
 import tripwire, aiohttp

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -5,7 +5,7 @@
 Install everything:
 
 ```bash
-pip install python-tripwire[all]
+pip install pytest-tripwire[all]
 ```
 
 This includes all plugins and their optional dependencies (httpx, requests, aiohttp, websockets, websocket-client, redis, psycopg2, asyncpg, dirty-equals).
@@ -15,20 +15,20 @@ This includes all plugins and their optional dependencies (httpx, requests, aioh
 For a more compact installation, pick only the extras you need:
 
 ```bash
-pip install python-tripwire                       # Core plugins (no extra deps)
-pip install python-tripwire[http]                 # + HttpPlugin (httpx, requests, urllib)
-pip install python-tripwire[aiohttp]              # + aiohttp support for HttpPlugin
-pip install python-tripwire[psycopg2]             # + Psycopg2Plugin (PostgreSQL)
-pip install python-tripwire[asyncpg]              # + AsyncpgPlugin (async PostgreSQL)
-pip install python-tripwire[websockets]           # + AsyncWebSocketPlugin
-pip install python-tripwire[websocket-client]     # + SyncWebSocketPlugin
-pip install python-tripwire[redis]                # + RedisPlugin
-pip install python-tripwire[matchers]             # + dirty-equals matchers
+pip install pytest-tripwire                       # Core plugins (no extra deps)
+pip install pytest-tripwire[http]                 # + HttpPlugin (httpx, requests, urllib)
+pip install pytest-tripwire[aiohttp]              # + aiohttp support for HttpPlugin
+pip install pytest-tripwire[psycopg2]             # + Psycopg2Plugin (PostgreSQL)
+pip install pytest-tripwire[asyncpg]              # + AsyncpgPlugin (async PostgreSQL)
+pip install pytest-tripwire[websockets]           # + AsyncWebSocketPlugin
+pip install pytest-tripwire[websocket-client]     # + SyncWebSocketPlugin
+pip install pytest-tripwire[redis]                # + RedisPlugin
+pip install pytest-tripwire[matchers]             # + dirty-equals matchers
 ```
 
 ### Core plugins (no extra dependencies)
 
-These plugins are always available with a bare `pip install python-tripwire`:
+These plugins are always available with a bare `pip install pytest-tripwire`:
 
 - `MockPlugin` -- general-purpose mock objects
 - `SubprocessPlugin` -- `subprocess.run` and `shutil.which`
@@ -44,7 +44,7 @@ These plugins are always available with a bare `pip install python-tripwire`:
 [dirty-equals](https://dirty-equals.helpmanual.io/) matchers can be used as expected field values in assertions:
 
 ```bash
-pip install python-tripwire[matchers]
+pip install pytest-tripwire[matchers]
 ```
 
 ## pytest fixture

--- a/docs/guides/jwt-plugin.md
+++ b/docs/guides/jwt-plugin.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-pip install python-tripwire[jwt]
+pip install pytest-tripwire[jwt]
 ```
 
 This installs `PyJWT`.

--- a/docs/guides/mcp-plugin.md
+++ b/docs/guides/mcp-plugin.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-pip install python-tripwire[mcp]
+pip install pytest-tripwire[mcp]
 ```
 
 This installs the `mcp` SDK.

--- a/docs/guides/memcache-plugin.md
+++ b/docs/guides/memcache-plugin.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-pip install python-tripwire[pymemcache]
+pip install pytest-tripwire[pymemcache]
 ```
 
 This installs `pymemcache`.

--- a/docs/guides/mongo-plugin.md
+++ b/docs/guides/mongo-plugin.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-pip install python-tripwire[pymongo]
+pip install pytest-tripwire[pymongo]
 ```
 
 This installs `pymongo`.

--- a/docs/guides/pika-plugin.md
+++ b/docs/guides/pika-plugin.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-pip install python-tripwire[pika]
+pip install pytest-tripwire[pika]
 ```
 
 This installs `pika`.

--- a/docs/guides/psycopg2-plugin.md
+++ b/docs/guides/psycopg2-plugin.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-pip install python-tripwire[psycopg2]
+pip install pytest-tripwire[psycopg2]
 ```
 
 ## Setup

--- a/docs/guides/redis-plugin.md
+++ b/docs/guides/redis-plugin.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-pip install python-tripwire[redis]
+pip install pytest-tripwire[redis]
 ```
 
 This installs `redis>=4.0.0`.

--- a/docs/guides/ssh-plugin.md
+++ b/docs/guides/ssh-plugin.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-pip install python-tripwire[paramiko]
+pip install pytest-tripwire[paramiko]
 ```
 
 This installs `paramiko`.

--- a/docs/guides/stateful-plugins.md
+++ b/docs/guides/stateful-plugins.md
@@ -215,7 +215,7 @@ assert exc_info.value.valid_states == frozenset({"in_transaction"})
 
 `AsyncWebSocketPlugin` intercepts `websockets.connect` and returns an async context manager that drives the session script.
 
-**Requires:** `pip install python-tripwire[websockets]`
+**Requires:** `pip install pytest-tripwire[websockets]`
 
 **State machine:**
 
@@ -284,7 +284,7 @@ async def test_two_ws_connections():
 
 `SyncWebSocketPlugin` intercepts `websocket.create_connection` from the `websocket-client` library and returns a fake connection object.
 
-**Requires:** `pip install python-tripwire[websocket-client]`
+**Requires:** `pip install pytest-tripwire[websocket-client]`
 
 **State machine:**
 
@@ -493,7 +493,7 @@ The state machine validates that `sendmail` is called from `greeted` (after `ehl
 
 `RedisPlugin` intercepts `redis.Redis.execute_command` at the class level. Unlike the other stateful plugins, Redis commands carry no inherent ordering constraint — GET and SET do not depend on each other's state. `RedisPlugin` therefore extends `BasePlugin` directly and uses a per-command FIFO queue rather than a session handle.
 
-**Requires:** `pip install python-tripwire[redis]`
+**Requires:** `pip install pytest-tripwire[redis]`
 
 **Proxy:** `tripwire.redis`
 

--- a/docs/guides/websocket-plugin.md
+++ b/docs/guides/websocket-plugin.md
@@ -12,13 +12,13 @@ Both use the same state machine and assertion pattern.
 === "Async (websockets)"
 
     ```bash
-    pip install python-tripwire[websockets]
+    pip install pytest-tripwire[websockets]
     ```
 
 === "Sync (websocket-client)"
 
     ```bash
-    pip install python-tripwire[websocket-client]
+    pip install pytest-tripwire[websocket-client]
     ```
 
 ## State machine

--- a/docs/guides/writing-plugins.md
+++ b/docs/guides/writing-plugins.md
@@ -609,7 +609,7 @@ If you use Claude Code or another AI coding assistant, tripwire includes a proje
 
 ## 1st party vs 3rd party plugins
 
-tripwire plugins don't depend on the libraries they intercept at install time. All library dependencies are optional extras (`pip install python-tripwire[http]`, `pip install python-tripwire[redis]`, etc.), so a 1st party plugin for any library costs nothing to users who don't install that extra. This means the usual "heavy dependencies" argument for splitting into a separate package doesn't apply.
+tripwire plugins don't depend on the libraries they intercept at install time. All library dependencies are optional extras (`pip install pytest-tripwire[http]`, `pip install pytest-tripwire[redis]`, etc.), so a 1st party plugin for any library costs nothing to users who don't install that extra. This means the usual "heavy dependencies" argument for splitting into a separate package doesn't apply.
 
 ### When to contribute a 1st party plugin
 
@@ -630,10 +630,10 @@ Create a separate package when:
 
 ### Packaging a 3rd party plugin
 
-A 3rd party plugin is a standard Python package that depends on `python-tripwire`. Users install it alongside tripwire:
+A 3rd party plugin is a standard Python package that depends on `pytest-tripwire`. Users install it alongside tripwire:
 
 ```bash
-pip install python-tripwire tripwire-myservice
+pip install pytest-tripwire tripwire-myservice
 ```
 
 **Project structure:**

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,6 +1,6 @@
 # API Reference
 
-All public symbols are importable from `tripwire` directly. `HttpPlugin` requires the `python-tripwire[http]` extra and is imported from `tripwire.plugins.http`.
+All public symbols are importable from `tripwire` directly. `HttpPlugin` requires the `pytest-tripwire[http]` extra and is imported from `tripwire.plugins.http`.
 
 ## Public symbols
 
@@ -10,7 +10,7 @@ All public symbols are importable from `tripwire` directly. `HttpPlugin` require
 | `SandboxContext` | class | Context manager returned by `verifier.sandbox()`. Activates all plugins for the duration of the `with` block. Supports both sync and async. |
 | `InAnyOrderContext` | class | Context manager returned by `verifier.in_any_order()`. Inside this block, `assert_interaction()` matches any unasserted interaction regardless of timeline order. |
 | `MockPlugin` | class | Intercepts method calls on named proxy objects. Created automatically by `verifier.mock()`. |
-| `HttpPlugin` | class | Intercepts `httpx`, `requests`, and `urllib` HTTP calls. Requires `python-tripwire[http]`. Import from `tripwire.plugins.http`. |
+| `HttpPlugin` | class | Intercepts `httpx`, `requests`, and `urllib` HTTP calls. Requires `pytest-tripwire[http]`. Import from `tripwire.plugins.http`. |
 | `SubprocessPlugin` | class | Intercepts `subprocess.run` and `shutil.which`. Included in core tripwire. Import from `tripwire.plugins.subprocess`. |
 | `subprocess` | proxy | Module-level proxy to `SubprocessPlugin` for the current test. Auto-creates the plugin on first access. |
 | `TripwireError` | exception | Base class for all tripwire exceptions. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: tripwire
 site_description: "Full-certainty test mocking for Python."
 site_url: https://axiomantic.github.io/tripwire/
-repo_url: https://github.com/axiomantic/python-tripwire
-repo_name: axiomantic/python-tripwire
+repo_url: https://github.com/axiomantic/pytest-tripwire
+repo_name: axiomantic/pytest-tripwire
 
 theme:
   name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "python-tripwire"
-version = "0.20.1"
+name = "pytest-tripwire"
+version = "0.21.0"
 description = "Full-certainty test mocking: every call recorded and verified"
 requires-python = ">=3.10"
 readme = "README.md"
@@ -33,10 +33,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/axiomantic/python-tripwire"
-Repository = "https://github.com/axiomantic/python-tripwire"
-Issues = "https://github.com/axiomantic/python-tripwire/issues"
-Changelog = "https://github.com/axiomantic/python-tripwire/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/axiomantic/pytest-tripwire"
+Repository = "https://github.com/axiomantic/pytest-tripwire"
+Issues = "https://github.com/axiomantic/pytest-tripwire/issues"
+Changelog = "https://github.com/axiomantic/pytest-tripwire/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 http = [
@@ -105,10 +105,10 @@ mcp = [
     "mcp>=1.0.0",
 ]
 all = [
-    "python-tripwire[http,matchers,websockets,websocket-client,redis,aiohttp,psycopg2,asyncpg,boto3,pika,celery,grpc,pymemcache,pymongo,cffi,jwt,crypto,elasticsearch,dnspython,paramiko,mcp]",
+    "pytest-tripwire[http,matchers,websockets,websocket-client,redis,aiohttp,psycopg2,asyncpg,boto3,pika,celery,grpc,pymemcache,pymongo,cffi,jwt,crypto,elasticsearch,dnspython,paramiko,mcp]",
 ]
 all-ft = [
-    "python-tripwire[http,matchers,websockets,websocket-client,redis,boto3,jwt,dnspython,pymemcache,elasticsearch]",
+    "pytest-tripwire[http,matchers,websockets,websocket-client,redis,boto3,jwt,dnspython,pymemcache,elasticsearch]",
 ]
 docs = [
     "mkdocs>=1.6",
@@ -117,7 +117,7 @@ docs = [
     "mike>=2.1",
 ]
 dev = [
-    "python-tripwire[all,docs]",
+    "pytest-tripwire[all,docs]",
     "pytest>=7.4.0",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=4.1.0",
@@ -125,7 +125,7 @@ dev = [
     "ruff>=0.1.0",
 ]
 dev-ft = [
-    "python-tripwire[all-ft]",
+    "pytest-tripwire[all-ft]",
     "pytest>=7.4.0",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=4.1.0",

--- a/src/tripwire/__init__.py
+++ b/src/tripwire/__init__.py
@@ -732,8 +732,8 @@ class _SshProxy:
 
         if not _PARAMIKO_AVAILABLE:
             raise ImportError(
-                "pytest-tripwire[ssh] is required to use tripwire.ssh. "
-                "Install it with: pip install pytest-tripwire[ssh]"
+                "pytest-tripwire[paramiko] is required to use tripwire.ssh. "
+                "Install it with: pip install pytest-tripwire[paramiko]"
             )
         verifier = _get_test_verifier_or_raise()
         plugin = _get_or_create_plugin(verifier, _SshPlugin)
@@ -816,8 +816,8 @@ class _MongoProxy:
 
         if not _PYMONGO_AVAILABLE:
             raise ImportError(
-                "pytest-tripwire[mongo] is required to use tripwire.mongo. "
-                "Install it with: pip install pytest-tripwire[mongo]"
+                "pytest-tripwire[pymongo] is required to use tripwire.mongo. "
+                "Install it with: pip install pytest-tripwire[pymongo]"
             )
         verifier = _get_test_verifier_or_raise()
         plugin = _get_or_create_plugin(verifier, _MongoPlugin)

--- a/src/tripwire/__init__.py
+++ b/src/tripwire/__init__.py
@@ -450,8 +450,8 @@ class _HttpProxy:
             from tripwire.plugins.http import HttpPlugin as _HttpPlugin
         except ImportError:
             raise ImportError(
-                "python-tripwire[http] is required to use tripwire.http. "
-                "Install it with: pip install python-tripwire[http]"
+                "pytest-tripwire[http] is required to use tripwire.http. "
+                "Install it with: pip install pytest-tripwire[http]"
             ) from None
         verifier = _get_test_verifier_or_raise()
         plugin = _get_or_create_plugin(verifier, _HttpPlugin)
@@ -578,8 +578,8 @@ class _AsyncWebSocketProxy:
 
         if not _WEBSOCKETS_AVAILABLE:
             raise ImportError(
-                "python-tripwire[websockets] is required to use tripwire.async_websocket. "
-                "Install it with: pip install python-tripwire[websockets]"
+                "pytest-tripwire[websockets] is required to use tripwire.async_websocket. "
+                "Install it with: pip install pytest-tripwire[websockets]"
             )
         verifier = _get_test_verifier_or_raise()
         plugin = _get_or_create_plugin(verifier, _AsyncWebSocketPlugin)
@@ -606,8 +606,8 @@ class _SyncWebSocketProxy:
 
         if not _WEBSOCKET_CLIENT_AVAILABLE:
             raise ImportError(
-                "python-tripwire[websocket-client] is required to use tripwire.sync_websocket. "
-                "Install it with: pip install python-tripwire[websocket-client]"
+                "pytest-tripwire[websocket-client] is required to use tripwire.sync_websocket. "
+                "Install it with: pip install pytest-tripwire[websocket-client]"
             )
         verifier = _get_test_verifier_or_raise()
         plugin = _get_or_create_plugin(verifier, _SyncWebSocketPlugin)
@@ -634,8 +634,8 @@ class _RedisProxy:
 
         if not _REDIS_AVAILABLE:
             raise ImportError(
-                "python-tripwire[redis] is required to use tripwire.redis. "
-                "Install it with: pip install python-tripwire[redis]"
+                "pytest-tripwire[redis] is required to use tripwire.redis. "
+                "Install it with: pip install pytest-tripwire[redis]"
             )
         verifier = _get_test_verifier_or_raise()
         plugin = _get_or_create_plugin(verifier, _RedisPlugin)
@@ -704,8 +704,8 @@ class _PikaProxy:
 
         if not _PIKA_AVAILABLE:
             raise ImportError(
-                "python-tripwire[pika] is required to use tripwire.pika. "
-                "Install it with: pip install python-tripwire[pika]"
+                "pytest-tripwire[pika] is required to use tripwire.pika. "
+                "Install it with: pip install pytest-tripwire[pika]"
             )
         verifier = _get_test_verifier_or_raise()
         plugin = _get_or_create_plugin(verifier, _PikaPlugin)
@@ -732,8 +732,8 @@ class _SshProxy:
 
         if not _PARAMIKO_AVAILABLE:
             raise ImportError(
-                "python-tripwire[ssh] is required to use tripwire.ssh. "
-                "Install it with: pip install python-tripwire[ssh]"
+                "pytest-tripwire[ssh] is required to use tripwire.ssh. "
+                "Install it with: pip install pytest-tripwire[ssh]"
             )
         verifier = _get_test_verifier_or_raise()
         plugin = _get_or_create_plugin(verifier, _SshPlugin)
@@ -760,8 +760,8 @@ class _GrpcProxy:
 
         if not _GRPC_AVAILABLE:
             raise ImportError(
-                "python-tripwire[grpc] is required to use tripwire.grpc. "
-                "Install it with: pip install python-tripwire[grpc]"
+                "pytest-tripwire[grpc] is required to use tripwire.grpc. "
+                "Install it with: pip install pytest-tripwire[grpc]"
             )
         verifier = _get_test_verifier_or_raise()
         plugin = _get_or_create_plugin(verifier, _GrpcPlugin)
@@ -788,8 +788,8 @@ class _McpProxy:
 
         if not _MCP_AVAILABLE:
             raise ImportError(
-                "python-tripwire[mcp] is required to use tripwire.mcp. "
-                "Install it with: pip install python-tripwire[mcp]"
+                "pytest-tripwire[mcp] is required to use tripwire.mcp. "
+                "Install it with: pip install pytest-tripwire[mcp]"
             )
         verifier = _get_test_verifier_or_raise()
         plugin = _get_or_create_plugin(verifier, _McpPlugin)
@@ -816,8 +816,8 @@ class _MongoProxy:
 
         if not _PYMONGO_AVAILABLE:
             raise ImportError(
-                "python-tripwire[mongo] is required to use tripwire.mongo. "
-                "Install it with: pip install python-tripwire[mongo]"
+                "pytest-tripwire[mongo] is required to use tripwire.mongo. "
+                "Install it with: pip install pytest-tripwire[mongo]"
             )
         verifier = _get_test_verifier_or_raise()
         plugin = _get_or_create_plugin(verifier, _MongoPlugin)
@@ -865,8 +865,8 @@ class _MemcacheProxy:
 
         if not _PYMEMCACHE_AVAILABLE:
             raise ImportError(
-                "python-tripwire[pymemcache] is required to use tripwire.memcache. "
-                "Install it with: pip install python-tripwire[pymemcache]"
+                "pytest-tripwire[pymemcache] is required to use tripwire.memcache. "
+                "Install it with: pip install pytest-tripwire[pymemcache]"
             )
         verifier = _get_test_verifier_or_raise()
         plugin = _get_or_create_plugin(verifier, _MemcachePlugin)
@@ -893,8 +893,8 @@ class _CeleryProxy:
 
         if not _CELERY_AVAILABLE:
             raise ImportError(
-                "python-tripwire[celery] is required to use tripwire.celery. "
-                "Install it with: pip install python-tripwire[celery]"
+                "pytest-tripwire[celery] is required to use tripwire.celery. "
+                "Install it with: pip install pytest-tripwire[celery]"
             )
         verifier = _get_test_verifier_or_raise()
         plugin = _get_or_create_plugin(verifier, _CeleryPlugin)
@@ -941,8 +941,8 @@ class _Psycopg2Proxy:
 
         if not _PSYCOPG2_AVAILABLE:
             raise ImportError(
-                "python-tripwire[psycopg2] is required to use tripwire.psycopg2. "
-                "Install it with: pip install python-tripwire[psycopg2]"
+                "pytest-tripwire[psycopg2] is required to use tripwire.psycopg2. "
+                "Install it with: pip install pytest-tripwire[psycopg2]"
             )
         verifier = _get_test_verifier_or_raise()
         plugin = _get_or_create_plugin(verifier, _Psycopg2Plugin)
@@ -969,8 +969,8 @@ class _AsyncpgProxy:
 
         if not _ASYNCPG_AVAILABLE:
             raise ImportError(
-                "python-tripwire[asyncpg] is required to use tripwire.asyncpg. "
-                "Install it with: pip install python-tripwire[asyncpg]"
+                "pytest-tripwire[asyncpg] is required to use tripwire.asyncpg. "
+                "Install it with: pip install pytest-tripwire[asyncpg]"
             )
         verifier = _get_test_verifier_or_raise()
         plugin = _get_or_create_plugin(verifier, _AsyncpgPlugin)
@@ -997,8 +997,8 @@ class _Boto3Proxy:
 
         if not _BOTO3_AVAILABLE:
             raise ImportError(
-                "python-tripwire[boto3] is required to use tripwire.boto3. "
-                "Install it with: pip install python-tripwire[boto3]"
+                "pytest-tripwire[boto3] is required to use tripwire.boto3. "
+                "Install it with: pip install pytest-tripwire[boto3]"
             )
         verifier = _get_test_verifier_or_raise()
         plugin = _get_or_create_plugin(verifier, _Boto3Plugin)
@@ -1025,8 +1025,8 @@ class _ElasticsearchProxy:
 
         if not _ELASTICSEARCH_AVAILABLE:
             raise ImportError(
-                "python-tripwire[elasticsearch] is required to use tripwire.elasticsearch. "
-                "Install it with: pip install python-tripwire[elasticsearch]"
+                "pytest-tripwire[elasticsearch] is required to use tripwire.elasticsearch. "
+                "Install it with: pip install pytest-tripwire[elasticsearch]"
             )
         verifier = _get_test_verifier_or_raise()
         plugin = _get_or_create_plugin(verifier, _ElasticsearchPlugin)
@@ -1053,8 +1053,8 @@ class _JwtProxy:
 
         if not _JWT_AVAILABLE:
             raise ImportError(
-                "python-tripwire[jwt] is required to use tripwire.jwt. "
-                "Install it with: pip install python-tripwire[jwt]"
+                "pytest-tripwire[jwt] is required to use tripwire.jwt. "
+                "Install it with: pip install pytest-tripwire[jwt]"
             )
         verifier = _get_test_verifier_or_raise()
         plugin = _get_or_create_plugin(verifier, _JwtPlugin)
@@ -1081,8 +1081,8 @@ class _CryptoProxy:
 
         if not _CRYPTOGRAPHY_AVAILABLE:
             raise ImportError(
-                "python-tripwire[crypto] is required to use tripwire.crypto. "
-                "Install it with: pip install python-tripwire[crypto]"
+                "pytest-tripwire[crypto] is required to use tripwire.crypto. "
+                "Install it with: pip install pytest-tripwire[crypto]"
             )
         verifier = _get_test_verifier_or_raise()
         plugin = _get_or_create_plugin(verifier, _CryptoPlugin)

--- a/src/tripwire/_registry.py
+++ b/src/tripwire/_registry.py
@@ -19,6 +19,12 @@ class PluginEntry:
     class_name: str  # e.g., "HttpPlugin"
     availability_check: str  # module path or flag path to check availability
     default_enabled: bool = True  # False for opt-in plugins (e.g., file I/O, ctypes/cffi)
+    extra_name: str | None = None  # PyPI extra; only set when it differs from `name`
+
+    @property
+    def install_hint_extra(self) -> str:
+        """The extra name to embed in `pip install pytest-tripwire[...]` hints."""
+        return self.extra_name or self.name
 
 
 def _check_dep_available(module_name: str) -> bool:
@@ -76,12 +82,14 @@ PLUGIN_REGISTRY: tuple[PluginEntry, ...] = (
         "tripwire.plugins.websocket_plugin",
         "AsyncWebSocketPlugin",
         "websockets",
+        extra_name="websockets",
     ),
     PluginEntry(
         "sync_websocket",
         "tripwire.plugins.websocket_plugin",
         "SyncWebSocketPlugin",
         "flag:tripwire.plugins.websocket_plugin:_WEBSOCKET_CLIENT_AVAILABLE",
+        extra_name="websocket-client",
     ),
     PluginEntry("redis", "tripwire.plugins.redis_plugin", "RedisPlugin", "redis"),
     PluginEntry("psycopg2", "tripwire.plugins.psycopg2_plugin", "Psycopg2Plugin", "psycopg2"),
@@ -94,7 +102,13 @@ PLUGIN_REGISTRY: tuple[PluginEntry, ...] = (
         "always",
     ),
     PluginEntry("dns", "tripwire.plugins.dns_plugin", "DnsPlugin", "always"),
-    PluginEntry("memcache", "tripwire.plugins.memcache_plugin", "MemcachePlugin", "pymemcache"),
+    PluginEntry(
+        "memcache",
+        "tripwire.plugins.memcache_plugin",
+        "MemcachePlugin",
+        "pymemcache",
+        extra_name="pymemcache",
+    ),
     PluginEntry("celery", "tripwire.plugins.celery_plugin", "CeleryPlugin", "celery"),
     PluginEntry("boto3", "tripwire.plugins.boto3_plugin", "Boto3Plugin", "boto3"),
     PluginEntry(
@@ -105,13 +119,25 @@ PLUGIN_REGISTRY: tuple[PluginEntry, ...] = (
     ),
     PluginEntry("jwt", "tripwire.plugins.jwt_plugin", "JwtPlugin", "jwt"),
     PluginEntry("crypto", "tripwire.plugins.crypto_plugin", "CryptoPlugin", "cryptography"),
-    PluginEntry("mongo", "tripwire.plugins.mongo_plugin", "MongoPlugin", "pymongo"),
+    PluginEntry(
+        "mongo",
+        "tripwire.plugins.mongo_plugin",
+        "MongoPlugin",
+        "pymongo",
+        extra_name="pymongo",
+    ),
     PluginEntry(
         "file_io", "tripwire.plugins.file_io_plugin", "FileIoPlugin",
         "always", default_enabled=False,
     ),
     PluginEntry("pika", "tripwire.plugins.pika_plugin", "PikaPlugin", "pika"),
-    PluginEntry("ssh", "tripwire.plugins.ssh_plugin", "SshPlugin", "paramiko"),
+    PluginEntry(
+        "ssh",
+        "tripwire.plugins.ssh_plugin",
+        "SshPlugin",
+        "paramiko",
+        extra_name="paramiko",
+    ),
     PluginEntry("grpc", "tripwire.plugins.grpc_plugin", "GrpcPlugin", "grpc"),
     PluginEntry("mcp", "tripwire.plugins.mcp_plugin", "McpPlugin", "mcp"),
     PluginEntry(
@@ -395,7 +421,7 @@ def resolve_enabled_plugins(
                     raise TripwireConfigError(
                         f"Plugin '{e.name}' is in enabled_plugins but its "
                         f"dependency '{e.availability_check}' is not installed. "
-                        f"Install with: pip install pytest-tripwire[{e.name}]"
+                        f"Install with: pip install pytest-tripwire[{e.install_hint_extra}]"
                     )
                 result.append(e)
         return result

--- a/src/tripwire/_registry.py
+++ b/src/tripwire/_registry.py
@@ -395,7 +395,7 @@ def resolve_enabled_plugins(
                     raise TripwireConfigError(
                         f"Plugin '{e.name}' is in enabled_plugins but its "
                         f"dependency '{e.availability_check}' is not installed. "
-                        f"Install with: pip install python-tripwire[{e.name}]"
+                        f"Install with: pip install pytest-tripwire[{e.name}]"
                     )
                 result.append(e)
         return result

--- a/src/tripwire/_verifier.py
+++ b/src/tripwire/_verifier.py
@@ -116,7 +116,7 @@ class StrictVerifier:
                     raise TripwireConfigError(
                         f"Plugin '{entry.name}' is in enabled_plugins but failed "
                         f"to import. Ensure its dependencies are installed: "
-                        f"pip install pytest-tripwire[{entry.name}]"
+                        f"pip install pytest-tripwire[{entry.install_hint_extra}]"
                     )
                 # Silent skip only for default-enabled (not explicitly listed) plugins
 

--- a/src/tripwire/_verifier.py
+++ b/src/tripwire/_verifier.py
@@ -116,7 +116,7 @@ class StrictVerifier:
                     raise TripwireConfigError(
                         f"Plugin '{entry.name}' is in enabled_plugins but failed "
                         f"to import. Ensure its dependencies are installed: "
-                        f"pip install python-tripwire[{entry.name}]"
+                        f"pip install pytest-tripwire[{entry.name}]"
                     )
                 # Silent skip only for default-enabled (not explicitly listed) plugins
 

--- a/src/tripwire/plugins/boto3_plugin.py
+++ b/src/tripwire/plugins/boto3_plugin.py
@@ -257,8 +257,8 @@ class Boto3Plugin(BasePlugin):
         """
         if not _BOTO3_AVAILABLE:
             raise ImportError(
-                "Install python-tripwire[boto3] to use Boto3Plugin: "
-                "pip install python-tripwire[boto3]"
+                "Install pytest-tripwire[boto3] to use Boto3Plugin: "
+                "pip install pytest-tripwire[boto3]"
             )
         # Save current env values and inject dummy credentials
         for key, value in self._CREDENTIAL_ENV_VARS.items():

--- a/src/tripwire/plugins/celery_plugin.py
+++ b/src/tripwire/plugins/celery_plugin.py
@@ -273,8 +273,8 @@ class CeleryPlugin(BasePlugin):
         """Install Celery Task.delay and Task.apply_async patches."""
         if not _CELERY_AVAILABLE:
             raise ImportError(
-                "Install python-tripwire[celery] to use CeleryPlugin: "
-                "pip install python-tripwire[celery]"
+                "Install pytest-tripwire[celery] to use CeleryPlugin: "
+                "pip install pytest-tripwire[celery]"
             )
         from celery.app.task import Task
 

--- a/src/tripwire/plugins/crypto_plugin.py
+++ b/src/tripwire/plugins/crypto_plugin.py
@@ -283,8 +283,8 @@ class CryptoPlugin(BasePlugin):
         """Install cryptography Fernet and RSA patches."""
         if not _CRYPTOGRAPHY_AVAILABLE:
             raise ImportError(
-                "Install python-tripwire[crypto] to use CryptoPlugin: "
-                "pip install python-tripwire[crypto]"
+                "Install pytest-tripwire[crypto] to use CryptoPlugin: "
+                "pip install pytest-tripwire[crypto]"
             )
         CryptoPlugin._original_encrypt = _Fernet.encrypt
         CryptoPlugin._original_decrypt = _Fernet.decrypt

--- a/src/tripwire/plugins/elasticsearch_plugin.py
+++ b/src/tripwire/plugins/elasticsearch_plugin.py
@@ -222,8 +222,8 @@ class ElasticsearchPlugin(BasePlugin):
         """Install Elasticsearch method patches."""
         if not _ELASTICSEARCH_AVAILABLE:
             raise ImportError(
-                "Install python-tripwire[elasticsearch] to use ElasticsearchPlugin: "
-                "pip install python-tripwire[elasticsearch]"
+                "Install pytest-tripwire[elasticsearch] to use ElasticsearchPlugin: "
+                "pip install pytest-tripwire[elasticsearch]"
             )
         es_cls = es_lib.Elasticsearch
 

--- a/src/tripwire/plugins/grpc_plugin.py
+++ b/src/tripwire/plugins/grpc_plugin.py
@@ -396,7 +396,7 @@ class GrpcPlugin(BasePlugin):
         """Install gRPC channel patches."""
         if not _GRPC_AVAILABLE:
             raise ImportError(
-                "Install python-tripwire[grpc] to use GrpcPlugin: pip install python-tripwire[grpc]"
+                "Install pytest-tripwire[grpc] to use GrpcPlugin: pip install pytest-tripwire[grpc]"
             )
         GrpcPlugin._original_insecure_channel = grpc_lib.insecure_channel
         GrpcPlugin._original_secure_channel = grpc_lib.secure_channel

--- a/src/tripwire/plugins/http.py
+++ b/src/tripwire/plugins/http.py
@@ -17,8 +17,8 @@ try:
     import requests.adapters
 except ImportError as exc:  # pragma: no cover
     raise ImportError(
-        "python-tripwire[http] extra is required to use HttpPlugin. "
-        "Install with: pip install python-tripwire[http]"
+        "pytest-tripwire[http] extra is required to use HttpPlugin. "
+        "Install with: pip install pytest-tripwire[http]"
     ) from exc
 
 try:
@@ -285,7 +285,7 @@ def _identify_patcher(method: object) -> str:
 
 
 class HttpPlugin(BasePlugin):
-    """HTTP interception plugin. Requires python-tripwire[http] extra.
+    """HTTP interception plugin. Requires pytest-tripwire[http] extra.
 
     Patches httpx sync/async transports, requests HTTPAdapter, urllib openers,
     and aiohttp ClientSession (if installed) at the class level. Uses reference

--- a/src/tripwire/plugins/jwt_plugin.py
+++ b/src/tripwire/plugins/jwt_plugin.py
@@ -230,7 +230,7 @@ class JwtPlugin(BasePlugin):
         """Install jwt.encode and jwt.decode patches."""
         if not _JWT_AVAILABLE:
             raise ImportError(
-                "Install python-tripwire[jwt] to use JwtPlugin: pip install python-tripwire[jwt]"
+                "Install pytest-tripwire[jwt] to use JwtPlugin: pip install pytest-tripwire[jwt]"
             )
         JwtPlugin._original_encode = jwt_lib.encode
         JwtPlugin._original_decode = jwt_lib.decode

--- a/src/tripwire/plugins/mcp_plugin.py
+++ b/src/tripwire/plugins/mcp_plugin.py
@@ -513,7 +513,7 @@ class McpPlugin(BasePlugin):
         """Install MCP client/server patches."""
         if not _MCP_AVAILABLE:
             raise ImportError(
-                "Install python-tripwire[mcp] to use McpPlugin: pip install python-tripwire[mcp]"
+                "Install pytest-tripwire[mcp] to use McpPlugin: pip install pytest-tripwire[mcp]"
             )
         McpPlugin._original_call_tool = _ClientSession.call_tool
         McpPlugin._original_read_resource = _ClientSession.read_resource

--- a/src/tripwire/plugins/memcache_plugin.py
+++ b/src/tripwire/plugins/memcache_plugin.py
@@ -231,8 +231,8 @@ class MemcachePlugin(BasePlugin):
         """Install pymemcache Client method patches."""
         if not _PYMEMCACHE_AVAILABLE:
             raise ImportError(
-                "Install python-tripwire[pymemcache] to use MemcachePlugin: "
-                "pip install python-tripwire[pymemcache]"
+                "Install pytest-tripwire[pymemcache] to use MemcachePlugin: "
+                "pip install pytest-tripwire[pymemcache]"
             )
         from pymemcache.client.base import Client
 

--- a/src/tripwire/plugins/mongo_plugin.py
+++ b/src/tripwire/plugins/mongo_plugin.py
@@ -307,8 +307,8 @@ class MongoPlugin(BasePlugin):
         """Install pymongo Collection method patches."""
         if not _PYMONGO_AVAILABLE:
             raise ImportError(
-                "Install pytest-tripwire[mongo] to use MongoPlugin: "
-                "pip install pytest-tripwire[mongo]"
+                "Install pytest-tripwire[pymongo] to use MongoPlugin: "
+                "pip install pytest-tripwire[pymongo]"
             )
 
         # Patch MongoClient.__init__ to capture connection metadata

--- a/src/tripwire/plugins/mongo_plugin.py
+++ b/src/tripwire/plugins/mongo_plugin.py
@@ -307,8 +307,8 @@ class MongoPlugin(BasePlugin):
         """Install pymongo Collection method patches."""
         if not _PYMONGO_AVAILABLE:
             raise ImportError(
-                "Install python-tripwire[mongo] to use MongoPlugin: "
-                "pip install python-tripwire[mongo]"
+                "Install pytest-tripwire[mongo] to use MongoPlugin: "
+                "pip install pytest-tripwire[mongo]"
             )
 
         # Patch MongoClient.__init__ to capture connection metadata

--- a/src/tripwire/plugins/redis_plugin.py
+++ b/src/tripwire/plugins/redis_plugin.py
@@ -200,8 +200,8 @@ class RedisPlugin(BasePlugin):
         """Install Redis.execute_command patch."""
         if not _REDIS_AVAILABLE:
             raise ImportError(
-                "Install python-tripwire[redis] to use RedisPlugin: "
-                "pip install python-tripwire[redis]"
+                "Install pytest-tripwire[redis] to use RedisPlugin: "
+                "pip install pytest-tripwire[redis]"
             )
         # Patch __init__ to capture connection metadata
         if RedisPlugin._original_init is None:

--- a/src/tripwire/plugins/websocket_plugin.py
+++ b/src/tripwire/plugins/websocket_plugin.py
@@ -228,8 +228,8 @@ class AsyncWebSocketPlugin(StateMachinePlugin):
     def install_patches(self) -> None:
         if not _WEBSOCKETS_AVAILABLE:
             raise ImportError(
-                "Install python-tripwire[websockets] to use AsyncWebSocketPlugin: "
-                "pip install python-tripwire[websockets]"
+                "Install pytest-tripwire[websockets] to use AsyncWebSocketPlugin: "
+                "pip install pytest-tripwire[websockets]"
             )
         import websockets as _ws
 
@@ -479,8 +479,8 @@ class SyncWebSocketPlugin(StateMachinePlugin):
     def install_patches(self) -> None:
         if not _WEBSOCKET_CLIENT_AVAILABLE:
             raise ImportError(
-                "Install python-tripwire[websocket-client] to use SyncWebSocketPlugin: "
-                "pip install python-tripwire[websocket-client]"
+                "Install pytest-tripwire[websocket-client] to use SyncWebSocketPlugin: "
+                "pip install pytest-tripwire[websocket-client]"
             )
         import websocket as _wsc
 

--- a/tests/unit/test_boto3_plugin.py
+++ b/tests/unit/test_boto3_plugin.py
@@ -73,7 +73,7 @@ def test_activate_raises_when_boto3_unavailable(monkeypatch: pytest.MonkeyPatch)
     with pytest.raises(ImportError) as exc_info:
         p.activate()
     assert str(exc_info.value) == (
-        "Install python-tripwire[boto3] to use Boto3Plugin: pip install python-tripwire[boto3]"
+        "Install pytest-tripwire[boto3] to use Boto3Plugin: pip install pytest-tripwire[boto3]"
     )
 
 

--- a/tests/unit/test_celery_plugin.py
+++ b/tests/unit/test_celery_plugin.py
@@ -81,7 +81,7 @@ def test_activate_raises_when_celery_unavailable(monkeypatch: pytest.MonkeyPatch
     with pytest.raises(ImportError) as exc_info:
         p.activate()
     assert str(exc_info.value) == (
-        "Install python-tripwire[celery] to use CeleryPlugin: pip install python-tripwire[celery]"
+        "Install pytest-tripwire[celery] to use CeleryPlugin: pip install pytest-tripwire[celery]"
     )
 
 

--- a/tests/unit/test_crypto_plugin.py
+++ b/tests/unit/test_crypto_plugin.py
@@ -64,7 +64,7 @@ def test_activate_raises_when_cryptography_unavailable(monkeypatch: pytest.Monke
     with pytest.raises(ImportError) as exc_info:
         p.activate()
     assert str(exc_info.value) == (
-        "Install python-tripwire[crypto] to use CryptoPlugin: pip install python-tripwire[crypto]"
+        "Install pytest-tripwire[crypto] to use CryptoPlugin: pip install pytest-tripwire[crypto]"
     )
 
 

--- a/tests/unit/test_elasticsearch_plugin.py
+++ b/tests/unit/test_elasticsearch_plugin.py
@@ -64,8 +64,8 @@ def test_activate_raises_when_elasticsearch_unavailable(monkeypatch: pytest.Monk
     with pytest.raises(ImportError) as exc_info:
         p.activate()
     assert str(exc_info.value) == (
-        "Install python-tripwire[elasticsearch] to use ElasticsearchPlugin: "
-        "pip install python-tripwire[elasticsearch]"
+        "Install pytest-tripwire[elasticsearch] to use ElasticsearchPlugin: "
+        "pip install pytest-tripwire[elasticsearch]"
     )
 
 

--- a/tests/unit/test_explicit_enable_error.py
+++ b/tests/unit/test_explicit_enable_error.py
@@ -33,7 +33,7 @@ class TestExplicitEnableError:
         entry = _fake_entry("fakeplugin", "nonexistent_module_xyz")
         with patch("tripwire._registry.PLUGIN_REGISTRY", (entry,)):
             with patch("tripwire._registry.VALID_PLUGIN_NAMES", frozenset({"fakeplugin"})):
-                with pytest.raises(TripwireConfigError, match=r"pip install python-tripwire\[fakeplugin\]"):
+                with pytest.raises(TripwireConfigError, match=r"pip install pytest-tripwire\[fakeplugin\]"):
                     resolve_enabled_plugins({"enabled_plugins": ["fakeplugin"]})
 
     def test_default_enable_missing_dep_silent_skip(self) -> None:

--- a/tests/unit/test_grpc_plugin.py
+++ b/tests/unit/test_grpc_plugin.py
@@ -84,7 +84,7 @@ def test_activate_raises_when_grpc_unavailable(monkeypatch: pytest.MonkeyPatch) 
     with pytest.raises(ImportError) as exc_info:
         p.activate()
     assert str(exc_info.value) == (
-        "Install python-tripwire[grpc] to use GrpcPlugin: pip install python-tripwire[grpc]"
+        "Install pytest-tripwire[grpc] to use GrpcPlugin: pip install pytest-tripwire[grpc]"
     )
 
 

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -385,7 +385,7 @@ def test_async_websocket_raises_import_error_when_websockets_unavailable(
       CLAIM: Accessing any attribute on async_websocket raises ImportError with
              instructions when tripwire.plugins.websocket_plugin._WEBSOCKETS_AVAILABLE is False.
       PATH:  _AsyncWebSocketProxy.__getattr__ -> checks _WEBSOCKETS_AVAILABLE -> raises ImportError.
-      CHECK: Raises ImportError with message containing "python-tripwire[websockets]" and "pip install".
+      CHECK: Raises ImportError with message containing "pytest-tripwire[websockets]" and "pip install".
       MUTATION: If __getattr__ does not check _WEBSOCKETS_AVAILABLE, the error is deferred to
                 activate() time (inside a test context), and the message will be different or absent.
       ESCAPE: A proxy that checks availability but emits a wrong message would still pass the
@@ -399,7 +399,7 @@ def test_async_websocket_raises_import_error_when_websockets_unavailable(
     with pytest.raises(ImportError) as exc_info:
         _ = tripwire.async_websocket.new_session  # noqa: B018
 
-    assert "python-tripwire[websockets]" in str(exc_info.value)
+    assert "pytest-tripwire[websockets]" in str(exc_info.value)
     assert "pip install" in str(exc_info.value)
 
 
@@ -499,7 +499,7 @@ def test_sync_websocket_raises_import_error_when_websocket_client_unavailable(
       CLAIM: Accessing any attribute on sync_websocket raises ImportError with
              instructions when tripwire.plugins.websocket_plugin._WEBSOCKET_CLIENT_AVAILABLE is False.
       PATH:  _SyncWebSocketProxy.__getattr__ -> checks _WEBSOCKET_CLIENT_AVAILABLE -> raises ImportError.
-      CHECK: Raises ImportError with message containing "python-tripwire[websocket-client]" and "pip install".
+      CHECK: Raises ImportError with message containing "pytest-tripwire[websocket-client]" and "pip install".
       MUTATION: If __getattr__ does not check _WEBSOCKET_CLIENT_AVAILABLE, the error is deferred
                 to activate() time (inside a test context), and the message will be different or absent.
       ESCAPE: A proxy that checks availability but emits a wrong message would still pass the
@@ -513,7 +513,7 @@ def test_sync_websocket_raises_import_error_when_websocket_client_unavailable(
     with pytest.raises(ImportError) as exc_info:
         _ = tripwire.sync_websocket.new_session  # noqa: B018
 
-    assert "python-tripwire[websocket-client]" in str(exc_info.value)
+    assert "pytest-tripwire[websocket-client]" in str(exc_info.value)
     assert "pip install" in str(exc_info.value)
 
 

--- a/tests/unit/test_jwt_plugin.py
+++ b/tests/unit/test_jwt_plugin.py
@@ -64,7 +64,7 @@ def test_activate_raises_when_jwt_unavailable(monkeypatch: pytest.MonkeyPatch) -
     with pytest.raises(ImportError) as exc_info:
         p.activate()
     assert str(exc_info.value) == (
-        "Install python-tripwire[jwt] to use JwtPlugin: pip install python-tripwire[jwt]"
+        "Install pytest-tripwire[jwt] to use JwtPlugin: pip install pytest-tripwire[jwt]"
     )
 
 

--- a/tests/unit/test_mcp_plugin.py
+++ b/tests/unit/test_mcp_plugin.py
@@ -71,7 +71,7 @@ def test_activate_raises_when_mcp_unavailable(monkeypatch: pytest.MonkeyPatch) -
     with pytest.raises(ImportError) as exc_info:
         p.activate()
     assert str(exc_info.value) == (
-        "Install python-tripwire[mcp] to use McpPlugin: pip install python-tripwire[mcp]"
+        "Install pytest-tripwire[mcp] to use McpPlugin: pip install pytest-tripwire[mcp]"
     )
 
 

--- a/tests/unit/test_memcache_plugin.py
+++ b/tests/unit/test_memcache_plugin.py
@@ -67,7 +67,7 @@ def test_activate_raises_when_pymemcache_unavailable(monkeypatch: pytest.MonkeyP
     with pytest.raises(ImportError) as exc_info:
         p.activate()
     assert str(exc_info.value) == (
-        "Install python-tripwire[pymemcache] to use MemcachePlugin: pip install python-tripwire[pymemcache]"
+        "Install pytest-tripwire[pymemcache] to use MemcachePlugin: pip install pytest-tripwire[pymemcache]"
     )
 
 

--- a/tests/unit/test_mongo_plugin.py
+++ b/tests/unit/test_mongo_plugin.py
@@ -103,7 +103,7 @@ def test_activate_raises_when_pymongo_unavailable(monkeypatch: pytest.MonkeyPatc
     with pytest.raises(ImportError) as exc_info:
         p.activate()
     assert str(exc_info.value) == (
-        "Install pytest-tripwire[mongo] to use MongoPlugin: pip install pytest-tripwire[mongo]"
+        "Install pytest-tripwire[pymongo] to use MongoPlugin: pip install pytest-tripwire[pymongo]"
     )
 
 

--- a/tests/unit/test_mongo_plugin.py
+++ b/tests/unit/test_mongo_plugin.py
@@ -103,7 +103,7 @@ def test_activate_raises_when_pymongo_unavailable(monkeypatch: pytest.MonkeyPatc
     with pytest.raises(ImportError) as exc_info:
         p.activate()
     assert str(exc_info.value) == (
-        "Install python-tripwire[mongo] to use MongoPlugin: pip install python-tripwire[mongo]"
+        "Install pytest-tripwire[mongo] to use MongoPlugin: pip install pytest-tripwire[mongo]"
     )
 
 

--- a/tests/unit/test_pika_plugin.py
+++ b/tests/unit/test_pika_plugin.py
@@ -690,7 +690,7 @@ def test_pika_available_flag() -> None:
 # ESCAPE: test_pika_mock_proxy_raises_import_error_when_unavailable
 #   CLAIM: Accessing tripwire.pika raises ImportError when pika is not installed.
 #   PATH:  _PikaProxy.__getattr__ -> checks _PIKA_AVAILABLE -> raises ImportError.
-#   CHECK: ImportError raised with message containing "python-tripwire[pika]" and "pip install".
+#   CHECK: ImportError raised with message containing "pytest-tripwire[pika]" and "pip install".
 #   MUTATION: Not checking _PIKA_AVAILABLE would defer the error.
 #   ESCAPE: Wrong message would fail the string check.
 def test_pika_mock_proxy_raises_import_error_when_unavailable(
@@ -704,8 +704,8 @@ def test_pika_mock_proxy_raises_import_error_when_unavailable(
         _ = tripwire.pika.new_session  # noqa: B018
 
     assert str(exc_info.value) == (
-        "python-tripwire[pika] is required to use tripwire.pika. "
-        "Install it with: pip install python-tripwire[pika]"
+        "pytest-tripwire[pika] is required to use tripwire.pika. "
+        "Install it with: pip install pytest-tripwire[pika]"
     )
 
 

--- a/tests/unit/test_project_structure.py
+++ b/tests/unit/test_project_structure.py
@@ -69,7 +69,7 @@ def test_pyproject_toml_package_name_is_tripwire() -> None:
     pyproject = PROJECT_ROOT / "pyproject.toml"
     data = tomllib.loads(pyproject.read_bytes().decode())
     name = data.get("project", {}).get("name")
-    assert name == "python-tripwire", f"[project].name must be 'python-tripwire', got {name!r}"
+    assert name == "pytest-tripwire", f"[project].name must be 'pytest-tripwire', got {name!r}"
 
 
 def test_pyproject_toml_python_requirement() -> None:

--- a/tests/unit/test_redis_plugin.py
+++ b/tests/unit/test_redis_plugin.py
@@ -81,7 +81,7 @@ def test_activate_raises_when_redis_unavailable(monkeypatch: pytest.MonkeyPatch)
     with pytest.raises(ImportError) as exc_info:
         p.activate()
     assert str(exc_info.value) == (
-        "Install python-tripwire[redis] to use RedisPlugin: pip install python-tripwire[redis]"
+        "Install pytest-tripwire[redis] to use RedisPlugin: pip install pytest-tripwire[redis]"
     )
 
 

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -581,3 +581,70 @@ class TestLookupPluginClassByNameCache:
             assert cached is not None
             _cls, canonical = cached
             assert canonical == entry.name
+
+
+# ---------------------------------------------------------------------------
+# Install-hint extra mapping
+# ---------------------------------------------------------------------------
+
+
+def test_install_hint_extra_defaults_to_name() -> None:
+    """When extra_name is unset, install_hint_extra falls back to name."""
+    entry = PluginEntry("redis", "tripwire.plugins.redis_plugin", "RedisPlugin", "redis")
+    assert entry.install_hint_extra == "redis"
+
+
+def test_install_hint_extra_uses_override_when_set() -> None:
+    """When extra_name differs from name, install_hint_extra returns the override."""
+    entry = PluginEntry(
+        "mongo", "tripwire.plugins.mongo_plugin", "MongoPlugin", "pymongo",
+        extra_name="pymongo",
+    )
+    assert entry.install_hint_extra == "pymongo"
+
+
+def test_known_install_hint_overrides() -> None:
+    """The five plugins whose registry name differs from their PyPI extra
+    must declare extra_name so install hints stay copy-paste correct."""
+    by_name = {e.name: e for e in PLUGIN_REGISTRY}
+    expected = {
+        "mongo": "pymongo",
+        "ssh": "paramiko",
+        "memcache": "pymemcache",
+        "async_websocket": "websockets",
+        "sync_websocket": "websocket-client",
+    }
+    for plugin_name, extra in expected.items():
+        assert by_name[plugin_name].install_hint_extra == extra, (
+            f"plugin {plugin_name!r} should map to extra {extra!r}"
+        )
+
+
+def test_every_plugin_install_hint_resolves_to_real_extra() -> None:
+    """Every plugin's install_hint_extra must exist as a key in
+    pyproject.toml's [project.optional-dependencies], so the suggested
+    `pip install pytest-tripwire[<extra>]` command actually works.
+
+    Plugins with availability_check == "always" have no optional deps and
+    are skipped (the install hint code path never fires for them).
+    """
+    import sys
+    from pathlib import Path
+
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:
+        import tomli as tomllib
+
+    pyproject = Path(__file__).parents[2] / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text())
+    declared_extras = set(data["project"]["optional-dependencies"].keys())
+
+    for entry in PLUGIN_REGISTRY:
+        if entry.availability_check == "always":
+            continue
+        assert entry.install_hint_extra in declared_extras, (
+            f"plugin {entry.name!r} suggests `pip install "
+            f"pytest-tripwire[{entry.install_hint_extra}]` but no such extra "
+            f"exists in pyproject.toml. Available extras: {sorted(declared_extras)}"
+        )

--- a/tests/unit/test_smoke_rename.py
+++ b/tests/unit/test_smoke_rename.py
@@ -58,7 +58,7 @@ def test_import_tripwire_resolves() -> None:
         f"tripwire imported from {module_path}, expected under {expected_pkg_dir}"
     )
 
-    assert importlib.metadata.version("python-tripwire") == _expected_version()
+    assert importlib.metadata.version("pytest-tripwire") == _expected_version()
 
 
 # C1-T2
@@ -72,9 +72,9 @@ def test_pytest_entrypoint_registered() -> None:
     - A stale legacy entry-point (e.g., `bigfoot`) still being registered.
     - The entry-point existing in metadata but failing to load at pytest start.
     """
-    # Half 1: the pytest11 entry-point is registered against python-tripwire
+    # Half 1: the pytest11 entry-point is registered against pytest-tripwire
     # at the version declared in pyproject.toml.
-    dist = importlib.metadata.distribution("python-tripwire")
+    dist = importlib.metadata.distribution("pytest-tripwire")
     pytest11_eps = [ep for ep in dist.entry_points if ep.group == "pytest11"]
     assert pytest11_eps == [
         importlib.metadata.EntryPoint(

--- a/tests/unit/test_ssh_plugin.py
+++ b/tests/unit/test_ssh_plugin.py
@@ -936,8 +936,8 @@ def test_ssh_mock_proxy_raises_import_error_when_unavailable(
         _ = tripwire.ssh.new_session  # noqa: B018
 
     assert str(exc_info.value) == (
-        "pytest-tripwire[ssh] is required to use tripwire.ssh. "
-        "Install it with: pip install pytest-tripwire[ssh]"
+        "pytest-tripwire[paramiko] is required to use tripwire.ssh. "
+        "Install it with: pip install pytest-tripwire[paramiko]"
     )
 
 

--- a/tests/unit/test_ssh_plugin.py
+++ b/tests/unit/test_ssh_plugin.py
@@ -936,8 +936,8 @@ def test_ssh_mock_proxy_raises_import_error_when_unavailable(
         _ = tripwire.ssh.new_session  # noqa: B018
 
     assert str(exc_info.value) == (
-        "python-tripwire[ssh] is required to use tripwire.ssh. "
-        "Install it with: pip install python-tripwire[ssh]"
+        "pytest-tripwire[ssh] is required to use tripwire.ssh. "
+        "Install it with: pip install pytest-tripwire[ssh]"
     )
 
 

--- a/tests/unit/test_websocket_plugin.py
+++ b/tests/unit/test_websocket_plugin.py
@@ -346,7 +346,7 @@ def test_async_activate_raises_when_unavailable(monkeypatch: pytest.MonkeyPatch)
     with pytest.raises(ImportError) as exc_info:
         p.activate()
     assert str(exc_info.value) == (
-        "Install python-tripwire[websockets] to use AsyncWebSocketPlugin: pip install python-tripwire[websockets]"
+        "Install pytest-tripwire[websockets] to use AsyncWebSocketPlugin: pip install pytest-tripwire[websockets]"
     )
 
 
@@ -630,8 +630,8 @@ def test_sync_activate_raises_when_unavailable(monkeypatch: pytest.MonkeyPatch) 
     with pytest.raises(ImportError) as exc_info:
         p.activate()
     assert str(exc_info.value) == (
-        "Install python-tripwire[websocket-client] to use SyncWebSocketPlugin: "
-        "pip install python-tripwire[websocket-client]"
+        "Install pytest-tripwire[websocket-client] to use SyncWebSocketPlugin: "
+        "pip install pytest-tripwire[websocket-client]"
     )
 
 


### PR DESCRIPTION
## Summary

- Renames the PyPI distribution from `python-tripwire` to `pytest-tripwire`
  to follow the standard pytest plugin convention (`pytest-<name>`).
- The Python import name (`tripwire`) and pytest plugin entry point are
  unchanged. Existing `import tripwire` code keeps working; users only
  change their `pip install`.
- A deprecation shim will be published under the old name on PyPI so
  existing `pip install python-tripwire` installs get redirected automatically.

Bumps version to `0.21.0`. Updates pyproject.toml, README, CHANGELOG, mkdocs
config, install hints in plugin error messages, and smoke/structure tests.
GitHub repo was renamed alongside.
