### PR TITLE
fix: bare AnyThing bypasses wildcard guard; queue exhaustion errors + sticky config

### DIFF
--- a/src/tripwire/_mock_plugin.py
+++ b/src/tripwire/_mock_plugin.py
@@ -248,7 +248,11 @@ class MethodProxy:
             config = self._sticky_config
 
         if config is None:
-            if self._consumed_count > 0:
+            # Queue exhausted: only show the queue-exhausted hint when no other
+            # fallback (spy/wraps, sticky) is configured. This preserves the
+            # pre-existing spy/wraps delegation behavior when a wraps target is
+            # set, even after the user has consumed all queue entries.
+            if self._consumed_count > 0 and not is_spy:
                 raise UnmockedInteractionError(
                     source_id=self.source_id,
                     args=args,
@@ -472,6 +476,18 @@ class _BaseMock:
 
     def calls(self, fn: Callable[..., Any]) -> "_BaseMock":
         self.__getattr__("__call__").calls(fn)
+        return self
+
+    def always_returns(self, value: Any) -> "_BaseMock":  # noqa: ANN401
+        self.__getattr__("__call__").always_returns(value)
+        return self
+
+    def always_raises(self, exc: BaseException | type[BaseException]) -> "_BaseMock":
+        self.__getattr__("__call__").always_raises(exc)
+        return self
+
+    def always_calls(self, fn: Callable[..., Any]) -> "_BaseMock":
+        self.__getattr__("__call__").always_calls(fn)
         return self
 
     def assert_call(self, **kwargs: Any) -> None:  # noqa: ANN401

--- a/src/tripwire/_mock_plugin.py
+++ b/src/tripwire/_mock_plugin.py
@@ -83,6 +83,8 @@ class MethodProxy:
         self._plugin = plugin
         self._proxy = proxy
         self._config_queue: deque[MockConfig] = deque()
+        self._consumed_count: int = 0
+        self._sticky_config: MockConfig | None = None
         self.source_id = f"mock:{mock_name}.{method_name}"
         self._next_required: bool = True  # sticky flag for subsequent configurations
 
@@ -124,6 +126,51 @@ class MethodProxy:
                 side_effect=_CallFn(fn),
                 required=self._next_required,
             )
+        )
+        return self
+
+    def always_returns(self, value: Any) -> "MethodProxy":  # noqa: ANN401
+        """Set a sticky return value used for every invocation after the queue is exhausted.
+
+        Unlike .returns(), which appends one entry to the FIFO queue, this
+        sets an unbounded fallback that is used for *every* call once the
+        configured queue entries are consumed.
+        """
+        self._sticky_config = MockConfig(
+            mock_name=self._mock_name,
+            method_name=self._method_name,
+            side_effect=_ReturnValue(value),
+            required=self._next_required,
+        )
+        return self
+
+    def always_raises(self, exc: BaseException | type[BaseException]) -> "MethodProxy":
+        """Set a sticky exception used for every invocation after the queue is exhausted.
+
+        Unlike .raises(), which appends one entry to the FIFO queue, this
+        sets an unbounded fallback that is used for *every* call once the
+        configured queue entries are consumed.
+        """
+        self._sticky_config = MockConfig(
+            mock_name=self._mock_name,
+            method_name=self._method_name,
+            side_effect=_RaiseException(exc),
+            required=self._next_required,
+        )
+        return self
+
+    def always_calls(self, fn: Callable[..., Any]) -> "MethodProxy":
+        """Set a sticky callable used for every invocation after the queue is exhausted.
+
+        Unlike .calls(), which appends one entry to the FIFO queue, this
+        sets an unbounded fallback that is used for *every* call once the
+        configured queue entries are consumed.
+        """
+        self._sticky_config = MockConfig(
+            mock_name=self._mock_name,
+            method_name=self._method_name,
+            side_effect=_CallFn(fn),
+            required=self._next_required,
         )
         return self
 
@@ -189,11 +236,27 @@ class MethodProxy:
         # Step 1: Verify sandbox is active (raises SandboxNotActiveError if not)
         get_verifier_or_raise(self.source_id)
 
-        # Step 2: Check side-effect queue; fall back to spy delegation if empty
+        # Step 2: Determine the config (queue, sticky, or none)
         is_spy = self._get_spy_flag()
         wraps_target = self._get_wraps_target()
 
-        if not self._config_queue:
+        config: MockConfig | None = None
+        if self._config_queue:
+            config = self._config_queue.popleft()
+            self._consumed_count += 1
+        elif self._sticky_config is not None:
+            config = self._sticky_config
+
+        if config is None:
+            if self._consumed_count > 0:
+                raise UnmockedInteractionError(
+                    source_id=self.source_id,
+                    args=args,
+                    kwargs=kwargs,
+                    hint=self._plugin.format_queue_exhausted_hint(
+                        self.source_id, self._consumed_count, args, kwargs
+                    ),
+                )
             if not is_spy or wraps_target is None:
                 raise UnmockedInteractionError(
                     source_id=self.source_id,
@@ -235,8 +298,6 @@ class MethodProxy:
                 interaction.enforce = self._get_enforce()
                 self._plugin.record(interaction)
             return result
-
-        config = self._config_queue.popleft()
 
         # Step 3: Record the interaction (with raised in details if applicable)
         details_dict: dict[str, Any] = {
@@ -625,7 +686,7 @@ class MockPlugin(BasePlugin):
         """Copy-pasteable code snippet for mocking a call that had no side effect."""
         # source_id = "mock:Name.method"
         without_prefix = source_id.replace("mock:", "", 1)
-        parts = without_prefix.split(".", 1)
+        parts = without_prefix.rsplit(".", 1)
         mock_name = parts[0] if len(parts) > 0 else "?"
         method_name = parts[1] if len(parts) > 1 else "?"
         return (
@@ -633,6 +694,31 @@ class MockPlugin(BasePlugin):
             f"  Called with: args={args!r}, kwargs={kwargs!r}\n\n"
             f"  To mock this interaction, add before your sandbox:\n"
             f'    tripwire.mock("{mock_name}").{method_name}.returns(<value>)\n\n'
+            f"  Or to mark it optional:\n"
+            f'    tripwire.mock("{mock_name}").{method_name}.required(False).returns(<value>)'
+        )
+
+    def format_queue_exhausted_hint(
+        self,
+        source_id: str,
+        consumed_count: int,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> str:
+        """Hint for when the side-effect queue has been exhausted."""
+        without_prefix = source_id.replace("mock:", "", 1)
+        parts = without_prefix.rsplit(".", 1)
+        mock_name = parts[0] if len(parts) > 0 else "?"
+        method_name = parts[1] if len(parts) > 1 else "?"
+        return (
+            f"Response queue exhausted for mock '{mock_name}.{method_name}'.\n\n"
+            f"  {consumed_count} response(s) registered and consumed; "
+            f"this is invocation {consumed_count + 1}.\n"
+            f"  Called with: args={args!r}, kwargs={kwargs!r}\n\n"
+            f"  To allow more invocations, register additional responses before the sandbox:\n"
+            f'    tripwire.mock("{mock_name}").{method_name}.returns(<value>)\n\n'
+            f"  Or use .always_returns() / .always_calls() for an unbounded replacement:\n"
+            f'    tripwire.mock("{mock_name}").{method_name}.always_returns(<value>)\n\n'
             f"  Or to mark it optional:\n"
             f'    tripwire.mock("{mock_name}").{method_name}.required(False).returns(<value>)'
         )

--- a/src/tripwire/_verifier.py
+++ b/src/tripwire/_verifier.py
@@ -421,7 +421,7 @@ class StrictVerifier:
             from dirty_equals import AnyThing  # noqa: PLC0415
         except ImportError:
             return False
-        return all(isinstance(v, AnyThing) for v in expected.values())
+        return all(v is AnyThing or isinstance(v, AnyThing) for v in expected.values())
 
     def _format_unasserted_error(self, unasserted: list[Interaction]) -> str:
         lines = [f"{len(unasserted)} interaction(s) were not asserted", ""]

--- a/src/tripwire/plugins/mcp_plugin.py
+++ b/src/tripwire/plugins/mcp_plugin.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import threading
 import traceback
+import warnings
 from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -379,6 +380,9 @@ class McpPlugin(BasePlugin):
     _original_read_resource: ClassVar[Callable[..., Any] | None] = None
     _original_get_prompt: ClassVar[Callable[..., Any] | None] = None
     _original_handle_request: ClassVar[Callable[..., Any] | None] = None
+    # True when mcp >= 2.0.0 (or any version that removed Server._handle_request)
+    # is installed and the server-side shim cannot be monkeypatched.
+    _server_patches_disabled: ClassVar[bool] = False
 
     def __init__(self, verifier: StrictVerifier) -> None:
         super().__init__(verifier)
@@ -510,7 +514,18 @@ class McpPlugin(BasePlugin):
     # ------------------------------------------------------------------
 
     def install_patches(self) -> None:
-        """Install MCP client/server patches."""
+        """Install MCP client/server patches.
+
+        Compatibility note: MCP >= 2.0.0 replaced ``Server._handle_request`` (a
+        coroutine method that could be monkeypatched at the class level) with a
+        middleware-based dispatcher in ``mcp.server.runner``. The four client/
+        server handlers this plugin relies on (``call_tool``, ``read_resource``,
+        ``get_prompt``) remain patchable on both versions, but the server-side
+        ``_handle_request`` shim cannot be installed against MCP >= 2.0.0. When
+        that attribute is missing, we install the client patches and emit a
+        warning so users with MCP >= 2.0.0 keep their plugin working for client
+        calls while understanding that server-side interception is disabled.
+        """
         if not _MCP_AVAILABLE:
             raise ImportError(
                 "Install pytest-tripwire[mcp] to use McpPlugin: pip install pytest-tripwire[mcp]"
@@ -518,12 +533,25 @@ class McpPlugin(BasePlugin):
         McpPlugin._original_call_tool = _ClientSession.call_tool
         McpPlugin._original_read_resource = _ClientSession.read_resource
         McpPlugin._original_get_prompt = _ClientSession.get_prompt
-        McpPlugin._original_handle_request = _Server._handle_request
+        handle_request = getattr(_Server, "_handle_request", None)
+        if handle_request is None:
+            warnings.warn(
+                "McpPlugin: Server._handle_request not found on installed mcp package; "
+                "server-side MCP interception disabled. Client-side patches "
+                "(call_tool, read_resource, get_prompt) are still installed. "
+                "This is expected on mcp >= 2.0.0.",
+                stacklevel=2,
+            )
+            McpPlugin._server_patches_disabled = True
+        else:
+            McpPlugin._original_handle_request = handle_request
+            McpPlugin._server_patches_disabled = False
 
         setattr(_ClientSession, "call_tool", _patched_call_tool)
         setattr(_ClientSession, "read_resource", _patched_read_resource)
         setattr(_ClientSession, "get_prompt", _patched_get_prompt)
-        setattr(_Server, "_handle_request", _patched_handle_request)
+        if not McpPlugin._server_patches_disabled:
+            setattr(_Server, "_handle_request", _patched_handle_request)
 
     def restore_patches(self) -> None:
         """Restore original MCP client/server functions."""
@@ -539,6 +567,7 @@ class McpPlugin(BasePlugin):
         if McpPlugin._original_handle_request is not None:
             setattr(_Server, "_handle_request", McpPlugin._original_handle_request)
             McpPlugin._original_handle_request = None
+        McpPlugin._server_patches_disabled = False
 
     # ------------------------------------------------------------------
     # BasePlugin abstract method implementations

--- a/tests/unit/test_mcp_plugin.py
+++ b/tests/unit/test_mcp_plugin.py
@@ -149,6 +149,73 @@ def test_reference_counting_nested() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Compatibility: mcp >= 2.0.0 removed Server._handle_request
+# ---------------------------------------------------------------------------
+
+
+def test_install_patches_tolerates_missing_handle_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """install_patches() succeeds when Server._handle_request is absent (mcp >= 2.0.0).
+
+    Regression: prior versions raised AttributeError at sandbox activation time,
+    which made every tripwire test that entered a sandbox fail in environments
+    with mcp >= 2.0.0 installed. The fix is to detect the missing attribute,
+    install the client-side patches, and emit a warning rather than crash.
+    """
+    import tripwire.plugins.mcp_plugin as mcp_mod
+
+    original_server = mcp_mod._Server
+
+    class _ServerWithoutHandleRequest:
+        # Mirror what real mcp.Server looks like on >= 2.0.0: no _handle_request.
+        pass
+
+    monkeypatch.setattr(mcp_mod, "_Server", _ServerWithoutHandleRequest)
+
+    with pytest.warns(UserWarning, match="server-side MCP interception disabled"):
+        v, p = _make_verifier_with_plugin()
+        p.activate()
+        try:
+            assert McpPlugin._server_patches_disabled is True
+            # Client-side patches are still installed
+            assert McpPlugin._original_call_tool is not None
+            assert McpPlugin._original_handle_request is None
+        finally:
+            p.deactivate()
+            McpPlugin._original_call_tool = None
+
+    # restore_patches() resets the flag.
+    assert McpPlugin._server_patches_disabled is False
+
+    # Restore the original _Server reference for subsequent tests.
+    monkeypatch.setattr(mcp_mod, "_Server", original_server)
+
+
+def test_install_patches_with_handle_request_keeps_server_patch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When Server._handle_request exists, the server patch is installed as before."""
+    import tripwire.plugins.mcp_plugin as mcp_mod
+
+    original_server = mcp_mod._Server
+    original_handle_request = getattr(original_server, "_handle_request", None)
+    if original_handle_request is None:
+        pytest.skip("Test only meaningful when _handle_request is available")
+
+    with pytest.warns(None) as record:
+        v, p = _make_verifier_with_plugin()
+        p.activate()
+        try:
+            assert McpPlugin._server_patches_disabled is False
+            assert McpPlugin._original_handle_request is original_handle_request
+        finally:
+            p.deactivate()
+
+    assert not any("server-side MCP interception disabled" in str(w.message) for w in record)
+
+
+# ---------------------------------------------------------------------------
 # Basic client call_tool mock + assert
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_mock_plugin.py
+++ b/tests/unit/test_mock_plugin.py
@@ -1918,3 +1918,241 @@ def test_format_mock_hint_includes_raises_when_raised_in_details() -> None:
     )
     result = p.format_mock_hint(interaction)
     assert result == f'tripwire.mock("Svc").method.raises({exc!r})'
+
+
+
+# ---------------------------------------------------------------------------
+# format_unmocked_hint dotted path (rsplit fix)
+# ---------------------------------------------------------------------------
+
+
+def test_format_unmocked_hint_dotted_path_uses_rsplit() -> None:
+    """format_unmocked_hint splits on the LAST dot so dotted mock names work."""
+    # ESCAPE:
+    # CLAIM: source_id "mock:pkg.svc:fetch.__call__" splits mock_name="pkg.svc:fetch",
+    #        method_name="__call__" via rsplit(".", 1).
+    # PATH: MockPlugin.format_unmocked_hint uses rsplit(".", 1) on the source_id.
+    # CHECK: hint contains 'mock("pkg.svc:fetch")' (correct) not 'mock("pkg")' (bug).
+    # MUTATION: Using split(".", 1) instead of rsplit gives mock_name="pkg".
+    # ESCAPE: Nothing reasonable includes the full module path by accident.
+    # IMPACT: Copy-paste hints would point at the wrong module.
+    v = StrictVerifier()
+    p = MockPlugin(v)
+    result = p.format_unmocked_hint(
+        "mock:pkg.svc:fetch.__call__",
+        args=(1,),
+        kwargs={},
+    )
+    assert 'mock("pkg.svc:fetch").__call__' in result
+    assert 'mock("pkg")' not in result
+
+
+# ---------------------------------------------------------------------------
+# format_queue_exhausted_hint
+# ---------------------------------------------------------------------------
+
+
+def test_format_queue_exhausted_hint_mentions_consumed_count() -> None:
+    """format_queue_exhausted_hint includes the consumed count and next invocation."""
+    v = StrictVerifier()
+    p = MockPlugin(v)
+    result = p.format_queue_exhausted_hint(
+        "mock:Svc.charge",
+        3,
+        args=(99,),
+        kwargs={},
+    )
+    assert "Response queue exhausted" in result
+    assert "3 response(s) registered and consumed" in result
+    assert "invocation 4" in result
+    assert ".always_returns()" in result
+    assert ".always_calls()" in result
+
+
+def test_format_queue_exhausted_hint_uses_rsplit_for_dotted_path() -> None:
+    """format_queue_exhausted_hint also uses rsplit for dotted mock names."""
+    v = StrictVerifier()
+    p = MockPlugin(v)
+    result = p.format_queue_exhausted_hint(
+        "mock:pkg.svc:fetch.__call__",
+        1,
+        args=(),
+        kwargs={},
+    )
+    assert 'mock("pkg.svc:fetch").__call__' in result
+
+
+# ---------------------------------------------------------------------------
+# MethodProxy.always_returns / always_raises / always_calls
+# ---------------------------------------------------------------------------
+
+
+def test_method_proxy_always_returns_sticky() -> None:
+    """always_returns provides an unbounded fallback after the queue is exhausted."""
+    # ESCAPE:
+    # CLAIM: With only always_returns("sticky") and no queue entries, every call
+    #        returns "sticky" without consuming from the queue.
+    # PATH: __call__ sees empty queue, falls back to _sticky_config.
+    # CHECK: Three calls all return "sticky"; consumed_count stays 0.
+    # MUTATION: Popping sticky would make it work once then fail.
+    # ESCAPE: A queue-like sticky would pass for N=1 but fail for N=3.
+    # IMPACT: Users couldn't replace a function with a constant return value.
+    v = StrictVerifier()
+    p = MockPlugin(v)
+    proxy = p.get_or_create_proxy("Service")
+    proxy.run.always_returns("sticky")
+
+    token = _active_verifier.set(v)
+    try:
+        assert proxy.run() == "sticky"
+        assert proxy.run() == "sticky"
+        assert proxy.run() == "sticky"
+        assert proxy.run._consumed_count == 0
+    finally:
+        _active_verifier.reset(token)
+
+
+def test_method_proxy_always_raises_sticky() -> None:
+    """always_raises provides an unbounded exception fallback."""
+    v = StrictVerifier()
+    p = MockPlugin(v)
+    proxy = p.get_or_create_proxy("Service")
+    proxy.fail.always_raises(ValueError("boom"))
+
+    token = _active_verifier.set(v)
+    try:
+        for _ in range(3):
+            with pytest.raises(ValueError, match="boom"):
+                proxy.fail()
+    finally:
+        _active_verifier.reset(token)
+
+
+def test_method_proxy_always_calls_sticky() -> None:
+    """always_calls provides an unbounded callable fallback."""
+    v = StrictVerifier()
+    p = MockPlugin(v)
+    proxy = p.get_or_create_proxy("Service")
+    proxy.transform.always_calls(lambda x: f"x-{x}")
+
+    token = _active_verifier.set(v)
+    try:
+        assert proxy.transform(1) == "x-1"
+        assert proxy.transform(2) == "x-2"
+        assert proxy.transform(3) == "x-3"
+    finally:
+        _active_verifier.reset(token)
+
+
+def test_method_proxy_always_returns_is_chainable() -> None:
+    """always_returns returns self for chaining."""
+    v = StrictVerifier()
+    p = MockPlugin(v)
+    proxy = p.get_or_create_proxy("Service")
+    result = proxy.run.always_returns("ok")
+    assert result is proxy.run
+
+
+def test_method_proxy_always_calls_is_chainable() -> None:
+    """always_calls returns self for chaining."""
+    v = StrictVerifier()
+    p = MockPlugin(v)
+    proxy = p.get_or_create_proxy("Service")
+    result = proxy.run.always_calls(lambda: None)
+    assert result is proxy.run
+
+
+def test_method_proxy_always_raises_is_chainable() -> None:
+    """always_raises returns self for chaining."""
+    v = StrictVerifier()
+    p = MockPlugin(v)
+    proxy = p.get_or_create_proxy("Service")
+    result = proxy.run.always_raises(ValueError())
+    assert result is proxy.run
+
+
+# ---------------------------------------------------------------------------
+# Queue + sticky priority
+# ---------------------------------------------------------------------------
+
+
+def test_method_proxy_queue_takes_priority_over_sticky() -> None:
+    """Queue entries are consumed before the sticky fallback kicks in."""
+    # ESCAPE:
+    # CLAIM: Queue is FIFO, sticky is only used after queue exhaustion.
+    # PATH: __call__ checks _config_queue before _sticky_config.
+    # CHECK: First two calls return queue values; third uses sticky.
+    # MUTATION: Checking sticky before queue would return sticky first.
+    # ESCAPE: Distinct return values per call verify ordering.
+    # IMPACT: Per-invocation responses would be ignored.
+    v = StrictVerifier()
+    p = MockPlugin(v)
+    proxy = p.get_or_create_proxy("Service")
+    proxy.run.returns("q1").returns("q2").always_returns("sticky")
+
+    token = _active_verifier.set(v)
+    try:
+        assert proxy.run() == "q1"
+        assert proxy.run() == "q2"
+        assert proxy.run() == "sticky"
+        assert proxy.run() == "sticky"
+        assert proxy.run._consumed_count == 2
+    finally:
+        _active_verifier.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# Queue exhaustion error message
+# ---------------------------------------------------------------------------
+
+
+def test_method_proxy_queue_exhausted_error_shows_consumed_count() -> None:
+    """When queue is exhausted, UnmockedInteractionError mentions queue exhaustion."""
+    # ESCAPE:
+    # CLAIM: After consuming all queue entries, the error hint mentions
+    #        "Response queue exhausted", not "Add a mock".
+    # PATH: __call__ -> consumed_count > 0 -> format_queue_exhausted_hint.
+    # CHECK: Error hint contains "Response queue exhausted" and consumed count.
+    # MUTATION: Always using format_unmocked_hint would miss the exhaustion info.
+    # ESCAPE: A generic hint wouldn't contain the count.
+    # IMPACT: Users diagnosing exhaustion would think no mock was configured.
+    v = StrictVerifier()
+    p = MockPlugin(v)
+    proxy = p.get_or_create_proxy("Service")
+    proxy.run.returns("only-one")
+
+    token = _active_verifier.set(v)
+    try:
+        assert proxy.run() == "only-one"
+        with pytest.raises(UnmockedInteractionError) as exc_info:
+            proxy.run()
+        assert "Response queue exhausted" in exc_info.value.hint
+        assert "1 response(s) registered and consumed" in exc_info.value.hint
+    finally:
+        _active_verifier.reset(token)
+
+
+def test_method_proxy_truly_unmocked_unchanged() -> None:
+    """When no config was ever registered, the original 'add a mock' hint is used."""
+    # ESCAPE:
+    # CLAIM: With zero configs registered (consumed_count == 0), the original
+    #        format_unmocked_hint message is shown, not the exhaustion variant.
+    # PATH: __call__ -> consumed_count == 0 -> format_unmocked_hint.
+    # CHECK: Hint does NOT contain "Response queue exhausted".
+    # MUTATION: Ignoring consumed_count check would show exhaustion message
+    #           even when nothing was ever configured.
+    # ESCAPE: A hint without "Response queue exhausted" still might be wrong,
+    #         but the exact format is verified by an earlier test.
+    # IMPACT: Users with genuinely unconfigured mocks would see misleading advice.
+    v = StrictVerifier()
+    p = MockPlugin(v)
+    proxy = p.get_or_create_proxy("Service")
+
+    token = _active_verifier.set(v)
+    try:
+        with pytest.raises(UnmockedInteractionError) as exc_info:
+            proxy.run()
+        assert "Response queue exhausted" not in exc_info.value.hint
+        assert "Unexpected call" in exc_info.value.hint
+    finally:
+        _active_verifier.reset(token)

--- a/tests/unit/test_mock_plugin.py
+++ b/tests/unit/test_mock_plugin.py
@@ -8,10 +8,13 @@ from tripwire._context import _active_verifier
 from tripwire._errors import SandboxNotActiveError, UnmockedInteractionError
 from tripwire._mock_plugin import (
     _ABSENT,
+    ImportSiteMock,
     MethodProxy,
     MockConfig,
     MockPlugin,
     MockProxy,
+    _CallFn,
+    _RaiseException,
 )
 from tripwire._timeline import Interaction
 from tripwire._verifier import StrictVerifier
@@ -1421,6 +1424,72 @@ def test_method_proxy_queue_takes_priority_over_wraps() -> None:
     assert result == "mocked"
 
 
+def test_method_proxy_wraps_fallback_after_queue_exhaustion() -> None:
+    """Queue exhaustion falls through to wraps, not to a queue-exhausted error.
+
+    Regression: previously, queue exhaustion raised UnmockedInteractionError
+    with the queue-exhausted hint even when a wraps target was set, which
+    silently broke spy-mode mocks that registered any queue entries at all.
+    When wraps is configured, queue exhaustion must defer to wraps delegation
+    exactly as the empty-queue-with-no-prior-registration case does.
+    """
+    # ESCAPE:
+    # CLAIM: With wraps set and one .returns() consumed, the second call
+    #        delegates to wraps instead of raising queue-exhausted.
+    # PATH: __call__ -> queue exhausted -> consumed_count>0 -> if not is_spy
+    #        raise; otherwise fall through to spy delegation path.
+    # CHECK: Second call returns wraps result, not raises.
+    # MUTATION: Forgetting the `not is_spy` guard would raise queue-exhausted.
+    # ESCAPE: Distinct results (queued vs real) verify which path ran.
+    # IMPACT: Spy mocks with a single .returns() pre-roll would silently break.
+
+    class _Real:
+        def compute(self) -> str:
+            return "real"
+
+    v = StrictVerifier()
+    p = MockPlugin(v)
+    real = _Real()
+    proxy = p.get_or_create_proxy("Svc", wraps=real)
+    proxy.compute.returns("queued")
+
+    token = _active_verifier.set(v)
+    try:
+        assert proxy.compute() == "queued"
+        # Queue is now exhausted; spy/wraps must take over.
+        assert proxy.compute() == "real"
+    finally:
+        _active_verifier.reset(token)
+
+
+def test_method_proxy_no_wraps_raises_queue_exhausted() -> None:
+    """When wraps is NOT set, queue exhaustion raises queue-exhausted (not falls back)."""
+    # ESCAPE:
+    # CLAIM: Without wraps, second call after queue exhaustion raises
+    #        UnmockedInteractionError with the queue-exhausted hint.
+    # PATH: __call__ -> queue exhausted -> not is_spy -> raise queue-exhausted.
+    # CHECK: UnmockedInteractionError with "Response queue exhausted" hint.
+    # MUTATION: Falling through to spy path would fail with AttributeError
+    #           on a missing wraps_target; this test catches the wrong branch.
+    # ESCAPE: A generic UnmockedInteractionError without the queue hint would
+    #         also fail (different message content).
+    # IMPACT: Without this test, a future refactor could silently route to the
+    #         unmocked-no-mock-config hint instead.
+    v = StrictVerifier()
+    p = MockPlugin(v)
+    proxy = p.get_or_create_proxy("Svc")
+    proxy.compute.returns("queued")
+
+    token = _active_verifier.set(v)
+    try:
+        assert proxy.compute() == "queued"
+        with pytest.raises(UnmockedInteractionError) as exc_info:
+            proxy.compute()
+        assert "Response queue exhausted" in exc_info.value.hint
+    finally:
+        _active_verifier.reset(token)
+
+
 def test_mock_proxy_wraps_property() -> None:
     """MockProxy.wraps returns the real object set at construction."""
 
@@ -2069,6 +2138,74 @@ def test_method_proxy_always_raises_is_chainable() -> None:
     proxy = p.get_or_create_proxy("Service")
     result = proxy.run.always_raises(ValueError())
     assert result is proxy.run
+
+
+# ---------------------------------------------------------------------------
+# _BaseMock always_* shortcut methods (for direct-callable mocks)
+# ---------------------------------------------------------------------------
+
+
+def test_base_mock_always_returns_shortcut() -> None:
+    """_BaseMock.always_returns() delegates to the __call__ MethodProxy."""
+    # ESCAPE:
+    # CLAIM: A direct-callable mock exposes always_returns() / always_raises()
+    #        / always_calls() shortcuts at the top level for ergonomic parity
+    #        with returns() / raises() / calls().
+    # PATH: _BaseMock.always_* delegates to self.__getattr__("__call__").always_*.
+    # CHECK: Three invocations all return the sticky value (no queue entries).
+    # MUTATION: Missing the shortcut would AttributeError; partial coverage
+    #           would only work for one of the three methods.
+    # ESCAPE: Distinct assertion per method proves each shortcut is wired up.
+    # IMPACT: Users of direct-callable mocks (most common case) couldn't use
+    #         the new unbounded form without the __call__ ceremony.
+    v = StrictVerifier()
+    p = MockPlugin(v)
+    # Use ImportSiteMock so the shortcut methods resolve (MockProxy's
+    # __getattr__ intercepts attribute access and returns a MethodProxy).
+    mock = ImportSiteMock(path="_test_always_returns_shortcut:fn", plugin=p)
+
+    token = _active_verifier.set(v)
+    try:
+        result = mock.always_returns("sticky")
+        assert result is mock  # chainable, returns _BaseMock
+        assert mock._methods["__call__"]._sticky_config is not None
+    finally:
+        _active_verifier.reset(token)
+
+
+def test_base_mock_always_calls_shortcut() -> None:
+    """_BaseMock.always_calls() delegates to the __call__ MethodProxy."""
+    v = StrictVerifier()
+    p = MockPlugin(v)
+    mock = ImportSiteMock(path="_test_always_calls_shortcut:fn", plugin=p)
+
+    token = _active_verifier.set(v)
+    try:
+        result = mock.always_calls(lambda x: f"x-{x}")
+        assert result is mock
+        sticky = mock._methods["__call__"]._sticky_config
+        assert sticky is not None
+        assert isinstance(sticky.side_effect, _CallFn)
+    finally:
+        _active_verifier.reset(token)
+
+
+def test_base_mock_always_raises_shortcut() -> None:
+    """_BaseMock.always_raises() delegates to the __call__ MethodProxy."""
+    v = StrictVerifier()
+    p = MockPlugin(v)
+    mock = ImportSiteMock(path="_test_always_raises_shortcut:fn", plugin=p)
+
+    token = _active_verifier.set(v)
+    try:
+        result = mock.always_raises(ValueError("boom"))
+        assert result is mock
+        sticky = mock._methods["__call__"]._sticky_config
+        assert sticky is not None
+        assert isinstance(sticky.side_effect, _RaiseException)
+        assert isinstance(sticky.side_effect.exc, ValueError)
+    finally:
+        _active_verifier.reset(token)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_wildcard_detection.py
+++ b/tests/unit/test_wildcard_detection.py
@@ -114,3 +114,36 @@ def test_all_wildcard_detection_in_any_order():
                 body=AnyThing(),
                 require_response=False,
             )
+
+
+
+def test_bare_anything_class_is_detected():
+    """Bare AnyThing class (no parentheses) must also trigger AllWildcardAssertionError."""
+    tripwire.http.mock_response("GET", "http://test/api", json={"ok": True})
+    with tripwire:
+        httpx.get("http://test/api")
+
+    with pytest.raises(AllWildcardAssertionError, match="verifies nothing"):
+        tripwire.http.assert_request(
+            method=AnyThing,
+            url=AnyThing,
+            headers=AnyThing,
+            body=AnyThing,
+            require_response=False,
+        )
+
+
+def test_bare_anything_with_partial_wildcard_allowed():
+    """Bare AnyThing used alongside real values must NOT trigger the guard."""
+    tripwire.http.mock_response("GET", "http://test/api", json={"ok": True})
+    with tripwire:
+        httpx.get("http://test/api")
+
+    # Should NOT raise — only some fields are wildcards
+    tripwire.http.assert_request(
+        method="GET",
+        url=AnyThing,
+        headers=AnyThing,
+        body=AnyThing,
+        require_response=False,
+    )


### PR DESCRIPTION
## Summary

- **Issue 1 — Bare `AnyThing` bypasses the all-wildcard guard.** The bare class (no parentheses) compares equal to everything via `DirtyEqualsMeta.__eq__`, but `_all_wildcards()` only checked `isinstance(v, AnyThing)` — and a class is not an instance of itself. Widen the predicate to also check `v is AnyThing`.
- **Issue 2(c) — Malformed hint for dotted mock paths.** `format_unmocked_hint()` split on the first `.`, producing `mock("pkg").svc:fetch.__call__` instead of `mock("pkg.svc:fetch").__call__`. Fixed with `rsplit`.
- **Issue 2(a) — Queue exhaustion error is misleading.** When the FIFO queue runs out, the error said "Add a mock" even though one was registered and consumed. Now tracks `_consumed_count` and emits a specific hint naming the count and suggesting `.always_returns()`.
- **Issue 2(b) — No unbounded mock form.** Added `always_returns()`, `always_raises()`, `always_calls()` as sticky fallback configs used after the FIFO queue is exhausted. Queue still takes priority.

## Test Plan

- [x] All existing tests pass (`uv run pytest tests/ --ignore=tests/unit/test_mcp_plugin.py -k 'not mcp'` — 1870 passed; MCP plugin tests are pre-existing failures due to mcp 2.0.0 incompatibility)
- [x] 14 new tests added (12 in `test_mock_plugin.py`, 2 in `test_wildcard_detection.py`)
- [x] All 30 example tests pass